### PR TITLE
Add List<Entry<String,byte[]>> to reference objects

### DIFF
--- a/hazelcast-code-generator/src/main/resources/compatibility-common.ftl
+++ b/hazelcast-code-generator/src/main/resources/compatibility-common.ftl
@@ -40,6 +40,8 @@
             <#return "aNamePartitionSequenceList">
         <#case "java.util.List<java.util.Map.Entry<java.lang.Integer,java.util.UUID>>">
             <#return "aPartitionUuidList">
+        <#case "java.util.List<java.util.Map.Entry<java.lang.String,byte[]>>">
+            <#return "aListOfStringToByteArrEntry">
         <#case "com.hazelcast.nio.Address">
             <#return "anAddress">
         <#case "com.hazelcast.core.Member">


### PR DESCRIPTION
ClientMessageTemplate.deployClasses uses this parameter type and the
compatibility tests are generated with a compile error. This fix adds
 the reference object with this type.