### PR TITLE
Marked map query requests as retryable

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
@@ -476,7 +476,7 @@ public interface MapCodecTemplate {
      * @return a set clone of the keys contained in this map.
      * @see com.hazelcast.instance.GroupProperty#QUERY_RESULT_SIZE_LIMIT
      */
-    @Request(id = 38, retryable = false, response = ResponseMessageConst.LIST_DATA)
+    @Request(id = 38, retryable = true, response = ResponseMessageConst.LIST_DATA)
     Object keySet(String name);
 
     /**
@@ -503,7 +503,7 @@ public interface MapCodecTemplate {
      * @return All values in the map
      * @see com.hazelcast.instance.GroupProperty#QUERY_RESULT_SIZE_LIMIT
      */
-    @Request(id = 40, retryable = false, response = ResponseMessageConst.LIST_DATA)
+    @Request(id = 40, retryable = true, response = ResponseMessageConst.LIST_DATA)
     Object values(String name);
 
     /**
@@ -516,7 +516,7 @@ public interface MapCodecTemplate {
      * @return a set clone of the keys mappings in this map
      * @see com.hazelcast.instance.GroupProperty#QUERY_RESULT_SIZE_LIMIT
      */
-    @Request(id = 41, retryable = false, response = ResponseMessageConst.LIST_ENTRY)
+    @Request(id = 41, retryable = true, response = ResponseMessageConst.LIST_ENTRY)
     Object entrySet(String name);
 
     /**
@@ -530,7 +530,7 @@ public interface MapCodecTemplate {
      * @return result key set for the query.
      * @see com.hazelcast.instance.GroupProperty#QUERY_RESULT_SIZE_LIMIT
      */
-    @Request(id = 42, retryable = false, response = ResponseMessageConst.LIST_DATA)
+    @Request(id = 42, retryable = true, response = ResponseMessageConst.LIST_DATA)
     Object keySetWithPredicate(String name, Data predicate);
 
     /**
@@ -544,7 +544,7 @@ public interface MapCodecTemplate {
      * @return result value collection of the query.
      * @see com.hazelcast.instance.GroupProperty#QUERY_RESULT_SIZE_LIMIT
      */
-    @Request(id = 43, retryable = false, response = ResponseMessageConst.LIST_DATA)
+    @Request(id = 43, retryable = true, response = ResponseMessageConst.LIST_DATA)
     Object valuesWithPredicate(String name, Data predicate);
 
     /**
@@ -558,7 +558,7 @@ public interface MapCodecTemplate {
      * @return result key-value entry collection of the query.
      * @see com.hazelcast.instance.GroupProperty#QUERY_RESULT_SIZE_LIMIT
      */
-    @Request(id = 44, retryable = false, response = ResponseMessageConst.LIST_ENTRY)
+    @Request(id = 44, retryable = true, response = ResponseMessageConst.LIST_ENTRY)
     Object entriesWithPredicate(String name, Data predicate);
 
     /**
@@ -697,7 +697,7 @@ public interface MapCodecTemplate {
      * @param predicate specified query criteria.
      * @return result keys for the query.
      */
-    @Request(id = 56, retryable = false, response = ResponseMessageConst.LIST_DATA)
+    @Request(id = 56, retryable = true, response = ResponseMessageConst.LIST_DATA)
     Object keySetWithPagingPredicate(String name, Data predicate);
 
     /**
@@ -711,7 +711,7 @@ public interface MapCodecTemplate {
      * @return values for the query.
      * @see com.hazelcast.instance.GroupProperty#QUERY_RESULT_SIZE_LIMIT
      */
-    @Request(id = 57, retryable = false, response = ResponseMessageConst.LIST_ENTRY)
+    @Request(id = 57, retryable = true, response = ResponseMessageConst.LIST_ENTRY)
     Object valuesWithPagingPredicate(String name, Data predicate);
 
     /**
@@ -719,7 +719,7 @@ public interface MapCodecTemplate {
      * @param predicate specified query criteria.
      * @return key-value pairs for the query.
      */
-    @Request(id = 58, retryable = false, response = ResponseMessageConst.LIST_ENTRY)
+    @Request(id = 58, retryable = true, response = ResponseMessageConst.LIST_ENTRY)
     Object entriesWithPagingPredicate(String name, Data predicate);
 
     @Request(id = 59, retryable = false, response = ResponseMessageConst.VOID)


### PR DESCRIPTION
IMap.keySet, entrySet and values methods are read-only and should be retried when cluster members fail.