### PR TITLE
Move logic for ScheduledExecutorService#getAllScheduled to the member side

### DIFF
--- a/hazelcast-code-generator/src/main/resources/BinaryCompatibilityFileGenerator.ftl
+++ b/hazelcast-code-generator/src/main/resources/BinaryCompatibilityFileGenerator.ftl
@@ -111,6 +111,8 @@ public class BinaryCompatibilityFileGenerator {
             <#return "aPartitionTable">
         <#case "java.util.List<java.util.Map.Entry<"+ util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">>">
             <#return "aListOfEntry">
+        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<java.lang.String>>>">
+            <#return "taskHandlers">
         <#case "com.hazelcast.map.impl.SimpleEntryView<" + util.DATA_FULL_NAME +"," + util.DATA_FULL_NAME +">">
             <#return "anEntryView">
         <#case "com.hazelcast.nio.Address">

--- a/hazelcast-code-generator/src/main/resources/BinaryCompatibilityNullFileGenerator.ftl
+++ b/hazelcast-code-generator/src/main/resources/BinaryCompatibilityNullFileGenerator.ftl
@@ -111,6 +111,8 @@ public class BinaryCompatibilityNullFileGenerator {
             <#return "aPartitionTable">
         <#case "java.util.List<java.util.Map.Entry<"+ util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">>">
             <#return "aListOfEntry">
+        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<java.lang.String>>>">
+            <#return "taskHandlers">
         <#case "com.hazelcast.map.impl.SimpleEntryView<" + util.DATA_FULL_NAME +"," + util.DATA_FULL_NAME +">">
             <#return "anEntryView">
         <#case "com.hazelcast.nio.Address">

--- a/hazelcast-code-generator/src/main/resources/ClientCompatibilityNullTest.ftl
+++ b/hazelcast-code-generator/src/main/resources/ClientCompatibilityNullTest.ftl
@@ -170,6 +170,8 @@ public class ClientCompatibilityNullTest_${testForVersionClassName} {
             <#return "aPartitionTable">
         <#case "java.util.List<java.util.Map.Entry<"+ util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">>">
             <#return "aListOfEntry">
+        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<java.lang.String>>>">
+            <#return "taskHandlers">
         <#case "com.hazelcast.map.impl.SimpleEntryView<" + util.DATA_FULL_NAME +"," + util.DATA_FULL_NAME +">">
             <#return "anEntryView">
         <#case "com.hazelcast.nio.Address">

--- a/hazelcast-code-generator/src/main/resources/ClientCompatibilityTest.ftl
+++ b/hazelcast-code-generator/src/main/resources/ClientCompatibilityTest.ftl
@@ -169,6 +169,8 @@ public class ClientCompatibilityTest_${testForVersionClassName} {
             <#return "aPartitionTable">
         <#case "java.util.List<java.util.Map.Entry<"+ util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">>">
             <#return "aListOfEntry">
+        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<java.lang.String>>>">
+            <#return "taskHandlers">
         <#case "com.hazelcast.map.impl.SimpleEntryView<" + util.DATA_FULL_NAME +"," + util.DATA_FULL_NAME +">">
             <#return "anEntryView">
         <#case "com.hazelcast.nio.Address">

--- a/hazelcast-code-generator/src/main/resources/EncodeDecodeCompatibilityNullTest.ftl
+++ b/hazelcast-code-generator/src/main/resources/EncodeDecodeCompatibilityNullTest.ftl
@@ -130,6 +130,8 @@ public class EncodeDecodeCompatibilityNullTest {
             <#return "aPartitionTable">
         <#case "java.util.List<java.util.Map.Entry<"+ util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">>">
             <#return "aListOfEntry">
+        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<java.lang.String>>>">
+            <#return "taskHandlers">
         <#case "com.hazelcast.map.impl.SimpleEntryView<" + util.DATA_FULL_NAME +"," + util.DATA_FULL_NAME +">">
             <#return "anEntryView">
         <#case "com.hazelcast.nio.Address">

--- a/hazelcast-code-generator/src/main/resources/EncodeDecodeCompatibilityTest.ftl
+++ b/hazelcast-code-generator/src/main/resources/EncodeDecodeCompatibilityTest.ftl
@@ -130,6 +130,8 @@ public class EncodeDecodeCompatibilityTest {
             <#return "aPartitionTable">
         <#case "java.util.List<java.util.Map.Entry<"+ util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">>">
             <#return "aListOfEntry">
+        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<java.lang.String>>>">
+            <#return "taskHandlers">
         <#case "com.hazelcast.map.impl.SimpleEntryView<" + util.DATA_FULL_NAME +"," + util.DATA_FULL_NAME +">">
             <#return "anEntryView">
         <#case "com.hazelcast.nio.Address">

--- a/hazelcast-code-generator/src/main/resources/ServerCompatibilityNullTest.ftl
+++ b/hazelcast-code-generator/src/main/resources/ServerCompatibilityNullTest.ftl
@@ -160,6 +160,8 @@ public class ServerCompatibilityNullTest_${testForVersionClassName} {
             <#return "aPartitionTable">
         <#case "java.util.List<java.util.Map.Entry<"+ util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">>">
             <#return "aListOfEntry">
+        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<java.lang.String>>>">
+            <#return "taskHandlers">
         <#case "com.hazelcast.map.impl.SimpleEntryView<" + util.DATA_FULL_NAME +"," + util.DATA_FULL_NAME +">">
             <#return "anEntryView">
         <#case "com.hazelcast.nio.Address">

--- a/hazelcast-code-generator/src/main/resources/ServerCompatibilityTest.ftl
+++ b/hazelcast-code-generator/src/main/resources/ServerCompatibilityTest.ftl
@@ -161,6 +161,8 @@ public class ServerCompatibilityTest_${testForVersionClassName} {
             <#return "aPartitionTable">
         <#case "java.util.List<java.util.Map.Entry<"+ util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">>">
             <#return "aListOfEntry">
+        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<java.lang.String>>>">
+            <#return "taskHandlers">
         <#case "com.hazelcast.map.impl.SimpleEntryView<" + util.DATA_FULL_NAME +"," + util.DATA_FULL_NAME +">">
             <#return "anEntryView">
         <#case "com.hazelcast.nio.Address">

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/constants/ResponseMessageConst.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/constants/ResponseMessageConst.java
@@ -51,7 +51,7 @@ public final class ResponseMessageConst {
     public static final int ENTRIES_WITH_CURSOR = 118;
     public static final int LIST_DATA_MAYBE_NULL_ELEMENTS = 119;
     @Since("1.4") public static final int SCHEDULED_TASK_STATISTICS = 120;
-    @Since("1.4") public static final int LIST_SCHEDULED_TASK_HANDLER = 121;
+    @Since("1.4") public static final int ALL_SCHEDULED_TASK_HANDLERS = 121;
 
     private ResponseMessageConst() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ResponseTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ResponseTemplate.java
@@ -178,7 +178,7 @@ public interface ResponseTemplate {
                                  long totalRuns, long totalRunTimeNanos);
 
     @Since("1.4")
-    @Response(ResponseMessageConst.LIST_SCHEDULED_TASK_HANDLER)
-    void ListScheduledTaskHandler(List<String> handlers);
+    @Response(ResponseMessageConst.ALL_SCHEDULED_TASK_HANDLERS)
+    void AllScheduledTasksHandlers(List<Map.Entry<Member, List<String>>> handlers);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ScheduledExecutorCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ScheduledExecutorCodecTemplate.java
@@ -63,13 +63,12 @@ public interface ScheduledExecutorCodecTemplate {
      * Returns all scheduled tasks in for a given scheduler in the given member.
      *
      * @param schedulerName The name of the scheduler.
-     * @param address  The address of the member to do the lookup.
      * @return A list of scheduled task handlers used to construct the future proxies.
      */
     @Since("1.4")
-    @Request(id = 4, retryable = true, response = ResponseMessageConst.LIST_SCHEDULED_TASK_HANDLER,
+    @Request(id = 4, retryable = true, response = ResponseMessageConst.ALL_SCHEDULED_TASK_HANDLERS,
             partitionIdentifier = "partitionId")
-    Object getAllScheduledFutures(String schedulerName, Address address);
+    Object getAllScheduledFutures(String schedulerName);
 
     /**
      * Returns statistics associated with the given task handler.

--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
     </modules>
 
     <properties>
-        <hazelcast.git.repo>hazelcast</hazelcast.git.repo>
-        <hazelcast.git.branch>master</hazelcast.git.branch>
+        <hazelcast.git.repo>tkountis</hazelcast.git.repo>
+        <hazelcast.git.branch>fix/3.8/partition_based_getAllScheduled_scheduledExecutorService</hazelcast.git.branch>
         <main.basedir>${project.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
Modify `ScheduledExecutorCodecTemplate#getAllScheduledFutures` to ignore address. 
Before we were issuing a Client -> Member request **per member** to fetch all scheduled tasks for a given scheduled executor. With this patch we are doing a **single** Client -> Member request, and let the member do the logic of fetching everything. 

Logic became a bit more complicated and is preferred to be kept on the member side, rather than having the protocol to deal with it. More details can be found here: hazelcast/hazelcast#9827