### PR TITLE
Prrotocol generator can not generate the tests when events are extended + missing long type

### DIFF
--- a/hazelcast-code-generator/src/main/resources/BinaryCompatibilityFileGenerator.ftl
+++ b/hazelcast-code-generator/src/main/resources/BinaryCompatibilityFileGenerator.ftl
@@ -127,6 +127,8 @@ public class BinaryCompatibilityFileGenerator {
             <#return "cacheEventDatas">
         <#case "java.util.List<java.lang.String>">
             <#return "strings">
+        <#case "java.util.List<java.lang.Long>">
+            <#return "longs">
         <#default>
             <#return "Unknown Data Type " + javaType>
     </#switch>

--- a/hazelcast-code-generator/src/main/resources/BinaryCompatibilityNullFileGenerator.ftl
+++ b/hazelcast-code-generator/src/main/resources/BinaryCompatibilityNullFileGenerator.ftl
@@ -126,7 +126,9 @@ public class BinaryCompatibilityNullFileGenerator {
         <#case "java.util.List<com.hazelcast.cache.impl.CacheEventData>">
             <#return "cacheEventDatas">
         <#case "java.util.List<java.lang.String>">
-            <#return "strings">
+           <#return "strings">
+        <#case "java.util.List<java.lang.Long>">
+            <#return "longs">
         <#default>
             <#return "Unknown Data Type " + javaType>
     </#switch>

--- a/hazelcast-code-generator/src/main/resources/ClientCompatibilityNullTest.ftl
+++ b/hazelcast-code-generator/src/main/resources/ClientCompatibilityNullTest.ftl
@@ -105,8 +105,6 @@ public class ClientCompatibilityNullTest_${testForVersionClassName} {
                        <#list event.eventParams as param>
                         <#if param.sinceVersionInt lte testForVersion >
                             assertTrue(isEqual(<#if param.nullable>null<#else>${convertTypeToSampleValue(param.type)}</#if>, ${param.name}));
-                        <#else>
-                            assertFalse(params.${param.name}Exist);
                         </#if>
                        </#list>
                 </#if>
@@ -188,6 +186,8 @@ public class ClientCompatibilityNullTest_${testForVersionClassName} {
             <#return "cacheEventDatas">
         <#case "java.util.List<java.lang.String>">
             <#return "strings">
+        <#case "java.util.List<java.lang.Long>">
+            <#return "longs">
         <#default>
             <#return "Unknown Data Type " + javaType>
     </#switch>

--- a/hazelcast-code-generator/src/main/resources/ClientCompatibilityTest.ftl
+++ b/hazelcast-code-generator/src/main/resources/ClientCompatibilityTest.ftl
@@ -106,8 +106,6 @@ public class ClientCompatibilityTest_${testForVersionClassName} {
                        <#list event.eventParams as param>
                         <#if param.sinceVersionInt lte testForVersion >
                             assertTrue(isEqual(${convertTypeToSampleValue(param.type)}, ${param.name}));
-                        <#else>
-                            assertFalse(params.${param.name}Exist);
                         </#if>
                        </#list>
                 </#if>
@@ -187,6 +185,8 @@ public class ClientCompatibilityTest_${testForVersionClassName} {
             <#return "cacheEventDatas">
         <#case "java.util.List<java.lang.String>">
             <#return "strings">
+        <#case "java.util.List<java.lang.Long>">
+            <#return "longs">
         <#default>
             <#return "Unknown Data Type " + javaType>
     </#switch>

--- a/hazelcast-code-generator/src/main/resources/EncodeDecodeCompatibilityNullTest.ftl
+++ b/hazelcast-code-generator/src/main/resources/EncodeDecodeCompatibilityNullTest.ftl
@@ -146,6 +146,8 @@ public class EncodeDecodeCompatibilityNullTest {
             <#return "cacheEventDatas">
         <#case "java.util.List<java.lang.String>">
             <#return "strings">
+         <#case "java.util.List<java.lang.Long>">
+            <#return "longs">
         <#default>
             <#return "Unknown Data Type " + javaType>
     </#switch>

--- a/hazelcast-code-generator/src/main/resources/EncodeDecodeCompatibilityTest.ftl
+++ b/hazelcast-code-generator/src/main/resources/EncodeDecodeCompatibilityTest.ftl
@@ -146,6 +146,8 @@ public class EncodeDecodeCompatibilityTest {
             <#return "cacheEventDatas">
         <#case "java.util.List<java.lang.String>">
             <#return "strings">
+        <#case "java.util.List<java.lang.Long>">
+            <#return "longs">
         <#default>
             <#return "Unknown Data Type " + javaType>
     </#switch>

--- a/hazelcast-code-generator/src/main/resources/ServerCompatibilityNullTest.ftl
+++ b/hazelcast-code-generator/src/main/resources/ServerCompatibilityNullTest.ftl
@@ -101,9 +101,20 @@ public class ServerCompatibilityNullTest_${testForVersionClassName} {
     {
         ClientMessage clientMessage = ${cm.className}.encode${event.name}Event(<#if event.eventParams?has_content> <#list event.eventParams as param><#if param.nullable>null<#else>${convertTypeToSampleValue(param.type)}</#if> <#if param_has_next>, </#if> </#list> </#if>);
         int length = inputStream.readInt();
-            byte[] bytes = new byte[length];
-            inputStream.read(bytes);
-            assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    <#if cm.highestParameterVersion lte testForVersion >
+        byte[] bytes = new byte[length];
+        inputStream.read(bytes);
+        assertTrue(isEqual(Arrays.copyOf(clientMessage.buffer().byteArray(), clientMessage.getFrameLength()), bytes));
+    <#else>
+        // Since the test is generated for protocol version (${testForVersionString}) which is earlier than latest change in the message
+        // (version ${util.versionAsString(cm.highestParameterVersion)}), only the bytes after frame length fields are compared
+        int frameLength = clientMessage.getFrameLength();
+        assertTrue(frameLength >= length);
+        inputStream.skipBytes(FRAME_LEN_FIELD_SIZE);
+        byte[] bytes = new byte[length - FRAME_LEN_FIELD_SIZE];
+        inputStream.read(bytes);
+        assertTrue(isEqual(Arrays.copyOfRange(clientMessage.buffer().byteArray(), FRAME_LEN_FIELD_SIZE, length), bytes));
+    </#if>
      }
     </#list>
 }
@@ -165,6 +176,8 @@ public class ServerCompatibilityNullTest_${testForVersionClassName} {
             <#return "cacheEventDatas">
         <#case "java.util.List<java.lang.String>">
             <#return "strings">
+        <#case "java.util.List<java.lang.Long>">
+            <#return "longs">
         <#default>
             <#return "Unknown Data Type " + javaType>
     </#switch>

--- a/hazelcast-code-generator/src/main/resources/codec-template-md.ftl
+++ b/hazelcast-code-generator/src/main/resources/codec-template-md.ftl
@@ -347,6 +347,8 @@ Header only event message, no message body exist.
             <#return "array of Query Cache Event Data">
         <#case "java.util.List<java.lang.String>">
             <#return "array of string">
+        <#case "java.util.List<java.lang.Long>">
+            <#return "array of longs">
         <#default>
             <#return "Unknown Data Type " + javaType>
     </#switch>


### PR DESCRIPTION
Enhances the codec code generator so that when events are extended the compatibility tests are generated correctly. Also introduces the long type.