### PR TITLE
Fragment RingbufferService and support predicates and projections

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ResponseTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ResponseTemplate.java
@@ -160,11 +160,27 @@ public interface ResponseTemplate {
             , int causeErrorCode, @Nullable String causeClassName);
 
     /**
-     * @param readCount Number of items in the response.
+     * @param readCount The number of items read from the ringbuffer. This can be different from
+     *                  the size of the item array if a filter was applied when reading and some
+     *                  items were skipped and are not in the returned array. This can also be
+     *                  seen as the delta with which the user should increase his sequence
+     *                  counter after consuming all of the returned items in the result set
+     *                  to request the next set from the ringbuffer.
      * @param items     The array of serialized items.
+     * @param itemSeqs  sequence IDs of returned ringbuffer items. This array can be {@code null}
+     *                  if the cluster version is 3.8 or lower. If the cluster version is 3.9 or
+     *                  higher then the array with sequence IDs will be sent. The array size is
+     *                  equal to the size of the items array and the arrays have a one-to-one
+     *                  mapping: the index of the sequence ID in the sequence array is equal
+     *                  to the index of the item in the item array. These sequences can be used to
+     *                  provide the user information to request a subset of the returned set if
+     *                  the user has for some reason stopped processing working when processing
+     *                  this returned set. If the ringbuffer is read without a filter then these
+     *                  sequences are a contiguous range and the size of the arrays is equal to the
+     *                  readCount.
      */
     @Response(ResponseMessageConst.READ_RESULT_SET)
-    void ReadResultSet(int readCount, List<Data> items);
+    void ReadResultSet(int readCount, List<Data> items, @Since("1.5") @Nullable long[] itemSeqs);
 
     /**
      * @param tableIndex the last tableIndex processed,

--- a/pom.xml
+++ b/pom.xml
@@ -52,8 +52,8 @@
     </modules>
 
     <properties>
-        <hazelcast.git.repo>hazelcast</hazelcast.git.repo>
-        <hazelcast.git.branch>master</hazelcast.git.branch>
+        <hazelcast.git.repo>mmedenjak</hazelcast.git.repo>
+        <hazelcast.git.branch>event-journal</hazelcast.git.branch>
         <main.basedir>${project.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 


### PR DESCRIPTION
Adapt RingbufferService to hold ringbuffers for other services (e.g.
map). This means that it should implement
FragmentedMigrationAwareService and return partition namespace data
for other services when requested.

Also, the read result sets were returning only how many items were
read as well as the matching items. In case the ringbuffer is read
with a filter, not all items match and the result set may not contain
items with a contiguous set of sequences. The itemCount is the
difference between the sequence ID of the last and first returned
item and is a hack not to send all sequence IDs.

We will send the sequence IDs instead. This allows the user to store
the sequence ID and resume processing even if the processing crashes
mid-point in the result set.

The ringbuffer already has supports for IFilter but we also add support
for predicates and projections.