### PR TITLE
version-changed check added to nodejs codec

### DIFF
--- a/hazelcast-code-generator/src/main/resources/codec-template-node.ftl
+++ b/hazelcast-code-generator/src/main/resources/codec-template-node.ftl
@@ -44,13 +44,24 @@ return clientMessage;
 <#--************************ RESPONSE ********************************************************-->
 <#if model.responseParams?has_content>
 static decodeResponse(clientMessage : ClientMessage,  toObjectFunction: (data: Data) => any = null){
-// Decode response from client message
-var parameters :any = { <#list model.responseParams as p>'${util.convertToNodeType(p.name)}' : null <#if p_has_next>, </#if></#list> };
+    // Decode response from client message
+<#assign messageVersion=model.messageSinceInt>
+    var parameters :any = {
     <#list model.responseParams as p>
-        <@getterText var_name=util.convertToNodeType(p.name) type=p.type isNullable=p.nullable/>
+        '${util.convertToNodeType(p.name)}' : null <#if p_has_next>, </#if>
     </#list>
-return parameters;
+    };
 
+<#list model.responseParams as p>
+    <#if p.versionChanged>
+    if (clientMessage.isComplete() ) {
+        return parameters;
+    }
+    </#if>
+    <@getterText var_name=util.convertToNodeType(p.name) type=p.type isNullable=p.nullable/>
+    <#if p.sinceVersionInt gt messageVersion >parameters.${p.name}Exist = true;</#if>
+</#list>
+    return parameters;
 }
 <#else>
 // Empty decodeResponse(ClientMessage), this message has no parameters to decode


### PR DESCRIPTION
Node.js codec template decodeResponse method missed `versionChanged` check. Therefore new codecs break backward compatibility by trying to read more than message has actually have. It throws exception. 