### PR TITLE
Generate correct code for response messages with primitive array

### DIFF
--- a/hazelcast-code-generator/src/main/resources/codec-template-java.ftl
+++ b/hazelcast-code-generator/src/main/resources/codec-template-java.ftl
@@ -379,7 +379,7 @@ public final class ${model.className} {
             int ${sizeVariableName} = clientMessage.getInt();
             ${var_name} = new ${itemVariableType}[${sizeVariableName}];
             for (int ${indexVariableName} = 0;${indexVariableName}<${sizeVariableName};${indexVariableName}++) {
-                ${itemVariableType} ${itemVariableName} = null;
+                ${itemVariableType} ${itemVariableName} = <@getDefaultValueForType type=itemVariableType />;
                 <#if containsNullable>
                         boolean ${isNullVariableName} = clientMessage.getBoolean();
                         if (!${isNullVariableName}) {


### PR DESCRIPTION
The code generation was expecting object arrays and was defaulting
the item value to `null`. This fails if we want to have a primitive
array. Here we default the value of the array item to the java
default value.