### PR TITLE
Document fixed header part should only be included one time

### DIFF
--- a/hazelcast-code-generator/src/main/java/com/hazelcast/client/protocol/generator/CodeGenerationUtils.java
+++ b/hazelcast-code-generator/src/main/java/com/hazelcast/client/protocol/generator/CodeGenerationUtils.java
@@ -38,6 +38,8 @@ public final class CodeGenerationUtils {
 
     private static final int BYTE_BIT_COUNT = 8;
 
+    private static boolean documentCreated = false;
+
     @SuppressWarnings("checkstyle:whitespacearound")
     private static final Map<String, String> JAVA_TO_PYTHON_TYPES = new HashMap<String, String>() {{
         put(DATA_FULL_NAME, "Data");
@@ -415,5 +417,13 @@ public final class CodeGenerationUtils {
                 //TODO add other lang reserved words
                 return str;
         }
+    }
+
+    public static boolean isDocumentCreated() {
+        return documentCreated;
+    }
+
+    public static void setDocumentCreated(boolean documentCreated) {
+        CodeGenerationUtils.documentCreated = documentCreated;
     }
 }

--- a/hazelcast-code-generator/src/main/java/com/hazelcast/client/protocol/generator/CodecCodeGenerator.java
+++ b/hazelcast-code-generator/src/main/java/com/hazelcast/client/protocol/generator/CodecCodeGenerator.java
@@ -45,7 +45,6 @@ import javax.lang.model.type.MirroredTypeException;
 import javax.lang.model.type.TypeMirror;
 import javax.lang.model.util.Elements;
 import javax.tools.Diagnostic;
-import javax.tools.FileObject;
 import javax.tools.JavaFileManager;
 import javax.tools.JavaFileObject;
 import javax.tools.StandardLocation;
@@ -378,6 +377,7 @@ public class CodecCodeGenerator extends AbstractProcessor {
         String content = generateFromTemplate(codecTemplate, model);
         String fileName = "HazelcastOpenBinaryProtocol-" + getClass().getPackage().getImplementationVersion();
         saveFile(fileName, "document", content);
+        CodeGenerationUtils.setDocumentCreated(true);
     }
 
     private void generateMessageTypeEnum(TypeElement classElement, Lang lang, Template messageTypeTemplate) {

--- a/hazelcast-code-generator/src/main/java/com/hazelcast/client/protocol/generator/CodecCodeGenerator.java
+++ b/hazelcast-code-generator/src/main/java/com/hazelcast/client/protocol/generator/CodecCodeGenerator.java
@@ -448,7 +448,7 @@ public class CodecCodeGenerator extends AbstractProcessor {
                 writer = filer.createResource(location, packageName, fileName).openWriter();
                 openedFiles.put(path, writer);
             }
-            writer.append(content);
+            writer.append(content).flush();
         } catch (IOException e) {
             messager.printMessage(Diagnostic.Kind.WARNING, e.getMessage());
             e.printStackTrace();

--- a/hazelcast-code-generator/src/main/resources/codec-template-md.ftl
+++ b/hazelcast-code-generator/src/main/resources/codec-template-md.ftl
@@ -1,4 +1,4 @@
-# Protocol Messages
+<#if !util.isDocumentCreated() ># Protocol Messages
 
 ## Compound Data Types Used In The Protocol Specification
 Some common compound data structures used in the protocol message specification are defined in this section.
@@ -197,7 +197,7 @@ The following error codes are defined in the system:
 |NATIVE_OUT_OF_MEMORY_ERROR|78|Thrown when Hazelcast cannot allocate required native memory.|
 
 Please note that there may be error messages with an error code which is not listed in this table. The client can handle this situation differently based on the particular implementation (e.g. throw an unknown error code exception).
-
+</#if>
 <#list model?keys as key>
 <#assign map=model?values[key_index]?values/>
 <#if map?has_content>
@@ -309,8 +309,8 @@ Header only event message, no message body exist.
             <#return "array of Member">
         <#case "java.util.List<com.hazelcast.client.impl.client.DistributedObjectInfo>">
             <#return "array of Distributed Object Info">
-        <#case "java.util.Map<com.hazelcast.nio.Address,java.util.List<java.lang.Integer>>">
-            <#return "array of Address-Partition Id pair">
+        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.nio.Address,java.util.List<java.lang.Integer>>>">
+            <#return "array of Address-Partition Id List pair">
         <#case "java.util.Collection<" + util.DATA_FULL_NAME + ">">
             <#return "array of byte-array">
         <#case "java.util.Map<" + util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">">


### PR DESCRIPTION
Makes sure that the fixed part of the generated document is included only one time(even if there are multiple rounds of generation) during document generation.

There is also a fix for handling of "java.util.List<java.util.Map.Entry<com.hazelcast.nio.Address,java.util.List<java.lang.Integer>>>" type.