### PR TITLE
Add since tag for the message codecs

### DIFF
--- a/hazelcast-code-generator/src/main/java/com/hazelcast/annotation/Request.java
+++ b/hazelcast-code-generator/src/main/java/com/hazelcast/annotation/Request.java
@@ -37,4 +37,10 @@ public @interface Request {
     String partitionIdentifier() default "-1";
 
     int[] event() default -1;
+
+    /**
+     *
+     * @return The string that indicates since which protocol version this message exists.
+     */
+    String since() default "1.0";
 }

--- a/hazelcast-code-generator/src/main/java/com/hazelcast/annotation/Request.java
+++ b/hazelcast-code-generator/src/main/java/com/hazelcast/annotation/Request.java
@@ -37,10 +37,4 @@ public @interface Request {
     String partitionIdentifier() default "-1";
 
     int[] event() default -1;
-
-    /**
-     *
-     * @return The string that indicates since which protocol version this message exists.
-     */
-    String since() default "1.0";
 }

--- a/hazelcast-code-generator/src/main/java/com/hazelcast/annotation/Since.java
+++ b/hazelcast-code-generator/src/main/java/com/hazelcast/annotation/Since.java
@@ -16,16 +16,22 @@
 
 package com.hazelcast.annotation;
 
+import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
- * Annotation for marking a method as encode to generate code
+ * Annotation to since which protocol version the parameter exists.
  */
+@Documented
 @Retention(RetentionPolicy.SOURCE)
-@Target(ElementType.METHOD)
-public @interface Response {
-    int value();
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE })
+public @interface Since {
+    /**
+     *
+     * @return The string that indicates since which protocol version the parameter exists.
+     */
+    String value() default "1.0";
 }

--- a/hazelcast-code-generator/src/main/java/com/hazelcast/annotation/Since.java
+++ b/hazelcast-code-generator/src/main/java/com/hazelcast/annotation/Since.java
@@ -27,7 +27,7 @@ import java.lang.annotation.Target;
  */
 @Documented
 @Retention(RetentionPolicy.SOURCE)
-@Target({ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE })
+@Target({ElementType.TYPE, ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER, ElementType.LOCAL_VARIABLE })
 public @interface Since {
     /**
      *

--- a/hazelcast-code-generator/src/main/java/com/hazelcast/client/protocol/generator/CodecModel.java
+++ b/hazelcast-code-generator/src/main/java/com/hazelcast/client/protocol/generator/CodecModel.java
@@ -58,7 +58,8 @@ public class CodecModel implements Model {
     private final int retryable;
     private final int response;
 
-    private String messageSince = DEFAULT_SINCE_VERSION;
+    private String codecSince = DEFAULT_SINCE_VERSION;
+    private String messageSince;
 
     private short requestId;
     private String id;
@@ -70,6 +71,11 @@ public class CodecModel implements Model {
     CodecModel(TypeElement parent, ExecutableElement methodElement, ExecutableElement responseElement,
                List<ExecutableElement> eventElementList, boolean retryable, Lang lang, Elements docCommentUtil) {
         GenerateCodec generateCodecAnnotation = parent.getAnnotation(GenerateCodec.class);
+        Since codecSinceVersion = parent.getAnnotation(Since.class);
+        if (null != codecSinceVersion) {
+            codecSince = codecSinceVersion.value();
+        }
+        this.messageSince = codecSince;
         Request requestAnnotation = methodElement.getAnnotation(Request.class);
         Since methodSince = methodElement.getAnnotation(Since.class);
 
@@ -117,7 +123,7 @@ public class CodecModel implements Model {
         for (VariableElement param : methodElement.getParameters()) {
             Nullable nullable = param.getAnnotation(Nullable.class);
             Since sinceVersion = param.getAnnotation(Since.class);
-            String paramVersion = DEFAULT_SINCE_VERSION;
+            String paramVersion = messageSince;
             if (null != sinceVersion) {
                 paramVersion = sinceVersion.value();
             }
@@ -129,7 +135,7 @@ public class CodecModel implements Model {
         for (VariableElement param : responseElement.getParameters()) {
             Nullable nullable = param.getAnnotation(Nullable.class);
             Since sinceVersion = param.getAnnotation(Since.class);
-            String paramVersion = DEFAULT_SINCE_VERSION;
+            String paramVersion = messageSince;
             if (null != sinceVersion) {
                 paramVersion = sinceVersion.value();
             }
@@ -146,7 +152,7 @@ public class CodecModel implements Model {
             for (VariableElement param : element.getParameters()) {
                 Nullable nullable = param.getAnnotation(Nullable.class);
                 Since sinceVersion = param.getAnnotation(Since.class);
-                String paramVersion = DEFAULT_SINCE_VERSION;
+                String paramVersion = messageSince;
                 if (null != sinceVersion) {
                     paramVersion = sinceVersion.value();
                 }

--- a/hazelcast-code-generator/src/main/java/com/hazelcast/client/protocol/generator/CodecModel.java
+++ b/hazelcast-code-generator/src/main/java/com/hazelcast/client/protocol/generator/CodecModel.java
@@ -56,6 +56,7 @@ public class CodecModel implements Model {
     private final int retryable;
     private final int response;
 
+    private String requestSince = "1.0";
     private short requestId;
     private String id;
     private String partitionIdentifier;
@@ -76,6 +77,8 @@ public class CodecModel implements Model {
 
         this.retryable = retryable ? 1 : 0;
         this.response = requestAnnotation.response();
+
+        this.requestSince = requestAnnotation.since();
 
         this.requestId = requestAnnotation.id();
         this.id = addHexPrefix(CodeGenerationUtils.mergeIds(generateCodecAnnotation.id(), requestId));
@@ -239,6 +242,10 @@ public class CodecModel implements Model {
 
     public int getRetryable() {
         return retryable;
+    }
+
+    public String getRequestSince() {
+        return requestSince;
     }
 
     public void setComment(String comment) {

--- a/hazelcast-code-generator/src/main/resources/codec-template-md.ftl
+++ b/hazelcast-code-generator/src/main/resources/codec-template-md.ftl
@@ -216,6 +216,8 @@ Please note that there may be error messages with an error code which is not lis
 ${util.getOperationDescription(cm.comment)}
 <#if cm.retryable == 1 >This message is idempotent.</#if>
 
+**Since** : ${cm.requestSince}
+
 #### Request Message
 **Type Id**      : ${cm.id}<br>
 **Partition Id** : ${resolvePartitionIdentifier(cm.partitionIdentifier)}

--- a/hazelcast-code-generator/src/main/resources/codec-template-md.ftl
+++ b/hazelcast-code-generator/src/main/resources/codec-template-md.ftl
@@ -212,11 +212,9 @@ Please note that there may be error messages with an error code which is not lis
 <#list map as cm>
 <br>
 ### ${util.getDistributedObjectName(key)}.${cm.name?cap_first}
-
 ${util.getOperationDescription(cm.comment)}
-<#if cm.retryable == 1 >This message is idempotent.</#if>
-
-**Since** : ${cm.requestSince}
+<#if cm.retryable == 1 >This message is idempotent.</#if><br>
+**Since Version** : ${cm.messageSince}
 
 #### Request Message
 **Type Id**      : ${cm.id}<br>
@@ -224,10 +222,10 @@ ${util.getOperationDescription(cm.comment)}
 
     <#if cm.requestParams?has_content>
 
-| Name| Type| Nullable| Description|
-|-----|-----|---------|------------|
+| Name| Type| Nullable| Description|Since Version|
+|-----|-----|---------|------------|-----|
         <#list cm.requestParams as param>
-|${param.name}| ${convertTypeToDocumentType(param.type)}| <#if param.nullable >Yes<#else>No</#if>|${util.getDescription(param.name, cm.comment)}|
+|${param.name}| ${convertTypeToDocumentType(param.type)}| <#if param.nullable >Yes<#else>No</#if>|${util.getDescription(param.name, cm.comment)}|${param.sinceVersion}|
         </#list>
     <#else>
 Header only request message, no message body exist.
@@ -240,10 +238,10 @@ ${util.getReturnDescription(cm.comment)}
 
     <#if cm.responseParams?has_content>
 
-| Name| Type| Nullable|
-|-------|------------|----------|
+| Name| Type| Nullable|Since Version|
+|-------|------------|----------|-----|
         <#list cm.responseParams as param>
-|${param.name}| ${convertTypeToDocumentType(param.type)}| <#if param.nullable >Yes<#else>No</#if>|
+|${param.name}| ${convertTypeToDocumentType(param.type)}| <#if param.nullable >Yes<#else>No</#if>|${param.sinceVersion}|
         </#list>
     <#else>
 Header only response message, no message body exist.
@@ -258,10 +256,10 @@ Header only response message, no message body exist.
 
     <#if event.eventParams?has_content>
 
-| Name| Type| Nullable| Description|
-|-------|------------|----------|------------|
+| Name| Type| Nullable| Description|Since Version|
+|-------|------------|----------|------------|-----|
         <#list event.eventParams as param>
-|${param.name}| ${convertTypeToDocumentType(param.type)}| <#if param.nullable >Yes<#else>No</#if>|${param.description}|
+|${param.name}| ${convertTypeToDocumentType(param.type)}| <#if param.nullable >Yes<#else>No</#if>|${param.description}|${param.sinceVersion}|
         </#list>
     <#else>
 

--- a/hazelcast/scripts/cleanDownloaded.sh
+++ b/hazelcast/scripts/cleanDownloaded.sh
@@ -7,6 +7,3 @@ if([[ $HAZELCAST_BRANCH == v* ]])
 then
    HAZELCAST_BRANCH=${HAZELCAST_BRANCH:1}
 fi
-
-rm -rf hazelcast-$HAZELCAST_BRANCH
-rm -rf ../hazelcast/downloaded/

--- a/hazelcast/scripts/downloadHazelcast.sh
+++ b/hazelcast/scripts/downloadHazelcast.sh
@@ -2,13 +2,3 @@
 
 HAZELCAST_REPO="$1"
 HAZELCAST_BRANCH="$2"
-
-wget -q https://github.com/$HAZELCAST_REPO/hazelcast/archive/$HAZELCAST_BRANCH.zip
-unzip -oq $HAZELCAST_BRANCH.zip
-
-if([[ $HAZELCAST_BRANCH == v* ]])
-then
-   HAZELCAST_BRANCH=${HAZELCAST_BRANCH:1}
-fi
-
-cp -R ./hazelcast-$HAZELCAST_BRANCH/hazelcast/src/main ../hazelcast/downloaded/

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/CacheCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/CacheCodecTemplate.java
@@ -371,7 +371,5 @@ public interface CacheCodecTemplate {
      */
     @Request(id = 29, retryable = true, response = ResponseMessageConst.ENTRIES_WITH_CURSOR, partitionIdentifier = "partitionId")
     @Since("1.1")
-    Object iterateEntries(@Since("1.1") String name, @Since("1.1") int partitionId, @Since("1.1") int tableIndex,
-                          @Since("1.1") int batch);
-
+    Object iterateEntries(String name, int partitionId, int tableIndex, int batch);
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/CacheCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/CacheCodecTemplate.java
@@ -19,6 +19,7 @@ package com.hazelcast.client.impl.protocol.template;
 import com.hazelcast.annotation.GenerateCodec;
 import com.hazelcast.annotation.Nullable;
 import com.hazelcast.annotation.Request;
+import com.hazelcast.annotation.Since;
 import com.hazelcast.client.impl.protocol.EventMessageConst;
 import com.hazelcast.client.impl.protocol.ResponseMessageConst;
 import com.hazelcast.nio.Address;
@@ -368,7 +369,9 @@ public interface CacheCodecTemplate {
      * @param batch       The number of items to be batched
      * @return last index processed and list of entries
      */
-    @Request(id = 29, retryable = true, response = ResponseMessageConst.ENTRIES_WITH_CURSOR, partitionIdentifier = "partitionId", since = "1.1")
-    Object iterateEntries(String name, int partitionId, int tableIndex, int batch);
+    @Request(id = 29, retryable = true, response = ResponseMessageConst.ENTRIES_WITH_CURSOR, partitionIdentifier = "partitionId")
+    @Since("1.1")
+    Object iterateEntries(@Since("1.1") String name, @Since("1.1") int partitionId, @Since("1.1") int tableIndex,
+                          @Since("1.1") int batch);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/CacheCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/CacheCodecTemplate.java
@@ -368,7 +368,7 @@ public interface CacheCodecTemplate {
      * @param batch       The number of items to be batched
      * @return last index processed and list of entries
      */
-    @Request(id = 29, retryable = true, response = ResponseMessageConst.ENTRIES_WITH_CURSOR, partitionIdentifier = "partitionId")
+    @Request(id = 29, retryable = true, response = ResponseMessageConst.ENTRIES_WITH_CURSOR, partitionIdentifier = "partitionId", since = "1.1")
     Object iterateEntries(String name, int partitionId, int tableIndex, int batch);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/DurableExecutorCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/DurableExecutorCodecTemplate.java
@@ -23,6 +23,7 @@ import com.hazelcast.client.impl.protocol.ResponseMessageConst;
 import com.hazelcast.nio.serialization.Data;
 
 @GenerateCodec(id = TemplateConstants.DURABLE_EXECUTOR_TEMPLATE_ID, name = "DurableExecutor", ns = "Hazelcast.Client.Protocol.Codec")
+@Since("1.1")
 public interface DurableExecutorCodecTemplate {
 
     /**
@@ -32,8 +33,7 @@ public interface DurableExecutorCodecTemplate {
      * @param name Name of the executor.
      */
     @Request(id = 1, retryable = false, response = ResponseMessageConst.VOID)
-    @Since("1.1")
-    void shutdown(@Since("1.1") String name);
+    void shutdown(String name);
 
     /**
      * Returns true if this executor has been shut down.
@@ -42,8 +42,7 @@ public interface DurableExecutorCodecTemplate {
      * @return true if this executor has been shut down
      */
     @Request(id = 2, retryable = false, response = ResponseMessageConst.BOOLEAN)
-    @Since("1.1")
-    Object isShutdown(@Since("1.1") String name);
+    Object isShutdown(String name);
 
     /**
      * Submits the task to partition for execution
@@ -53,8 +52,7 @@ public interface DurableExecutorCodecTemplate {
      * @return the sequence for the submitted execution.
      */
     @Request(id = 3, retryable = true, response = ResponseMessageConst.INTEGER, partitionIdentifier = "partitionId")
-    @Since("1.1")
-    Object submitToPartition(@Since("1.1") String name, @Since("1.1") Data callable);
+    Object submitToPartition(String name, Data callable);
 
     /**
      * Retrieves the result of the execution with the given sequence
@@ -64,8 +62,7 @@ public interface DurableExecutorCodecTemplate {
      * @return The result of the callable execution with the given sequence.
      */
     @Request(id = 4, retryable = true, response = ResponseMessageConst.DATA, partitionIdentifier = "partitionId")
-    @Since("1.1")
-    Object retrieveResult(@Since("1.1") String name, @Since("1.1") int sequence);
+    Object retrieveResult(String name, int sequence);
 
     /**
      * Disposes the result of the execution with the given sequence
@@ -74,8 +71,7 @@ public interface DurableExecutorCodecTemplate {
      * @param sequence    Sequence of the execution.
      */
     @Request(id = 5, retryable = true, response = ResponseMessageConst.VOID, partitionIdentifier = "partitionId")
-    @Since("1.1")
-    Object disposeResult(@Since("1.1") String name, @Since("1.1") int sequence);
+    Object disposeResult(String name, int sequence);
 
     /**
      * Retrieves and disposes the result of the execution with the given sequence
@@ -85,6 +81,5 @@ public interface DurableExecutorCodecTemplate {
      * @return The result of the callable execution with the given sequence.
      */
     @Request(id = 6, retryable = true, response = ResponseMessageConst.DATA, partitionIdentifier = "partitionId")
-    @Since("1.1")
-    Object retrieveAndDisposeResult(@Since("1.1") String name, @Since("1.1") int sequence);
+    Object retrieveAndDisposeResult(String name, int sequence);
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/DurableExecutorCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/DurableExecutorCodecTemplate.java
@@ -18,6 +18,7 @@ package com.hazelcast.client.impl.protocol.template;
 
 import com.hazelcast.annotation.GenerateCodec;
 import com.hazelcast.annotation.Request;
+import com.hazelcast.annotation.Since;
 import com.hazelcast.client.impl.protocol.ResponseMessageConst;
 import com.hazelcast.nio.serialization.Data;
 
@@ -30,8 +31,9 @@ public interface DurableExecutorCodecTemplate {
      *
      * @param name Name of the executor.
      */
-    @Request(id = 1, retryable = false, response = ResponseMessageConst.VOID, since = "1.1")
-    void shutdown(String name);
+    @Request(id = 1, retryable = false, response = ResponseMessageConst.VOID)
+    @Since("1.1")
+    void shutdown(@Since("1.1") String name);
 
     /**
      * Returns true if this executor has been shut down.
@@ -39,8 +41,9 @@ public interface DurableExecutorCodecTemplate {
      * @param name Name of the executor.
      * @return true if this executor has been shut down
      */
-    @Request(id = 2, retryable = false, response = ResponseMessageConst.BOOLEAN, since = "1.1")
-    Object isShutdown(String name);
+    @Request(id = 2, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Since("1.1")
+    Object isShutdown(@Since("1.1") String name);
 
     /**
      * Submits the task to partition for execution
@@ -49,8 +52,9 @@ public interface DurableExecutorCodecTemplate {
      * @param callable    The callable object to be executed.
      * @return the sequence for the submitted execution.
      */
-    @Request(id = 3, retryable = true, response = ResponseMessageConst.INTEGER, partitionIdentifier = "partitionId", since = "1.1")
-    Object submitToPartition(String name, Data callable);
+    @Request(id = 3, retryable = true, response = ResponseMessageConst.INTEGER, partitionIdentifier = "partitionId")
+    @Since("1.1")
+    Object submitToPartition(@Since("1.1") String name, @Since("1.1") Data callable);
 
     /**
      * Retrieves the result of the execution with the given sequence
@@ -59,8 +63,9 @@ public interface DurableExecutorCodecTemplate {
      * @param sequence    Sequence of the execution.
      * @return The result of the callable execution with the given sequence.
      */
-    @Request(id = 4, retryable = true, response = ResponseMessageConst.DATA, partitionIdentifier = "partitionId", since = "1.1")
-    Object retrieveResult(String name, int sequence);
+    @Request(id = 4, retryable = true, response = ResponseMessageConst.DATA, partitionIdentifier = "partitionId")
+    @Since("1.1")
+    Object retrieveResult(@Since("1.1") String name, @Since("1.1") int sequence);
 
     /**
      * Disposes the result of the execution with the given sequence
@@ -68,8 +73,9 @@ public interface DurableExecutorCodecTemplate {
      * @param name        Name of the executor.
      * @param sequence    Sequence of the execution.
      */
-    @Request(id = 5, retryable = true, response = ResponseMessageConst.VOID, partitionIdentifier = "partitionId", since = "1.1")
-    Object disposeResult(String name, int sequence);
+    @Request(id = 5, retryable = true, response = ResponseMessageConst.VOID, partitionIdentifier = "partitionId")
+    @Since("1.1")
+    Object disposeResult(@Since("1.1") String name, @Since("1.1") int sequence);
 
     /**
      * Retrieves and disposes the result of the execution with the given sequence
@@ -78,6 +84,7 @@ public interface DurableExecutorCodecTemplate {
      * @param sequence    Sequence of the execution.
      * @return The result of the callable execution with the given sequence.
      */
-    @Request(id = 6, retryable = true, response = ResponseMessageConst.DATA, partitionIdentifier = "partitionId", since = "1.1")
-    Object retrieveAndDisposeResult(String name, int sequence);
+    @Request(id = 6, retryable = true, response = ResponseMessageConst.DATA, partitionIdentifier = "partitionId")
+    @Since("1.1")
+    Object retrieveAndDisposeResult(@Since("1.1") String name, @Since("1.1") int sequence);
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/DurableExecutorCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/DurableExecutorCodecTemplate.java
@@ -30,7 +30,7 @@ public interface DurableExecutorCodecTemplate {
      *
      * @param name Name of the executor.
      */
-    @Request(id = 1, retryable = false, response = ResponseMessageConst.VOID)
+    @Request(id = 1, retryable = false, response = ResponseMessageConst.VOID, since = "1.1")
     void shutdown(String name);
 
     /**
@@ -39,7 +39,7 @@ public interface DurableExecutorCodecTemplate {
      * @param name Name of the executor.
      * @return true if this executor has been shut down
      */
-    @Request(id = 2, retryable = false, response = ResponseMessageConst.BOOLEAN)
+    @Request(id = 2, retryable = false, response = ResponseMessageConst.BOOLEAN, since = "1.1")
     Object isShutdown(String name);
 
     /**
@@ -49,7 +49,7 @@ public interface DurableExecutorCodecTemplate {
      * @param callable    The callable object to be executed.
      * @return the sequence for the submitted execution.
      */
-    @Request(id = 3, retryable = true, response = ResponseMessageConst.INTEGER, partitionIdentifier = "partitionId")
+    @Request(id = 3, retryable = true, response = ResponseMessageConst.INTEGER, partitionIdentifier = "partitionId", since = "1.1")
     Object submitToPartition(String name, Data callable);
 
     /**
@@ -59,7 +59,7 @@ public interface DurableExecutorCodecTemplate {
      * @param sequence    Sequence of the execution.
      * @return The result of the callable execution with the given sequence.
      */
-    @Request(id = 4, retryable = true, response = ResponseMessageConst.DATA, partitionIdentifier = "partitionId")
+    @Request(id = 4, retryable = true, response = ResponseMessageConst.DATA, partitionIdentifier = "partitionId", since = "1.1")
     Object retrieveResult(String name, int sequence);
 
     /**
@@ -68,7 +68,7 @@ public interface DurableExecutorCodecTemplate {
      * @param name        Name of the executor.
      * @param sequence    Sequence of the execution.
      */
-    @Request(id = 5, retryable = true, response = ResponseMessageConst.VOID, partitionIdentifier = "partitionId")
+    @Request(id = 5, retryable = true, response = ResponseMessageConst.VOID, partitionIdentifier = "partitionId", since = "1.1")
     Object disposeResult(String name, int sequence);
 
     /**
@@ -78,6 +78,6 @@ public interface DurableExecutorCodecTemplate {
      * @param sequence    Sequence of the execution.
      * @return The result of the callable execution with the given sequence.
      */
-    @Request(id = 6, retryable = true, response = ResponseMessageConst.DATA, partitionIdentifier = "partitionId")
+    @Request(id = 6, retryable = true, response = ResponseMessageConst.DATA, partitionIdentifier = "partitionId", since = "1.1")
     Object retrieveAndDisposeResult(String name, int sequence);
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
@@ -731,7 +731,7 @@ public interface MapCodecTemplate {
      */
     @Request(id = 60, retryable = true, response = ResponseMessageConst.CACHE_KEY_ITERATOR_RESULT, partitionIdentifier = "partitionId")
     @Since("1.1")
-    Object fetchKeys(@Since("1.1") String name, @Since("1.1") int partitionId, @Since("1.1") int tableIndex, @Since("1.1") int batch);
+    Object fetchKeys(String name, int partitionId, int tableIndex, int batch);
 
     /**
      * Fetches specified number of entries from the specified partition starting from specified table index.
@@ -744,6 +744,6 @@ public interface MapCodecTemplate {
      */
     @Request(id = 61, retryable = true, response = ResponseMessageConst.ENTRIES_WITH_CURSOR, partitionIdentifier = "partitionId")
     @Since("1.1")
-    Object fetchEntries(@Since("1.1") String name, @Since("1.1") int partitionId, @Since("1.1") int tableIndex, @Since("1.1") int batch);
+    Object fetchEntries(String name, int partitionId, int tableIndex, int batch);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
@@ -18,6 +18,7 @@ package com.hazelcast.client.impl.protocol.template;
 
 import com.hazelcast.annotation.GenerateCodec;
 import com.hazelcast.annotation.Request;
+import com.hazelcast.annotation.Since;
 import com.hazelcast.client.impl.protocol.EventMessageConst;
 import com.hazelcast.client.impl.protocol.ResponseMessageConst;
 import com.hazelcast.nio.Address;
@@ -728,8 +729,9 @@ public interface MapCodecTemplate {
      * @param batch       The number of items to be batched
      * @return last index processed and list of keys
      */
-    @Request(id = 60, retryable = true, response = ResponseMessageConst.CACHE_KEY_ITERATOR_RESULT, partitionIdentifier = "partitionId", since = "1.1")
-    Object fetchKeys(String name, int partitionId, int tableIndex, int batch);
+    @Request(id = 60, retryable = true, response = ResponseMessageConst.CACHE_KEY_ITERATOR_RESULT, partitionIdentifier = "partitionId")
+    @Since("1.1")
+    Object fetchKeys(@Since("1.1") String name, @Since("1.1") int partitionId, @Since("1.1") int tableIndex, @Since("1.1") int batch);
 
     /**
      * Fetches specified number of entries from the specified partition starting from specified table index.
@@ -740,7 +742,8 @@ public interface MapCodecTemplate {
      * @param batch       The number of items to be batched
      * @return last index processed and list of entries
      */
-    @Request(id = 61, retryable = true, response = ResponseMessageConst.ENTRIES_WITH_CURSOR, partitionIdentifier = "partitionId", since = "1.1")
-    Object fetchEntries(String name, int partitionId, int tableIndex, int batch);
+    @Request(id = 61, retryable = true, response = ResponseMessageConst.ENTRIES_WITH_CURSOR, partitionIdentifier = "partitionId")
+    @Since("1.1")
+    Object fetchEntries(@Since("1.1") String name, @Since("1.1") int partitionId, @Since("1.1") int tableIndex, @Since("1.1") int batch);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
@@ -728,7 +728,7 @@ public interface MapCodecTemplate {
      * @param batch       The number of items to be batched
      * @return last index processed and list of keys
      */
-    @Request(id = 60, retryable = true, response = ResponseMessageConst.CACHE_KEY_ITERATOR_RESULT, partitionIdentifier = "partitionId")
+    @Request(id = 60, retryable = true, response = ResponseMessageConst.CACHE_KEY_ITERATOR_RESULT, partitionIdentifier = "partitionId", since = "1.1")
     Object fetchKeys(String name, int partitionId, int tableIndex, int batch);
 
     /**
@@ -740,7 +740,7 @@ public interface MapCodecTemplate {
      * @param batch       The number of items to be batched
      * @return last index processed and list of entries
      */
-    @Request(id = 61, retryable = true, response = ResponseMessageConst.ENTRIES_WITH_CURSOR, partitionIdentifier = "partitionId")
+    @Request(id = 61, retryable = true, response = ResponseMessageConst.ENTRIES_WITH_CURSOR, partitionIdentifier = "partitionId", since = "1.1")
     Object fetchEntries(String name, int partitionId, int tableIndex, int batch);
 
 }


### PR DESCRIPTION
Adds the since tag to message codecs so that we can mark since which version the request exists. It is used in protocol documentation.