### PR TITLE
The downloaded hazelcast zip does not compile with the hazelcast-client-protocol

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
     </modules>
 
     <properties>
-        <hazelcast.git.repo>hazelcast</hazelcast.git.repo>
-        <hazelcast.git.branch>master</hazelcast.git.branch>
+        <hazelcast.git.repo>ihsandemir</hazelcast.git.repo>
+        <hazelcast.git.branch>getCacheConfigCompatibilityFix</hazelcast.git.branch>
         <main.basedir>${project.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
Temporarily changed the download script to download from https://github.com/ihsandemir/hazelcast/archive/getCacheConfigCompatibilityFix.zip. This will allow the protocol repo build successfully.