### PR TITLE
[BACKPORT]Old .net clients fix

### DIFF
--- a/hazelcast-code-generator/src/main/resources/codec-template-java.ftl
+++ b/hazelcast-code-generator/src/main/resources/codec-template-java.ftl
@@ -52,7 +52,21 @@ public final class ${model.className} {
             return parameters;
         }
     </#if>
-    <@getterText varName=p.name type=p.type isNullable=p.nullable/>
+    <#--  Id 2: AuthenticationCodec, Id:3 CustomAuthenticationCodec -->
+    <#if p.name == "clientHazelcastVersion" && (model.id == "0x0002" || model.id == "0x0003") >
+            try {
+            <@getterText varName=p.name type=p.type isNullable=p.nullable/>
+            } catch (IndexOutOfBoundsException e) {
+                if (parameters.clientType == "CSHARP") {
+                    // suppress this error for older csharp client since they had a bug which was fixed later (writeByte related)
+                    return parameters;
+                } else {
+                    throw e;
+                }
+            }
+    <#else>
+           <@getterText varName=p.name type=p.type isNullable=p.nullable/>
+    </#if>
     <#if p.sinceVersionInt gt messageVersion >parameters.${p.name}Exist = true;</#if>
 </#list>
         return parameters;

--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
     </modules>
 
     <properties>
-        <hazelcast.git.repo>ihsandemir</hazelcast.git.repo>
-        <hazelcast.git.branch>heartbeatMissedListenersFix</hazelcast.git.branch>
+        <hazelcast.git.repo>hazelcast</hazelcast.git.repo>
+        <hazelcast.git.branch>3.7.4</hazelcast.git.branch>
         <main.basedir>${project.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
Fixes the problem that older .net clients were failing to connect to 3.7.3 server. The fix does an exception for the .net client in authentication and custom authentication codecs generation to suppress a message read error.
