### PR TITLE
Generate build properties on downloaded hazelcast code

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -151,7 +151,32 @@
                 </executions>
             </plugin>
 
-
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.0.2</version>
+                <executions>
+                    <execution>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>downloaded/template</directory>
+                                    <includes>
+                                        <include>**/*.java</include>
+                                    </includes>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                            <outputDirectory>downloaded/java</outputDirectory>
+                            <overwrite>true</overwrite>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
The build step was compiling hazelcast code but failed to generate
the GeneratedBuildProperties which causes the build to fail.
Added plugin for generating class on the same step as in the hazelcast
project.

See : https://github.com/hazelcast/hazelcast/commit/5fbbe09ee90777063d3c82f72ff00eebacbf1c0b