### PR TITLE
ResponseParameter is missing capability to detect the existence of an extended message fields

### DIFF
--- a/hazelcast-code-generator/src/main/resources/codec-template-java.ftl
+++ b/hazelcast-code-generator/src/main/resources/codec-template-java.ftl
@@ -63,6 +63,8 @@ public final class ${model.className} {
     public static class ResponseParameters {
 <#list model.responseParams as param>
         public ${param.type} ${param.name};
+<#assign messageVersion=model.messageSinceInt>
+        <#if param.sinceVersionInt gt messageVersion >public boolean ${param.name}Exist = false;</#if>
 </#list>
 
         public static int calculateDataSize(<#list model.responseParams as param><@methodParam type=param.type/> ${param.name}<#if param_has_next>, </#if></#list>) {
@@ -89,7 +91,13 @@ public final class ${model.className} {
     public static ResponseParameters decodeResponse(ClientMessage clientMessage) {
         ResponseParameters parameters = new ResponseParameters();
 <#list model.responseParams as p>
+    <#if p.versionChanged >
+        if (clientMessage.isComplete()) {
+            return parameters;
+        }
+    </#if>
     <@getterText varName=p.name type=p.type isNullable=p.nullable/>
+    <#if p.sinceVersionInt gt messageVersion >parameters.${p.name}Exist = true;</#if>
 </#list>
         return parameters;
     }


### PR DESCRIPTION
Added the <param_name>Exist field for the response parameters. This already existed for RequestParameters and added it to ResponseParameters. This field allows for detecting whether the extended message field exists in the decoded message or not. The protocol user can use this boolean flag to check existence of the extended field and do appropriate action based on the field's existence.

E.g. if the 3.6 server sends and authentication message, it will miss the serverHazelcastVersion field since it is added in 1.3 protocol version. Hence, the decoded message at the server will not have this field, and with this PR it will have a field called serverHazelcastVersionExist and it will be set to false.
