### PR TITLE
Double read for config template causes cpp code generation to not work

### DIFF
--- a/hazelcast-code-generator/src/main/java/com/hazelcast/client/protocol/generator/CodecCodeGenerator.java
+++ b/hazelcast-code-generator/src/main/java/com/hazelcast/client/protocol/generator/CodecCodeGenerator.java
@@ -192,13 +192,6 @@ public class CodecCodeGenerator extends AbstractProcessor {
                             "Cannot find messagetype template for lang:" + lang + ". " + e.getMessage());
                 }
             }
-            try {
-                Template messageTypeTemplate = cfg.getTemplate("messagetype-template-" + lang.name().toLowerCase() + ".ftl");
-                messageTypeTemplateMap.put(lang, messageTypeTemplate);
-            } catch (IOException e) {
-                logMessage(Diagnostic.Kind.WARNING,
-                        "Cannot find messagetype template for lang:" + lang + ". " + e.getMessage());
-            }
 
             if (generateTests) {
                 getCompatibilityTestTemplates(cfg);


### PR DESCRIPTION
Removed the mistakenly duplicated template read code.