### PR TITLE
[BACKPORT] Fixed includes for sources and JavaDoc JAR

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,9 @@
 .idea/
 .settings/
 hazelcast/downloaded
-hazelcast/hazelcast*
-hazelcast/*.zip
+hazelcast/hazelcast-*
+hazelcast/download.info
+hazelcast/*.zip*
 target/
 .classpath
 .project

--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -151,7 +151,56 @@
                 </executions>
             </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
+                <version>${maven.source.plugin.version}</version>
+                <configuration>
+                    <includes>
+                        <include>**/target/generated-sources/annotations/**/**</include>
+                        <include>**/com/hazelcast/client/impl/protocol/**</include>
+                    </includes>
+                </configuration>
+            </plugin>
 
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-javadoc-plugin</artifactId>
+                <version>${maven.javadoc.plugin.version}</version>
+                <configuration>
+                    <includes>
+                        <include>**/target/generated-sources/annotations/**/**</include>
+                        <include>**/com/hazelcast/client/impl/protocol/**</include>
+                    </includes>
+                </configuration>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>3.0.2</version>
+                <executions>
+                    <execution>
+                        <phase>process-sources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <resources>
+                                <resource>
+                                    <directory>downloaded/template</directory>
+                                    <includes>
+                                        <include>**/*.java</include>
+                                    </includes>
+                                    <filtering>true</filtering>
+                                </resource>
+                            </resources>
+                            <outputDirectory>downloaded/java</outputDirectory>
+                            <overwrite>true</overwrite>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/hazelcast/scripts/cleanDownloaded.sh
+++ b/hazelcast/scripts/cleanDownloaded.sh
@@ -1,12 +1,12 @@
 #!/usr/bin/env bash
 
-HAZELCAST_BRANCH="${1//\//-}"   # finds directory name by replacing `/` with `-` (e.g. `fix/3.8/abc` will become `fix-3.8-abc`)
-rm $HAZELCAST_BRANCH.zip*
+# finds directory name by replacing `/` with `-` (e.g. `fix/3.8/abc` will become `fix-3.8-abc`)
+HAZELCAST_BRANCH="${1//\//-}"
+rm ${HAZELCAST_BRANCH}.zip*
 
-if([[ $HAZELCAST_BRANCH == v* ]])
-then
+if ([[ ${HAZELCAST_BRANCH} == v* ]]); then
    HAZELCAST_BRANCH=${HAZELCAST_BRANCH:1}
 fi
 
-rm -rf hazelcast-$HAZELCAST_BRANCH
+rm -rf hazelcast-${HAZELCAST_BRANCH}
 rm -rf ../hazelcast/downloaded/

--- a/hazelcast/scripts/downloadHazelcast.sh
+++ b/hazelcast/scripts/downloadHazelcast.sh
@@ -2,15 +2,21 @@
 
 HAZELCAST_REPO="$1"
 HAZELCAST_BRANCH="$2"
-DOWNLOADED_HAZELCAST_BRANCH=${2##*/}    # finds downloaded-file-name by extracting string after rightmost slash.(e.g. extracted name from `fix/3.8/abc` will be `abc`)
-COPY_HAZELCAST_BRANCH=${2//\//-}    # finds unzipped directory name by replacing `/` with `-` (e.g. `fix/3.8/abc` will become `fix-3.8-abc`)
+# finds downloaded-file-name by extracting string after rightmost slash.(e.g. extracted name from `fix/3.8/abc` will be `abc`)
+DOWNLOADED_HAZELCAST_BRANCH=${2##*/}
+# finds unzipped directory name by replacing `/` with `-` (e.g. `fix/3.8/abc` will become `fix-3.8-abc`)
+COPY_HAZELCAST_BRANCH=${2//\//-}
 
-wget -q https://github.com/$HAZELCAST_REPO/hazelcast/archive/$HAZELCAST_BRANCH.zip
-unzip -oq $DOWNLOADED_HAZELCAST_BRANCH.zip
+wget -q https://github.com/${HAZELCAST_REPO}/hazelcast/archive/${HAZELCAST_BRANCH}.zip
+unzip -oq ${DOWNLOADED_HAZELCAST_BRANCH}.zip
 
-if([[ $DOWNLOADED_HAZELCAST_BRANCH == v* ]])
-then
+if ([[ ${DOWNLOADED_HAZELCAST_BRANCH} == v* ]]); then
    DOWNLOADED_HAZELCAST_BRANCH=${DOWNLOADED_HAZELCAST_BRANCH:1}
 fi
+
+echo "HAZELCAST_REPO: $HAZELCAST_REPO" > download.info
+echo "HAZELCAST_BRANCH: $HAZELCAST_BRANCH" >> download.info
+echo "DOWNLOADED_HAZELCAST_BRANCH: $DOWNLOADED_HAZELCAST_BRANCH" >> download.info
+echo "COPY_HAZELCAST_BRANCH: $DOWNLOADED_HAZELCAST_BRANCH" >> download.info
 
 cp -R ./hazelcast-${COPY_HAZELCAST_BRANCH}/hazelcast/src/main ../hazelcast/downloaded/

--- a/pom.xml
+++ b/pom.xml
@@ -33,15 +33,16 @@
         <developerConnection>scm:git:git@github.com:hazelcast/hazelcast-client-protocol.git</developerConnection>
         <url>https://github.com/hazelcast/hazelcast-client-protocol/</url>
     </scm>
+
     <developers>
         <developer>
             <id>sancar</id>
-            <name>sancar koyunlu</name>
+            <name>Sancar Koyunlu</name>
             <email>sancar@hazelcast.com</email>
         </developer>
         <developer>
             <id>asimarslan</id>
-            <name>asim arslan</name>
+            <name>Asim Arslan</name>
             <email>asim@hazelcast.com</email>
         </developer>
     </developers>
@@ -52,8 +53,11 @@
     </modules>
 
     <properties>
+        <!-- Hazelcast branch to download and compile with -->
         <hazelcast.git.repo>asimarslan</hazelcast.git.repo>
         <hazelcast.git.branch>mergedbr</hazelcast.git.branch>
+
+        <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
@@ -108,16 +112,8 @@
         <sonar.verbose>true</sonar.verbose>
 
         <jsr107.api.version>1.0.0</jsr107.api.version>
-        <CacheManagerImpl>com.hazelcast.cache.HazelcastCacheManager</CacheManagerImpl>
-        <CacheImpl>com.hazelcast.cache.ICache</CacheImpl>
-        <CacheEntryImpl>com.hazelcast.cache.impl.CacheEntry</CacheEntryImpl>
-        <javax.management.builder.initial>com.hazelcast.cache.impl.TCKMBeanServerBuilder
-        </javax.management.builder.initial>
-        <org.jsr107.tck.management.agentId>TCKMbeanServer</org.jsr107.tck.management.agentId>
-        <javax.cache.annotation.CacheInvocationContext>javax.cache.annotation.impl.cdi.CdiCacheKeyInvocationContextImpl
-        </javax.cache.annotation.CacheInvocationContext>
-
     </properties>
+
     <licenses>
         <license>
             <name>The Apache Software License, Version 2.0</name>


### PR DESCRIPTION
* fixed the include settings for the Maven sources and JavaDoc plugin
* added a debug file which prints which Hazelcast version was downloaded
* small cleanup of pom.xml files

(cherry picked from commit 4bae497)

Backport of https://github.com/hazelcast/hazelcast-client-protocol/pull/99
Fixes https://github.com/hazelcast/hazelcast/issues/11261