### PR TITLE
Add projection and filtering support for map iterator

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/constants/ResponseMessageConst.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/constants/ResponseMessageConst.java
@@ -54,6 +54,7 @@ public final class ResponseMessageConst {
     @Since("1.4") public static final int ALL_SCHEDULED_TASK_HANDLERS = 121;
     @Since("1.4") public static final int NEAR_CACHE_INVALIDATION_META_DATA = 122;
     @Since("1.4") public static final int LIST_ENTRY_PARTITION_UUID = 123;
+    @Since("1.5") public static final int QUERY_RESULT_SEGMENT = 124;
 
     private ResponseMessageConst() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
@@ -843,4 +843,20 @@ public interface MapCodecTemplate {
     @Since("1.4")
     Object addNearCacheInvalidationListener(String name, int listenerFlags, boolean localOnly);
 
+
+    /**
+     * Fetches the specified number of entries from the specified partition starting from specified table index
+     * that match the predicate and applies the projection logic on them.
+     *
+     * @param name       Name of the map
+     * @param tableIndex The slot number (or index) to start the iterator
+     * @param batch      The number of items to be batched
+     * @param projection projection to transform the entries with
+     * @param predicate  predicate to filter the entries with
+     * @return last index processed and list of entries after applied to the projection
+     */
+    @Request(id = 70, retryable = true, response = ResponseMessageConst.QUERY_RESULT_SEGMENT, partitionIdentifier = "partitionId")
+    @Since("1.5")
+    Object fetchWithQuery(String name, int tableIndex, int batch, Data projection, Data predicate);
+
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ResponseTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ResponseTemplate.java
@@ -197,4 +197,12 @@ public interface ResponseTemplate {
     @Since("1.4")
     @Response(ResponseMessageConst.LIST_ENTRY_PARTITION_UUID)
     void PartitionUuidList(List<Map.Entry<Integer, UUID>> partitionUuidList);
+
+    /**
+     * @param results                  The query results as an list of serialized projected entries that might have null entries
+     * @param nextTableIndexToReadFrom the index from which new items can be fetched
+     */
+    @Since("1.5")
+    @Response(ResponseMessageConst.QUERY_RESULT_SEGMENT)
+    void ResultSegment(@ContainsNullable List<Data> results, int nextTableIndexToReadFrom);
 }


### PR DESCRIPTION
The added projection and filtering support reuses the query engine but
allows running the query on chunk within a single partition. This
allows iteration with predicates and projections. Currently iterating
the indexes is not supported, the predicate will be run on each entry.
Also, the projection does not support the Offloadable which means that
it is invoked on the partition thread.

Changed the type of the entry which is provided to the predicate from
CachedQueryEntry to LazyMapEntry to allow the identity projection -
previously it failed when being serialized since CachedQueryEntry is
not serializable.

Also added some more generics and javadocs.