### PR TITLE
Authentication response message needs to include the list of client unregistered members for PR #8848  

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ClientMessageTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ClientMessageTemplate.java
@@ -53,6 +53,7 @@ public interface ClientMessageTemplate {
      * @param isOwnerConnection    You must set this field to true while connecting to the owner member, otherwise set to false.
      * @param clientType           The type of the client. E.g. JAVA, CPP, CSHARP, etc.
      * @param serializationVersion client side supported version to inform server side
+     * @param clientHazelcastVersion The Hazelcast version of the client. (e.g. 3.7.2)
      * @return Returns the address, uuid and owner uuid.
      */
 

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ResponseTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ResponseTemplate.java
@@ -22,10 +22,12 @@ import com.hazelcast.annotation.Response;
 import com.hazelcast.annotation.Since;
 import com.hazelcast.client.impl.client.DistributedObjectInfo;
 import com.hazelcast.client.impl.protocol.constants.ResponseMessageConst;
+import com.hazelcast.core.Member;
 import com.hazelcast.map.impl.SimpleEntryView;
 import com.hazelcast.mapreduce.JobPartitionState;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
+
 import java.util.List;
 import java.util.Map;
 
@@ -89,11 +91,18 @@ public interface ResponseTemplate {
      * @param ownerUuid            Unique string identifying the server member uniquely.This value will be null if status is not 0
      * @param serializationVersion server side supported serialization version.
      *                             This value should be used for setting serialization version if status is 2
+     * @param serverHazelcastVersion The hazelcast version of the member
+     * @param clientUnregisteredMembers The list of members at which the client has no resources. This may be due to the client
+     *                                  no connected to the cluster at all or it may be that the cleanup operation is executed at
+     *                                  the member and no resources of the particular client is left at the member. The client
+     *                                  can use this information to restore its needed resources at the member, e.g.
+     *                                  registers its listeners.
      * @return Returns the address, uuid and owner uuid.
      */
     @Response(ResponseMessageConst.AUTHENTICATION)
     Object Authentication(byte status, @Nullable Address address, @Nullable String uuid, @Nullable String ownerUuid,
-                          byte serializationVersion, @Since (value = "1.3") String serverHazelcastVersion);
+                          byte serializationVersion, @Since(value = "1.3") String serverHazelcastVersion,
+                          @Since(value = "1.3") List<Member> clientUnregisteredMembers);
 
     /**
      * @param partitions mappings from member address to list of partition id 's that member owns

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ResponseTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ResponseTemplate.java
@@ -96,7 +96,8 @@ public interface ResponseTemplate {
      *                                  no connected to the cluster at all or it may be that the cleanup operation is executed at
      *                                  the member and no resources of the particular client is left at the member. The client
      *                                  can use this information to restore its needed resources at the member, e.g.
-     *                                  registers its listeners.
+     *                                  registers its listeners. The list will be empty if this is response to non-owner
+     *                                  connection request.
      * @return Returns the address, uuid and owner uuid.
      */
     @Response(ResponseMessageConst.AUTHENTICATION)

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ResponseTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ResponseTemplate.java
@@ -103,7 +103,7 @@ public interface ResponseTemplate {
     @Response(ResponseMessageConst.AUTHENTICATION)
     Object Authentication(byte status, @Nullable Address address, @Nullable String uuid, @Nullable String ownerUuid,
                           byte serializationVersion, @Since(value = "1.3") String serverHazelcastVersion,
-                          @Since(value = "1.3") List<Member> clientUnregisteredMembers);
+                          @Since(value = "1.3") @Nullable List<Member> clientUnregisteredMembers);
 
     /**
      * @param partitions mappings from member address to list of partition id 's that member owns

--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
     </modules>
 
     <properties>
-        <hazelcast.git.repo>hazelcast</hazelcast.git.repo>
-        <hazelcast.git.branch>master</hazelcast.git.branch>
+        <hazelcast.git.repo>ihsandemir</hazelcast.git.repo>
+        <hazelcast.git.branch>heartbeatMissedListenersFix</hazelcast.git.branch>
         <main.basedir>${project.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
Extends the authentication response message with the new clientUnregisteredMembers field. This list of members at which the client has no resources. his may be due to the client no connected to the cluster at all or it may be that the cleanup operation is executed at and no resources of the particular client is left at the member. The client can use this information to restore its needed resources at the member, e.g. registers its listeners.

Change is needed for https://github.com/hazelcast/hazelcast/pull/8848