### PR TITLE
Add map and cache event journal

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/constants/ResponseMessageConst.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/constants/ResponseMessageConst.java
@@ -54,6 +54,7 @@ public final class ResponseMessageConst {
     @Since("1.4") public static final int ALL_SCHEDULED_TASK_HANDLERS = 121;
     @Since("1.4") public static final int NEAR_CACHE_INVALIDATION_META_DATA = 122;
     @Since("1.4") public static final int LIST_ENTRY_PARTITION_UUID = 123;
+    @Since("1.5") public static final int EVENT_JOURNAL_INITIAL_SUBSCRIBER_STATE = 124;
 
     private ResponseMessageConst() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/CacheCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/CacheCodecTemplate.java
@@ -405,4 +405,38 @@ public interface CacheCodecTemplate {
     @Request(id = 32, retryable = true, response = ResponseMessageConst.LIST_ENTRY_PARTITION_UUID)
     @Since("1.4")
     Object assignAndGetUuids();
+
+
+    /**
+     * Performs the initial subscription to the cache event journal.
+     * This includes retrieving the event journal sequences of the
+     * oldest and newest event in the journal.
+     *
+     * @param name name of the cache
+     * @return the cache event journal subcription information
+     */
+    @Request(id = 33, retryable = true, response = ResponseMessageConst.EVENT_JOURNAL_INITIAL_SUBSCRIBER_STATE, partitionIdentifier = "partitionId")
+    @Since("1.5")
+    Object eventJournalSubscribe(String name);
+
+    /**
+     * Reads from the cache event journal in batches. You may specify the start sequence,
+     * the minumum required number of items in the response, the maximum number of items
+     * in the response, a predicate that the events should pass and a projection to
+     * apply to the events in the journal.
+     * The predicate, filter and projection may be {@code null} in which case all elements are returned
+     * and no projection is applied.
+     *
+     * @param name          name of the map
+     * @param startSequence the startSequence of the first item to read
+     * @param minSize       the minimum number of items to read.
+     * @param maxSize       the maximum number of items to read.
+     * @param predicate     the predicate to apply before processing events
+     * @param projection    the projection to apply to journal events
+     * @return read event journal items
+     */
+    @Request(id = 34, retryable = true, response = ResponseMessageConst.READ_RESULT_SET, partitionIdentifier = "partitionId")
+    @Since("1.5")
+    Object eventJournalRead(String name, long startSequence, int minSize, int maxSize,
+                            @Nullable Data predicate, @Nullable Data projection);
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
@@ -17,6 +17,7 @@
 package com.hazelcast.client.impl.protocol.template;
 
 import com.hazelcast.annotation.GenerateCodec;
+import com.hazelcast.annotation.Nullable;
 import com.hazelcast.annotation.Request;
 import com.hazelcast.annotation.Since;
 import com.hazelcast.client.impl.protocol.constants.EventMessageConst;
@@ -843,4 +844,50 @@ public interface MapCodecTemplate {
     @Since("1.4")
     Object addNearCacheInvalidationListener(String name, int listenerFlags, boolean localOnly);
 
+
+    /**
+     * Performs the initial subscription to the map event journal. This includes running a query for the
+     * initial map snapshot and retrieving the latest event journal sequence from which events may
+     * be read after the snapshot is processed.
+     *
+     * @param name       name of the map
+     * @param predicate  the predicate to apply before processing events
+     * @param projection the projection to apply to journal events
+     * @return The response for the map event journal subcription. This includes the
+     * {@link com.hazelcast.map.impl.query.QueryResult} for the initial snapshot
+     * and the sequence from which new events can be read after the snapshot
+     * has been processed.
+     */
+    /**
+     * Performs the initial subscription to the map event journal.
+     * This includes retrieving the event journal sequences of the
+     * oldest and newest event in the journal.
+     *
+     * @param name name of the map
+     * @return the map event journal subcription information
+     */
+    @Request(id = 70, retryable = true, response = ResponseMessageConst.EVENT_JOURNAL_INITIAL_SUBSCRIBER_STATE, partitionIdentifier = "partitionId")
+    @Since("1.5")
+    Object eventJournalSubscribe(String name);
+
+    /**
+     * Reads from the map event journal in batches. You may specify the start sequence,
+     * the minumum required number of items in the response, the maximum number of items
+     * in the response, a predicate that the events should pass and a projection to
+     * apply to the events in the journal.
+     * The predicate, filter and projection may be {@code null} in which case all elements are returned
+     * and no projection is applied.
+     *
+     * @param name          name of the map
+     * @param startSequence the startSequence of the first item to read
+     * @param minSize       the minimum number of items to read.
+     * @param maxSize       the maximum number of items to read.
+     * @param predicate     the predicate to apply before processing events
+     * @param projection    the projection to apply to journal events
+     * @return read event journal items
+     */
+    @Request(id = 71, retryable = true, response = ResponseMessageConst.READ_RESULT_SET, partitionIdentifier = "partitionId")
+    @Since("1.5")
+    Object eventJournalRead(String name, long startSequence, int minSize, int maxSize,
+                            @Nullable Data predicate, @Nullable Data projection);
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ResponseTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ResponseTemplate.java
@@ -162,9 +162,10 @@ public interface ResponseTemplate {
     /**
      * @param readCount Number of items in the response.
      * @param items     The array of serialized items.
+     * @param itemSeqs  sequence IDs of returned ringbuffer items
      */
     @Response(ResponseMessageConst.READ_RESULT_SET)
-    void ReadResultSet(int readCount, List<Data> items);
+    void ReadResultSet(int readCount, List<Data> items, long[] itemSeqs);
 
     /**
      * @param tableIndex the last tableIndex processed,
@@ -197,4 +198,13 @@ public interface ResponseTemplate {
     @Since("1.4")
     @Response(ResponseMessageConst.LIST_ENTRY_PARTITION_UUID)
     void PartitionUuidList(List<Map.Entry<Integer, UUID>> partitionUuidList);
+
+    /**
+     *
+     * @param oldestSequence sequence ID of the oldest event in the event journal
+     * @param newestSequence sequence ID of the newest event in the event journal
+     */
+    @Since("1.5")
+    @Response(ResponseMessageConst.EVENT_JOURNAL_INITIAL_SUBSCRIBER_STATE)
+    void EventJournalInitialSubscriberState(long oldestSequence, long newestSequence);
 }

--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
     </modules>
 
     <properties>
-        <hazelcast.git.repo>hazelcast</hazelcast.git.repo>
-        <hazelcast.git.branch>master</hazelcast.git.branch>
+        <hazelcast.git.repo>mmedenjak</hazelcast.git.repo>
+        <hazelcast.git.branch>event-stream</hazelcast.git.branch>
         <main.basedir>${project.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
Add event journal for storing and reading mutation events on map and
cache. The events are identified by a long sequence ID.
The events are written in a ringbuffer (event journal) and can be
read from MapProxyImpl, CacheProxy, ClientMapProxy and
ClientCacheProxy. The reading is done by first subscribing and then
calling the read method.
The subscription currently only returns the oldest and newest
sequence ID but it could hold more information in the future, such as
 the subscription ID.