### PR TITLE
Fix/scheduled executor/master

### DIFF
--- a/hazelcast-code-generator/src/main/resources/BinaryCompatibilityFileGenerator.ftl
+++ b/hazelcast-code-generator/src/main/resources/BinaryCompatibilityFileGenerator.ftl
@@ -111,6 +111,8 @@ public class BinaryCompatibilityFileGenerator {
             <#return "aPartitionTable">
         <#case "java.util.List<java.util.Map.Entry<"+ util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">>">
             <#return "aListOfEntry">
+        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<java.lang.String>>>">
+            <#return "taskHandlers">
         <#case "com.hazelcast.map.impl.SimpleEntryView<" + util.DATA_FULL_NAME +"," + util.DATA_FULL_NAME +">">
             <#return "anEntryView">
         <#case "com.hazelcast.nio.Address">

--- a/hazelcast-code-generator/src/main/resources/BinaryCompatibilityFileGenerator.ftl
+++ b/hazelcast-code-generator/src/main/resources/BinaryCompatibilityFileGenerator.ftl
@@ -16,6 +16,7 @@ import com.hazelcast.map.impl.querycache.event.QueryCacheEventData;
 import com.hazelcast.mapreduce.JobPartitionState;
 import com.hazelcast.mapreduce.impl.task.JobPartitionStateImpl;
 import com.hazelcast.nio.Address;
+import com.hazelcast.scheduledexecutor.ScheduledTaskHandler;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.transaction.impl.xa.SerializableXID;
 
@@ -111,7 +112,7 @@ public class BinaryCompatibilityFileGenerator {
             <#return "aPartitionTable">
         <#case "java.util.List<java.util.Map.Entry<"+ util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">>">
             <#return "aListOfEntry">
-        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<java.lang.String>>>">
+        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<com.hazelcast.scheduledexecutor.ScheduledTaskHandler>>>">
             <#return "taskHandlers">
         <#case "com.hazelcast.map.impl.SimpleEntryView<" + util.DATA_FULL_NAME +"," + util.DATA_FULL_NAME +">">
             <#return "anEntryView">

--- a/hazelcast-code-generator/src/main/resources/BinaryCompatibilityNullFileGenerator.ftl
+++ b/hazelcast-code-generator/src/main/resources/BinaryCompatibilityNullFileGenerator.ftl
@@ -16,6 +16,7 @@ import com.hazelcast.map.impl.querycache.event.QueryCacheEventData;
 import com.hazelcast.mapreduce.JobPartitionState;
 import com.hazelcast.mapreduce.impl.task.JobPartitionStateImpl;
 import com.hazelcast.nio.Address;
+import com.hazelcast.scheduledexecutor.ScheduledTaskHandler;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.transaction.impl.xa.SerializableXID;
 
@@ -111,7 +112,7 @@ public class BinaryCompatibilityNullFileGenerator {
             <#return "aPartitionTable">
         <#case "java.util.List<java.util.Map.Entry<"+ util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">>">
             <#return "aListOfEntry">
-        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<java.lang.String>>>">
+        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<com.hazelcast.scheduledexecutor.ScheduledTaskHandler>>>">
             <#return "taskHandlers">
         <#case "com.hazelcast.map.impl.SimpleEntryView<" + util.DATA_FULL_NAME +"," + util.DATA_FULL_NAME +">">
             <#return "anEntryView">

--- a/hazelcast-code-generator/src/main/resources/BinaryCompatibilityNullFileGenerator.ftl
+++ b/hazelcast-code-generator/src/main/resources/BinaryCompatibilityNullFileGenerator.ftl
@@ -111,6 +111,8 @@ public class BinaryCompatibilityNullFileGenerator {
             <#return "aPartitionTable">
         <#case "java.util.List<java.util.Map.Entry<"+ util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">>">
             <#return "aListOfEntry">
+        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<java.lang.String>>>">
+            <#return "taskHandlers">
         <#case "com.hazelcast.map.impl.SimpleEntryView<" + util.DATA_FULL_NAME +"," + util.DATA_FULL_NAME +">">
             <#return "anEntryView">
         <#case "com.hazelcast.nio.Address">

--- a/hazelcast-code-generator/src/main/resources/ClientCompatibilityNullTest.ftl
+++ b/hazelcast-code-generator/src/main/resources/ClientCompatibilityNullTest.ftl
@@ -18,6 +18,7 @@ import com.hazelcast.map.impl.querycache.event.QueryCacheEventData;
 import com.hazelcast.mapreduce.JobPartitionState;
 import com.hazelcast.mapreduce.impl.task.JobPartitionStateImpl;
 import com.hazelcast.nio.Address;
+import com.hazelcast.scheduledexecutor.ScheduledTaskHandler;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.transaction.impl.xa.SerializableXID;
 import java.io.IOException;
@@ -170,7 +171,7 @@ public class ClientCompatibilityNullTest_${testForVersionClassName} {
             <#return "aPartitionTable">
         <#case "java.util.List<java.util.Map.Entry<"+ util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">>">
             <#return "aListOfEntry">
-        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<java.lang.String>>>">
+        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<com.hazelcast.scheduledexecutor.ScheduledTaskHandler>>>">
             <#return "taskHandlers">
         <#case "com.hazelcast.map.impl.SimpleEntryView<" + util.DATA_FULL_NAME +"," + util.DATA_FULL_NAME +">">
             <#return "anEntryView">

--- a/hazelcast-code-generator/src/main/resources/ClientCompatibilityNullTest.ftl
+++ b/hazelcast-code-generator/src/main/resources/ClientCompatibilityNullTest.ftl
@@ -170,6 +170,8 @@ public class ClientCompatibilityNullTest_${testForVersionClassName} {
             <#return "aPartitionTable">
         <#case "java.util.List<java.util.Map.Entry<"+ util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">>">
             <#return "aListOfEntry">
+        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<java.lang.String>>>">
+            <#return "taskHandlers">
         <#case "com.hazelcast.map.impl.SimpleEntryView<" + util.DATA_FULL_NAME +"," + util.DATA_FULL_NAME +">">
             <#return "anEntryView">
         <#case "com.hazelcast.nio.Address">

--- a/hazelcast-code-generator/src/main/resources/ClientCompatibilityTest.ftl
+++ b/hazelcast-code-generator/src/main/resources/ClientCompatibilityTest.ftl
@@ -169,6 +169,8 @@ public class ClientCompatibilityTest_${testForVersionClassName} {
             <#return "aPartitionTable">
         <#case "java.util.List<java.util.Map.Entry<"+ util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">>">
             <#return "aListOfEntry">
+        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<java.lang.String>>>">
+            <#return "taskHandlers">
         <#case "com.hazelcast.map.impl.SimpleEntryView<" + util.DATA_FULL_NAME +"," + util.DATA_FULL_NAME +">">
             <#return "anEntryView">
         <#case "com.hazelcast.nio.Address">

--- a/hazelcast-code-generator/src/main/resources/ClientCompatibilityTest.ftl
+++ b/hazelcast-code-generator/src/main/resources/ClientCompatibilityTest.ftl
@@ -18,6 +18,7 @@ import com.hazelcast.map.impl.querycache.event.QueryCacheEventData;
 import com.hazelcast.mapreduce.JobPartitionState;
 import com.hazelcast.mapreduce.impl.task.JobPartitionStateImpl;
 import com.hazelcast.nio.Address;
+import com.hazelcast.scheduledexecutor.ScheduledTaskHandler;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.transaction.impl.xa.SerializableXID;
 import java.io.IOException;
@@ -169,7 +170,7 @@ public class ClientCompatibilityTest_${testForVersionClassName} {
             <#return "aPartitionTable">
         <#case "java.util.List<java.util.Map.Entry<"+ util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">>">
             <#return "aListOfEntry">
-        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<java.lang.String>>>">
+        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<com.hazelcast.scheduledexecutor.ScheduledTaskHandler>>>">
             <#return "taskHandlers">
         <#case "com.hazelcast.map.impl.SimpleEntryView<" + util.DATA_FULL_NAME +"," + util.DATA_FULL_NAME +">">
             <#return "anEntryView">

--- a/hazelcast-code-generator/src/main/resources/EncodeDecodeCompatibilityNullTest.ftl
+++ b/hazelcast-code-generator/src/main/resources/EncodeDecodeCompatibilityNullTest.ftl
@@ -15,6 +15,7 @@ import com.hazelcast.map.impl.querycache.event.QueryCacheEventData;
 import com.hazelcast.mapreduce.JobPartitionState;
 import com.hazelcast.mapreduce.impl.task.JobPartitionStateImpl;
 import com.hazelcast.nio.Address;
+import com.hazelcast.scheduledexecutor.ScheduledTaskHandler;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.transaction.impl.xa.SerializableXID;
 
@@ -130,7 +131,7 @@ public class EncodeDecodeCompatibilityNullTest {
             <#return "aPartitionTable">
         <#case "java.util.List<java.util.Map.Entry<"+ util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">>">
             <#return "aListOfEntry">
-        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<java.lang.String>>>">
+        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<com.hazelcast.scheduledexecutor.ScheduledTaskHandler>>>">
             <#return "taskHandlers">
         <#case "com.hazelcast.map.impl.SimpleEntryView<" + util.DATA_FULL_NAME +"," + util.DATA_FULL_NAME +">">
             <#return "anEntryView">

--- a/hazelcast-code-generator/src/main/resources/EncodeDecodeCompatibilityNullTest.ftl
+++ b/hazelcast-code-generator/src/main/resources/EncodeDecodeCompatibilityNullTest.ftl
@@ -130,6 +130,8 @@ public class EncodeDecodeCompatibilityNullTest {
             <#return "aPartitionTable">
         <#case "java.util.List<java.util.Map.Entry<"+ util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">>">
             <#return "aListOfEntry">
+        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<java.lang.String>>>">
+            <#return "taskHandlers">
         <#case "com.hazelcast.map.impl.SimpleEntryView<" + util.DATA_FULL_NAME +"," + util.DATA_FULL_NAME +">">
             <#return "anEntryView">
         <#case "com.hazelcast.nio.Address">

--- a/hazelcast-code-generator/src/main/resources/EncodeDecodeCompatibilityTest.ftl
+++ b/hazelcast-code-generator/src/main/resources/EncodeDecodeCompatibilityTest.ftl
@@ -130,6 +130,8 @@ public class EncodeDecodeCompatibilityTest {
             <#return "aPartitionTable">
         <#case "java.util.List<java.util.Map.Entry<"+ util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">>">
             <#return "aListOfEntry">
+        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<java.lang.String>>>">
+            <#return "taskHandlers">
         <#case "com.hazelcast.map.impl.SimpleEntryView<" + util.DATA_FULL_NAME +"," + util.DATA_FULL_NAME +">">
             <#return "anEntryView">
         <#case "com.hazelcast.nio.Address">

--- a/hazelcast-code-generator/src/main/resources/EncodeDecodeCompatibilityTest.ftl
+++ b/hazelcast-code-generator/src/main/resources/EncodeDecodeCompatibilityTest.ftl
@@ -15,6 +15,7 @@ import com.hazelcast.map.impl.querycache.event.QueryCacheEventData;
 import com.hazelcast.mapreduce.JobPartitionState;
 import com.hazelcast.mapreduce.impl.task.JobPartitionStateImpl;
 import com.hazelcast.nio.Address;
+import com.hazelcast.scheduledexecutor.ScheduledTaskHandler;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.transaction.impl.xa.SerializableXID;
 
@@ -130,7 +131,7 @@ public class EncodeDecodeCompatibilityTest {
             <#return "aPartitionTable">
         <#case "java.util.List<java.util.Map.Entry<"+ util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">>">
             <#return "aListOfEntry">
-        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<java.lang.String>>>">
+        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<com.hazelcast.scheduledexecutor.ScheduledTaskHandler>>>">
             <#return "taskHandlers">
         <#case "com.hazelcast.map.impl.SimpleEntryView<" + util.DATA_FULL_NAME +"," + util.DATA_FULL_NAME +">">
             <#return "anEntryView">

--- a/hazelcast-code-generator/src/main/resources/ServerCompatibilityNullTest.ftl
+++ b/hazelcast-code-generator/src/main/resources/ServerCompatibilityNullTest.ftl
@@ -17,6 +17,7 @@ import com.hazelcast.map.impl.querycache.event.QueryCacheEventData;
 import com.hazelcast.mapreduce.JobPartitionState;
 import com.hazelcast.mapreduce.impl.task.JobPartitionStateImpl;
 import com.hazelcast.nio.Address;
+import com.hazelcast.scheduledexecutor.ScheduledTaskHandler;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.transaction.impl.xa.SerializableXID;
 import com.hazelcast.client.impl.protocol.util.SafeBuffer;
@@ -160,7 +161,7 @@ public class ServerCompatibilityNullTest_${testForVersionClassName} {
             <#return "aPartitionTable">
         <#case "java.util.List<java.util.Map.Entry<"+ util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">>">
             <#return "aListOfEntry">
-        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<java.lang.String>>>">
+        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<com.hazelcast.scheduledexecutor.ScheduledTaskHandler>>>">
             <#return "taskHandlers">
         <#case "com.hazelcast.map.impl.SimpleEntryView<" + util.DATA_FULL_NAME +"," + util.DATA_FULL_NAME +">">
             <#return "anEntryView">

--- a/hazelcast-code-generator/src/main/resources/ServerCompatibilityNullTest.ftl
+++ b/hazelcast-code-generator/src/main/resources/ServerCompatibilityNullTest.ftl
@@ -160,6 +160,8 @@ public class ServerCompatibilityNullTest_${testForVersionClassName} {
             <#return "aPartitionTable">
         <#case "java.util.List<java.util.Map.Entry<"+ util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">>">
             <#return "aListOfEntry">
+        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<java.lang.String>>>">
+            <#return "taskHandlers">
         <#case "com.hazelcast.map.impl.SimpleEntryView<" + util.DATA_FULL_NAME +"," + util.DATA_FULL_NAME +">">
             <#return "anEntryView">
         <#case "com.hazelcast.nio.Address">

--- a/hazelcast-code-generator/src/main/resources/ServerCompatibilityTest.ftl
+++ b/hazelcast-code-generator/src/main/resources/ServerCompatibilityTest.ftl
@@ -17,6 +17,7 @@ import com.hazelcast.map.impl.querycache.event.QueryCacheEventData;
 import com.hazelcast.mapreduce.JobPartitionState;
 import com.hazelcast.mapreduce.impl.task.JobPartitionStateImpl;
 import com.hazelcast.nio.Address;
+import com.hazelcast.scheduledexecutor.ScheduledTaskHandler;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.transaction.impl.xa.SerializableXID;
 import com.hazelcast.client.impl.protocol.util.SafeBuffer;
@@ -161,7 +162,7 @@ public class ServerCompatibilityTest_${testForVersionClassName} {
             <#return "aPartitionTable">
         <#case "java.util.List<java.util.Map.Entry<"+ util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">>">
             <#return "aListOfEntry">
-        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<java.lang.String>>>">
+        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<com.hazelcast.scheduledexecutor.ScheduledTaskHandler>>>">
             <#return "taskHandlers">
         <#case "com.hazelcast.map.impl.SimpleEntryView<" + util.DATA_FULL_NAME +"," + util.DATA_FULL_NAME +">">
             <#return "anEntryView">

--- a/hazelcast-code-generator/src/main/resources/ServerCompatibilityTest.ftl
+++ b/hazelcast-code-generator/src/main/resources/ServerCompatibilityTest.ftl
@@ -161,6 +161,8 @@ public class ServerCompatibilityTest_${testForVersionClassName} {
             <#return "aPartitionTable">
         <#case "java.util.List<java.util.Map.Entry<"+ util.DATA_FULL_NAME + "," + util.DATA_FULL_NAME + ">>">
             <#return "aListOfEntry">
+        <#case "java.util.List<java.util.Map.Entry<com.hazelcast.core.Member,java.util.List<java.lang.String>>>">
+            <#return "taskHandlers">
         <#case "com.hazelcast.map.impl.SimpleEntryView<" + util.DATA_FULL_NAME +"," + util.DATA_FULL_NAME +">">
             <#return "anEntryView">
         <#case "com.hazelcast.nio.Address">

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledTaskHandlerCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/ScheduledTaskHandlerCodec.java
@@ -1,0 +1,56 @@
+package com.hazelcast.client.impl.protocol.codec;
+
+import com.hazelcast.annotation.Codec;
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.util.ParameterUtil;
+import com.hazelcast.nio.Address;
+import com.hazelcast.nio.Bits;
+import com.hazelcast.scheduledexecutor.ScheduledTaskHandler;
+import com.hazelcast.scheduledexecutor.impl.ScheduledTaskHandlerImpl;
+
+@Codec(ScheduledTaskHandler.class)
+public final class ScheduledTaskHandlerCodec {
+
+    private ScheduledTaskHandlerCodec() {
+    }
+
+    public static ScheduledTaskHandler decode(ClientMessage clientMessage) {
+        String schedulerName = clientMessage.getStringUtf8();
+        String taskName = clientMessage.getStringUtf8();
+        boolean isToAddress = clientMessage.getBoolean();
+        if (isToAddress) {
+            Address address = AddressCodec.decode(clientMessage);
+            return ScheduledTaskHandlerImpl.of(address, schedulerName, taskName);
+        } else {
+            int partitionId = clientMessage.getInt();
+            return ScheduledTaskHandlerImpl.of(partitionId, schedulerName, taskName);
+        }
+    }
+
+    public static void encode(ScheduledTaskHandler scheduledTaskHandler, ClientMessage clientMessage) {
+        clientMessage.set(scheduledTaskHandler.getSchedulerName());
+        clientMessage.set(scheduledTaskHandler.getTaskName());
+        Address address = scheduledTaskHandler.getAddress();
+        boolean isToAddress = address != null;
+        clientMessage.set(isToAddress);
+        if (isToAddress) {
+            AddressCodec.encode(address, clientMessage);
+        } else {
+            clientMessage.set(scheduledTaskHandler.getPartitionId());
+        }
+    }
+
+    public static int calculateDataSize(ScheduledTaskHandler scheduledTaskHandler) {
+        int dataSize = ParameterUtil.calculateDataSize(scheduledTaskHandler.getSchedulerName());
+        dataSize += ParameterUtil.calculateDataSize(scheduledTaskHandler.getTaskName());
+        // is to address field
+        dataSize += Bits.BOOLEAN_SIZE_IN_BYTES;
+        Address address = scheduledTaskHandler.getAddress();
+        if (address != null) {
+            dataSize += AddressCodec.calculateDataSize(address);
+        } else {
+            dataSize += Bits.INT_SIZE_IN_BYTES;
+        }
+        return dataSize;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/constants/ResponseMessageConst.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/constants/ResponseMessageConst.java
@@ -51,7 +51,7 @@ public final class ResponseMessageConst {
     public static final int ENTRIES_WITH_CURSOR = 118;
     public static final int LIST_DATA_MAYBE_NULL_ELEMENTS = 119;
     @Since("1.4") public static final int SCHEDULED_TASK_STATISTICS = 120;
-    @Since("1.4") public static final int LIST_SCHEDULED_TASK_HANDLER = 121;
+    @Since("1.4") public static final int ALL_SCHEDULED_TASK_HANDLERS = 121;
 
     private ResponseMessageConst() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ResponseTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ResponseTemplate.java
@@ -178,7 +178,7 @@ public interface ResponseTemplate {
                                  long totalRuns, long totalRunTimeNanos);
 
     @Since("1.4")
-    @Response(ResponseMessageConst.LIST_SCHEDULED_TASK_HANDLER)
-    void ListScheduledTaskHandler(List<String> handlers);
+    @Response(ResponseMessageConst.ALL_SCHEDULED_TASK_HANDLERS)
+    void AllScheduledTasksHandlers(List<Map.Entry<Member, List<String>>> handlers);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ResponseTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ResponseTemplate.java
@@ -28,6 +28,7 @@ import com.hazelcast.map.impl.SimpleEntryView;
 import com.hazelcast.mapreduce.JobPartitionState;
 import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
+import com.hazelcast.scheduledexecutor.ScheduledTaskHandler;
 
 import java.util.List;
 import java.util.Map;
@@ -179,6 +180,6 @@ public interface ResponseTemplate {
 
     @Since("1.4")
     @Response(ResponseMessageConst.ALL_SCHEDULED_TASK_HANDLERS)
-    void AllScheduledTasksHandlers(List<Map.Entry<Member, List<String>>> handlers);
+    void AllScheduledTasksHandlers(List<Map.Entry<Member, List<ScheduledTaskHandler>>> handlers);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ScheduledExecutorCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ScheduledExecutorCodecTemplate.java
@@ -42,22 +42,30 @@ public interface ScheduledExecutorCodecTemplate {
      * Submits the task to partition for execution, partition is chosen based on multiple criteria of the given task.
      *
      * @param schedulerName The name of the scheduler.
-     * @param taskDefinition  The data form of the Callable or Runnable task to be executed on that scheduler
+     * @param type type of schedule logic, values 0 for SINGLE_RUN, 1 for AT_FIXED_RATE
+     * @param taskName The name of the task
+     * @param task The data form of the Callable or Runnable task to be executed on that scheduler
+     * @param initialDelayInMillis initial delay in milliseconds
+     * @param periodInMillis period between each run in milliseconds
      */
     @Since("1.4")
-    @Request(id = 2, retryable = true, response = ResponseMessageConst.VOID, partitionIdentifier = "partitionId")
-    void submitToPartition(String schedulerName, Data taskDefinition);
+    @Request(id = 2, retryable = true, response = ResponseMessageConst.VOID, partitionIdentifier = "taskName")
+    void submitToPartition(String schedulerName, byte type, String taskName, Data task, long initialDelayInMillis, long periodInMillis);
 
     /**
      * Submits the task to a member for execution, member is provided in the form of an address.
      *
      * @param schedulerName The name of the scheduler.
-     * @param taskDefinition  The data form of the Callable or Runnable task to be executed on that scheduler
      * @param address The address of the member where the task will get scheduled.
+     * @param type type of schedule logic, values 0 for SINGLE_RUN, 1 for AT_FIXED_RATE
+     * @param taskName The name of the task
+     * @param task The data form of the Callable or Runnable task to be executed on that scheduler
+     * @param initialDelayInMillis initial delay in milliseconds
+     * @param periodInMillis period between each run in milliseconds
      */
     @Since("1.4")
-    @Request(id = 3, retryable = true, response = ResponseMessageConst.VOID, partitionIdentifier = "partitionId")
-    void submitToAddress(String schedulerName, Address address, Data taskDefinition);
+    @Request(id = 3, retryable = true, response = ResponseMessageConst.VOID)
+    void submitToAddress(String schedulerName, Address address, byte type, String taskName, Data task, long initialDelayInMillis, long periodInMillis);
 
     /**
      * Returns all scheduled tasks in for a given scheduler in the given member.
@@ -66,92 +74,171 @@ public interface ScheduledExecutorCodecTemplate {
      * @return A list of scheduled task handlers used to construct the future proxies.
      */
     @Since("1.4")
-    @Request(id = 4, retryable = true, response = ResponseMessageConst.ALL_SCHEDULED_TASK_HANDLERS,
-            partitionIdentifier = "partitionId")
+    @Request(id = 4, retryable = true, response = ResponseMessageConst.ALL_SCHEDULED_TASK_HANDLERS)
     Object getAllScheduledFutures(String schedulerName);
 
     /**
-     * Returns statistics associated with the given task handler.
+     * Returns statistics of the task
      *
-     * @param handlerUrn The resource handler URN of the task
-     * @return A snapshot of the task statistics as identified from the given handler.
+     * @param schedulerName The name of the scheduler.
+     * @param taskName The name of the task
+     * @return A snapshot of the task statistics
      */
     @Since("1.4")
-    @Request(id = 5, retryable = true, response = ResponseMessageConst.SCHEDULED_TASK_STATISTICS,
-            partitionIdentifier = "partitionId")
-    Object getStats(String handlerUrn);
+    @Request(id = 5, retryable = true, response = ResponseMessageConst.SCHEDULED_TASK_STATISTICS, partitionIdentifier = "taskName")
+    Object getStatsFromPartition(String schedulerName, String taskName);
 
     /**
-     * Returns the ScheduledFuture's for the task in the scheduler as identified from the given handler.
+     * Returns statistics of the task
      *
-     * @param handlerUrn The resource handler URN of the task
-     * @param timeUnitName A string representing time unit information.
-     *                     <br/> Allowed values:
-     *                     <ul>
-     *                         <li>"NANOSECONDS"</li>
-     *                         <li>"MICROSECONDS"</li>
-     *                         <li>"MILLISECONDS"</li>
-     *                         <li>"SECONDS"</li>
-     *                         <li>"MINUTES"</li>
-     *                         <li>"HOURS"</li>
-     *                         <li>"DAYS"</li>
-     *                     </ul>
-     *                     Any other non NULL input will result in ILLEGAL_ARGUMENT.
-     * @return The remaining delay of the task formatted in the given Time Unit.
+     * @param schedulerName The name of the scheduler.
+     * @param taskName The name of the task
+     * @param address The address of the member where the task will get scheduled.
+     * @return A snapshot of the task statistics
      */
     @Since("1.4")
-    @Request(id = 6, retryable = true, response = ResponseMessageConst.LONG, partitionIdentifier = "partitionId")
-    long getDelay(String handlerUrn, String timeUnitName);
+    @Request(id = 6, retryable = true, response = ResponseMessageConst.SCHEDULED_TASK_STATISTICS)
+    Object getStatsFromAddress(String schedulerName , String taskName, Address address);
 
     /**
-     * Cancels further execution and scheduling of the task as identified from the given handler.
+     * Returns the ScheduledFuture's delay in nanoseconds for the task in the scheduler.
      *
-     * @param handlerUrn The resource handler URN of the task
+     * @param schedulerName The name of the scheduler.
+     * @param taskName The name of the task
+     * @return The remaining delay of the task formatted in nanoseconds.
+     */
+    @Since("1.4")
+    @Request(id = 7, retryable = true, response = ResponseMessageConst.LONG, partitionIdentifier = "taskName")
+    long getDelayFromPartition(String schedulerName , String taskName);
+
+    /**
+     * Returns the ScheduledFuture's delay in nanoseconds for the task in the scheduler.
+     *
+     * @param schedulerName The name of the scheduler.
+     * @param taskName The name of the task
+     * @param address The address of the member where the task will get scheduled.
+     * @return The remaining delay of the task formatted in nanoseconds.
+     */
+    @Since("1.4")
+    @Request(id = 8, retryable = true, response = ResponseMessageConst.LONG)
+    long getDelayFromAddress(String schedulerName , String taskName, Address address);
+
+    /**
+     * Cancels further execution and scheduling of the task
+     *
+     * @param schedulerName The name of the scheduler.
+     * @param taskName The name of the task
      * @param mayInterruptIfRunning  A boolean flag to indicate whether the task should be interrupted.
      * @return True if the task was cancelled
      */
     @Since("1.4")
-    @Request(id = 7, retryable = true, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "partitionId")
-    boolean cancel(String handlerUrn, boolean mayInterruptIfRunning);
+    @Request(id = 9, retryable = true, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "taskName")
+    boolean cancelFromPartition(String schedulerName, String taskName, boolean mayInterruptIfRunning);
+
+    /**
+     * Cancels further execution and scheduling of the task
+     *
+     * @param schedulerName The name of the scheduler.
+     * @param taskName The name of the task
+     * @param address The address of the member where the task will get scheduled.
+     * @param mayInterruptIfRunning  A boolean flag to indicate whether the task should be interrupted.
+     * @return True if the task was cancelled
+     */
+    @Since("1.4")
+    @Request(id = 10, retryable = true, response = ResponseMessageConst.BOOLEAN)
+    boolean cancelFromAddress(String schedulerName, String taskName, Address address, boolean mayInterruptIfRunning);
 
     /**
      * Checks whether a task as identified from the given handler is already cancelled.
      *
-     * @param handlerUrn The resource handler URN of the task
+     * @param schedulerName The name of the scheduler.
+     * @param taskName The name of the task
      * @return True if the task is cancelled
      */
     @Since("1.4")
-    @Request(id = 8, retryable = true, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "partitionId")
-    boolean isCancelled(String handlerUrn);
+    @Request(id = 11, retryable = true, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "taskName")
+    boolean isCancelledFromPartition(String schedulerName, String taskName);
 
     /**
-     * Checks whether a task as identified from the given handler is done.
+     * Checks whether a task as identified from the given handler is already cancelled.
+     *
+     * @param schedulerName The name of the scheduler.
+     * @param taskName The name of the task
+     * @param address The address of the member where the task will get scheduled.
+     * @return True if the task is cancelled
+     */
+    @Since("1.4")
+    @Request(id = 12, retryable = true, response = ResponseMessageConst.BOOLEAN)
+    boolean isCancelledFromAddress(String schedulerName , String taskName, Address address);
+
+    /**
+     * Checks whether a task is done.
      * @see {@link java.util.concurrent.Future#cancel(boolean)}
      *
-     * @param handlerUrn The resource handler URN of the task
+     * @param schedulerName The name of the scheduler.
+     * @param taskName The name of the task
      * @return True if the task is done
      */
     @Since("1.4")
-    @Request(id = 9, retryable = true, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "partitionId")
-    boolean isDone(String handlerUrn);
+    @Request(id = 13, retryable = true, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "taskName")
+    boolean isDoneFromPartition(String schedulerName , String taskName);
 
     /**
-     * Fetches the result of the task ({@link java.util.concurrent.Callable}) as identified from the given handler.
+     * Checks whether a task is done.
+     * @see {@link java.util.concurrent.Future#cancel(boolean)}
+     *
+     * @param schedulerName The name of the scheduler.
+     * @param taskName The name of the task
+     * @param address The address of the member where the task will get scheduled.
+     * @return True if the task is done
+     */
+    @Since("1.4")
+    @Request(id = 14, retryable = true, response = ResponseMessageConst.BOOLEAN)
+    boolean isDoneFromAddress(String schedulerName , String taskName, Address address);
+
+    /**
+     * Fetches the result of the task ({@link java.util.concurrent.Callable})
      * The call will blocking until the result is ready.
      *
-     * @param handlerUrn The resource handler URN of the task
+     * @param schedulerName The name of the scheduler.
+     * @param taskName The name of the task
      * @return The result of the completed task, in serialized form ({@link Data}.
      */
     @Since("1.4")
-    @Request(id = 10, retryable = true, response = ResponseMessageConst.DATA, partitionIdentifier = "partitionId")
-    Data getResult(String handlerUrn);
+    @Request(id = 15, retryable = true, response = ResponseMessageConst.DATA, partitionIdentifier = "taskName")
+    Data getResultFromPartition(String schedulerName , String taskName);
 
     /**
-     * Dispose the task from the scheduler, as identified from the given handler.
+     * Fetches the result of the task ({@link java.util.concurrent.Callable})
+     * The call will blocking until the result is ready.
      *
-     * @param handlerUrn The resource handler URN of the task
+     * @param schedulerName The name of the scheduler.
+     * @param taskName The name of the task
+     * @param address The address of the member where the task will get scheduled.
+     * @return The result of the completed task, in serialized form ({@link Data}.
      */
     @Since("1.4")
-    @Request(id = 11, retryable = true, response = ResponseMessageConst.VOID, partitionIdentifier = "partitionId")
-    void dispose(String handlerUrn);
+    @Request(id = 16, retryable = true, response = ResponseMessageConst.DATA)
+    Data getResultFromAddress(String schedulerName , String taskName, Address address);
+
+    /**
+     * Dispose the task from the scheduler
+     *
+     * @param schedulerName The name of the scheduler.
+     * @param taskName The name of the task
+     */
+    @Since("1.4")
+    @Request(id = 17, retryable = true, response = ResponseMessageConst.VOID, partitionIdentifier = "taskName")
+    void disposeFromPartition(String schedulerName, String taskName);
+
+    /**
+     * Dispose the task from the scheduler
+     *
+     * @param schedulerName The name of the scheduler.
+     * @param taskName The name of the task
+     * @param address The address of the member where the task will get scheduled.
+     */
+    @Since("1.4")
+    @Request(id = 18, retryable = true, response = ResponseMessageConst.VOID)
+    void disposeFromAddress(String schedulerName , String taskName, Address address);
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ScheduledExecutorCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ScheduledExecutorCodecTemplate.java
@@ -63,13 +63,12 @@ public interface ScheduledExecutorCodecTemplate {
      * Returns all scheduled tasks in for a given scheduler in the given member.
      *
      * @param schedulerName The name of the scheduler.
-     * @param address  The address of the member to do the lookup.
      * @return A list of scheduled task handlers used to construct the future proxies.
      */
     @Since("1.4")
-    @Request(id = 4, retryable = true, response = ResponseMessageConst.LIST_SCHEDULED_TASK_HANDLER,
+    @Request(id = 4, retryable = true, response = ResponseMessageConst.ALL_SCHEDULED_TASK_HANDLERS,
             partitionIdentifier = "partitionId")
-    Object getAllScheduledFutures(String schedulerName, Address address);
+    Object getAllScheduledFutures(String schedulerName);
 
     /**
      * Returns statistics associated with the given task handler.

--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
     </modules>
 
     <properties>
-        <hazelcast.git.repo>hazelcast</hazelcast.git.repo>
-        <hazelcast.git.branch>master</hazelcast.git.branch>
+        <hazelcast.git.repo>tkountis</hazelcast.git.repo>
+        <hazelcast.git.branch>fix/3.8/partition_based_getAllScheduled_scheduledExecutorService</hazelcast.git.branch>
         <main.basedir>${project.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 

--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
     </modules>
 
     <properties>
-        <hazelcast.git.repo>tkountis</hazelcast.git.repo>
-        <hazelcast.git.branch>fix/3.8/partition_based_getAllScheduled_scheduledExecutorService</hazelcast.git.branch>
+        <hazelcast.git.repo>sancar</hazelcast.git.repo>
+        <hazelcast.git.branch>fix/scheduledExecutor/master</hazelcast.git.branch>
         <main.basedir>${project.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
@tkountis 
Modify ScheduledExecutorCodecTemplate#getAllScheduledFutures to ignore address.
Before we were issuing a Client -> Member request per member to fetch all scheduled tasks for a given scheduled executor. With this patch we are doing a single Client -> Member request, and let the member do the logic of fetching everything.

Logic became a bit more complicated and is preferred to be kept on the member side, rather than having the protocol to deal with it. More details can be found here: hazelcast/hazelcast#9827

@sancar
TaskDefinition was used as serialized to a single string(urn) in client protocol. In this pr these usages are expanded. Instead of single string schedularName, taskName, address/parition id is used.
Messages going to partition id or address are seperated. 

`partitionIdentifier` annotation is fixed. Since partition id is calculated from `taskName`, it should have `taskName` is value.

ScheduledTaskHandlerCodec is implemented to handle this in responses.
More details can be found here: hazelcast/hazelcast#9827
