### PR TITLE
fixes <java.lang.Long> conversion to Long

### DIFF
--- a/hazelcast-code-generator/src/main/java/com/hazelcast/client/protocol/generator/CodeGenerationUtils.java
+++ b/hazelcast-code-generator/src/main/java/com/hazelcast/client/protocol/generator/CodeGenerationUtils.java
@@ -408,7 +408,7 @@ public final class CodeGenerationUtils {
         return getLanguageType(Lang.NODE, type, JAVA_TO_TS_TYPES);
     }
 
-    @SuppressWarnings({"checkstyle:npathcomplexity", "checkstyle:whitespacearound"})
+    @SuppressWarnings({"checkstyle:npathcomplexity", "checkstyle:whitespacearound", "checkstyle:cyclomaticcomplexity"})
     public static String getLanguageType(Lang language, String type, Map<String, String> languageMapping) {
         type = type.trim();
         if (isGeneric(type)) {

--- a/hazelcast-code-generator/src/main/resources/codec-template-node.ftl
+++ b/hazelcast-code-generator/src/main/resources/codec-template-node.ftl
@@ -1,3 +1,19 @@
+/*
+ * Copyright (c) 2008-2018, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 /* tslint:disable */
 import ClientMessage = require('../ClientMessage');
 import {BitsUtil} from '../BitsUtil';
@@ -8,6 +24,8 @@ import {MemberCodec} from './MemberCodec';
 import {Data} from '../serialization/Data';
 import {EntryViewCodec} from './EntryViewCodec';
 import DistributedObjectInfoCodec = require('./DistributedObjectInfoCodec');
+import {Member} from '../core/Member';
+import {UUID} from '../core/UUID';
 import {${model.parentName}MessageType} from './${model.parentName}MessageType';
 
 var REQUEST_TYPE = ${model.parentName}MessageType.${model.parentName?upper_case}_${model.name?upper_case};
@@ -16,94 +34,86 @@ var RETRYABLE = <#if model.retryable == 1>true<#else>false</#if>;
 
 <#--************************ REQUEST ********************************************************-->
 
-export class ${model.className}{
+export class ${model.className} {
+    static calculateSize(<#list model.requestParams as param>${util.convertSpecialNodeName(param.name)} : ${util.getTsType(param.type)} <#if param_has_next> , </#if></#list>){
+        var dataSize : number = 0;
+        <#list model.requestParams as p>
+            <@sizeText var_name=util.convertSpecialNodeName(p.name) type=p.type isNullable=p.nullable/>
+        </#list>
+        return dataSize;
+    }
 
-
-
-static calculateSize(<#list model.requestParams as param>${util.convertToNodeType(param.name)} : ${util.getNodeTsType(param.type)} <#if param_has_next> , </#if></#list>){
-// Calculates the request payload size
-var dataSize : number = 0;
-<#list model.requestParams as p>
-    <@sizeText var_name=util.convertToNodeType(p.name) type=p.type isNullable=p.nullable/>
-</#list>
-return dataSize;
-}
-
-static encodeRequest(<#list model.requestParams as param>${util.convertToNodeType(param.name)} : ${util.getNodeTsType(param.type)}<#if param_has_next>, </#if></#list>){
-// Encode request into clientMessage
-var clientMessage = ClientMessage.newClientMessage(this.calculateSize(<#list model.requestParams as param>${util.convertToNodeType(param.name)}<#if param_has_next>, </#if></#list>));
-clientMessage.setMessageType(REQUEST_TYPE);
-clientMessage.setRetryable(RETRYABLE);
-<#list model.requestParams as p>
-    <@setterText var_name=util.convertToNodeType(p.name) type=p.type isNullable=p.nullable/>
-</#list>
-clientMessage.updateFrameLength();
-return clientMessage;
-}
+    static encodeRequest(<#list model.requestParams as param>${util.convertSpecialNodeName(param.name)} : ${util.getTsType(param.type)}<#if param_has_next>, </#if></#list>){
+        var clientMessage = ClientMessage.newClientMessage(this.calculateSize(<#list model.requestParams as param>${util.convertSpecialNodeName(param.name)}<#if param_has_next>, </#if></#list>));
+        clientMessage.setMessageType(REQUEST_TYPE);
+        clientMessage.setRetryable(RETRYABLE);
+        <#list model.requestParams as p>
+            <@setterText var_name=util.convertSpecialNodeName(p.name) type=p.type isNullable=p.nullable/>
+        </#list>
+        clientMessage.updateFrameLength();
+        return clientMessage;
+    }
 
 <#--************************ RESPONSE ********************************************************-->
 <#if model.responseParams?has_content>
-static decodeResponse(clientMessage : ClientMessage,  toObjectFunction: (data: Data) => any = null){
-    // Decode response from client message
-<#assign messageVersion=model.messageSinceInt>
-    var parameters :any = {
+    static decodeResponse(clientMessage : ClientMessage,  toObjectFunction: (data: Data) => any = null){
+    <#assign messageVersion=model.messageSinceInt>
+        var parameters :any = {
     <#list model.responseParams as p>
-        '${util.convertToNodeType(p.name)}' : null <#if p_has_next>, </#if>
+            '${util.convertSpecialNodeName(p.name)}' : null <#if p_has_next>, </#if>
     </#list>
-    };
+        };
 
-<#list model.responseParams as p>
-    <#if p.versionChanged>
-    if (clientMessage.isComplete() ) {
-        return parameters;
-    }
-    </#if>
-    <@getterText var_name=util.convertToNodeType(p.name) type=p.type isNullable=p.nullable/>
-    <#if p.sinceVersionInt gt messageVersion >parameters.${p.name}Exist = true;</#if>
-</#list>
+    <#list model.responseParams as p>
+        <#if p.versionChanged>
+        if (clientMessage.isComplete() ) {
+            return parameters;
+        }
+        </#if>
+        <@getterText var_name=util.convertSpecialNodeName(p.name) type=p.type isNullable=p.nullable/>
+        <#if p.sinceVersionInt gt messageVersion >parameters.${util.convertSpecialNodeName(p.name)}Exist = true;</#if>
+    </#list>
     return parameters;
-}
+    }
 <#else>
 // Empty decodeResponse(ClientMessage), this message has no parameters to decode
 </#if>
 
 <#--************************ EVENTS ********************************************************-->
 <#if model.events?has_content>
-static handle(clientMessage : ClientMessage, <#list model.events as event>handleEvent${util.capitalizeFirstLetter(event.name?lower_case)} : any<#if event_has_next>, </#if></#list> ,toObjectFunction: (data: Data) => any = null){
-
-var messageType = clientMessage.getMessageType();
+    static handle(clientMessage : ClientMessage, <#list model.events as event>handleEvent${util.capitalizeFirstLetter(event.name?lower_case)} : any<#if event_has_next>, </#if></#list> ,toObjectFunction: (data: Data) => any = null){
+        var messageType = clientMessage.getMessageType();
     <#list model.events as event>
-    if ( messageType === BitsUtil.EVENT_${event.name?upper_case} && handleEvent${util.capitalizeFirstLetter(event.name?lower_case)} !== null) {
-        var messageFinished = false;
+        if ( messageType === BitsUtil.EVENT_${event.name?upper_case} && handleEvent${util.capitalizeFirstLetter(event.name?lower_case)} !== null) {
+            var messageFinished = false;
         <#list event.eventParams as p>
-            var ${util.convertToNodeType(p.name)} : ${util.getNodeTsType(p.type)} = undefined;
+            var ${util.convertSpecialNodeName(p.name)} : ${util.getTsType(p.type)} = undefined;
         <#if p.versionChanged >
             if (!messageFinished) {
                 messageFinished = clientMessage.isComplete();
             }
         </#if>
             if (!messageFinished) {
-            <@getterText var_name=util.convertToNodeType(p.name) type=p.type isNullable=p.nullable isEvent=true isDefined=true />
-        }
+            <@getterText var_name=util.convertSpecialNodeName(p.name) type=p.type isNullable=p.nullable isEvent=true isDefined=true />
+            }
         </#list>
-    handleEvent${util.capitalizeFirstLetter(util.convertToNodeType(event.name?lower_case))}(<#list event.eventParams as param>${util.convertToNodeType(param.name)}<#if param_has_next>, </#if></#list>);
-    }
+        handleEvent${util.capitalizeFirstLetter(event.name?lower_case)}(<#list event.eventParams as param>${util.convertSpecialNodeName(param.name)}<#if param_has_next>, </#if></#list>);
+        }
     </#list>
-}
+    }
 </#if>
-
 }
 <#--MACROS BELOW-->
 <#--SIZE NULL CHECK MACRO -->
 <#macro sizeText var_name type isNullable=false>
-    <#if isNullable>
+<#if isNullable>
     dataSize += BitsUtil.BOOLEAN_SIZE_IN_BYTES;
     if(${var_name} !== null) {
         <@sizeTextInternal var_name=var_name type=type/>
     }
-    <#else>
-        <@sizeTextInternal var_name=var_name type=type/>
-    </#if>
+<#else>
+<@sizeTextInternal var_name=var_name type=type/>
+</#if>
 </#macro>
 
 
@@ -117,24 +127,33 @@ var messageType = clientMessage.getMessageType();
 
 <#--SIZE MACRO -->
 <#macro sizeTextInternal var_name type>
-    <#local cat= util.getTypeCategory(type)>
+    <#local cat=util.getTypeCategory(type)>
     <#switch cat>
         <#case "OTHER">
             <#if util.isPrimitive(type)>
-            dataSize += BitsUtil.${type?upper_case}_SIZE_IN_BYTES;
+        dataSize += BitsUtil.${type?upper_case}_SIZE_IN_BYTES;
             <#else >
-            dataSize += BitsUtil.calculateSize${util.capitalizeFirstLetter(util.getNodeType(type)?lower_case)}(${var_name});
-            </#if>
+            <#switch type>
+                <#case "java.lang.Integer">
+        dataSize += BitsUtil.INT_SIZE_IN_BYTES;
+                    <#break >
+                <#case "java.lang.Long">
+        dataSize += BitsUtil.LONG_SIZE_IN_BYTES;
+                    <#break >
+                <#default>
+        dataSize += BitsUtil.calculateSize${util.capitalizeFirstLetter(util.getTsType(type)?lower_case)}(${var_name});
+            </#switch>
+        </#if>
             <#break >
         <#case "CUSTOM">
-        dataSize += BitsUtil.calculateSize${util.capitalizeFirstLetter(util.getNodeType(type)?lower_case)}(${var_name});
+        dataSize += BitsUtil.calculateSize${util.capitalizeFirstLetter(util.getTsType(type)?lower_case)}(${var_name});
             <#break >
         <#case "COLLECTION">
         dataSize += BitsUtil.INT_SIZE_IN_BYTES;
-            <#local genericType= util.getGenericType(type)>
+            <#local genericType=util.getGenericType(type)>
             <#local n= var_name>
 
-        ${var_name}.forEach((${var_name}Item : any) => {
+        ${var_name}.forEach((${var_name}Item : ${util.getTsType(genericType)}) => {
             <@sizeTextInternal var_name="${n}Item"  type=genericType />
         });
             <#break >
@@ -159,8 +178,8 @@ var messageType = clientMessage.getMessageType();
             <#local keyType = util.getFirstGenericParameterType(type)>
             <#local valueType = util.getSecondGenericParameterType(type)>
             <#local n= var_name>
-        var key : ${util.getNodeTsType(keyType)} =  ${var_name}[0];
-        var val : ${util.getNodeTsType(valueType)} = ${var_name}[1];
+        var key : ${util.getTsType(keyType)} =  ${var_name}[0];
+        var val : ${util.getTsType(valueType)} = ${var_name}[1];
             <@sizeText var_name="key"  type=keyType/>
             <@sizeText var_name="val"  type=valueType/>
     </#switch>
@@ -183,7 +202,25 @@ var messageType = clientMessage.getMessageType();
 <#macro setterTextInternal var_name type >
     <#local cat= util.getTypeCategory(type)>
     <#if cat == "OTHER">
-    clientMessage.append${util.capitalizeFirstLetter(util.capitalizeFirstLetter(util.getNodeType(type)?lower_case))}(${var_name});
+        <#switch type>
+            <#case "java.lang.Integer">
+                clientMessage.appendInt32(${var_name});
+                <#break >
+            <#case "int">
+                clientMessage.appendInt32(${var_name});
+                <#break >
+            <#case "byte">
+                clientMessage.appendByte(${var_name});
+                <#break >
+            <#case "java.lang.Long">
+                clientMessage.appendLong(${var_name});
+                <#break >
+            <#case "long">
+                clientMessage.appendLong(${var_name});
+                <#break >
+            <#default>
+                clientMessage.append${util.capitalizeFirstLetter(util.getTsType(type))}(${var_name});
+        </#switch>
     </#if>
     <#if cat == "CUSTOM">
     ${util.getTypeCodec(type)?split(".")?last}.encode(clientMessage, ${var_name});
@@ -220,8 +257,8 @@ var messageType = clientMessage.getMessageType();
     <#if cat == "MAPENTRY">
         <#local keyType = util.getFirstGenericParameterType(type)>
         <#local valueType = util.getSecondGenericParameterType(type)>
-    var key : ${util.getNodeTsType(keyType)} = ${var_name}[0];
-    var val : ${util.getNodeTsType(valueType)}  = ${var_name}[1];
+    var key : ${util.getTsType(keyType)} = ${var_name}[0];
+    var val : ${util.getTsType(valueType)}  = ${var_name}[1];
         <@setterTextInternal var_name="key"  type=keyType/>
         <@setterTextInternal var_name="val"  type=valueType/>
     </#if>
@@ -251,7 +288,16 @@ var messageType = clientMessage.getMessageType();
                 <#case "java.lang.Integer">
                     <#if !isEvent>parameters['${var_name}']<#else>${var_name}</#if> = clientMessage.readInt32();
                     <#break >
+                <#case "int">
+                    <#if !isEvent>parameters['${var_name}']<#else>${var_name}</#if> = clientMessage.readInt32();
+                    <#break >
+                <#case "byte">
+                    <#if !isEvent>parameters['${var_name}']<#else>${var_name}</#if> = clientMessage.readByte();
+                    <#break >
                 <#case "java.lang.Long">
+                    <#if !isEvent>parameters['${var_name}']<#else>${var_name}</#if> = clientMessage.readLong();
+                    <#break >
+                <#case "long">
                     <#if !isEvent>parameters['${var_name}']<#else>${var_name}</#if> = clientMessage.readLong();
                     <#break >
                 <#case "java.lang.Boolean">
@@ -264,7 +310,7 @@ var messageType = clientMessage.getMessageType();
                     <#if !isEvent>parameters['${var_name}']<#else>${var_name}</#if> = [<#if isDeserial>toObjectFunction(</#if>clientMessage.readData()<#if isDeserial>)</#if>, <#if isDeserial>toObjectFunction(</#if>clientMessage.readData()<#if isDeserial>)</#if>]
                     <#break >
                 <#default>
-                    <#if !isEvent>parameters['${var_name}']<#else>${var_name}</#if> = clientMessage.read${util.capitalizeFirstLetter(util.getNodeType(varType))}();
+                    <#if !isEvent>parameters['${var_name}']<#else>${var_name}</#if> = clientMessage.read${util.capitalizeFirstLetter(util.getTsType(varType))}();
             </#switch>
             <#break >
         <#case "CUSTOM">
@@ -283,11 +329,11 @@ var messageType = clientMessage.getMessageType();
             <#local indexVariableName= "${var_name}Index">
         var ${sizeVariableName} = clientMessage.readInt32();
             <#if !isDefined>
-            var ${var_name} : any = [];
+            var ${var_name} : ${util.getTsType(varType)} = [];
             <#else>${var_name} = [];
             </#if>
         for(var ${indexVariableName} = 0 ;  ${indexVariableName} < ${sizeVariableName} ; ${indexVariableName}++){
-        var ${itemVariableName} : ${util.getNodeTsType(itemVariableType)};
+        var ${itemVariableName} : ${util.getTsType(itemVariableType)};
             <@getterTextInternal var_name=itemVariableName varType=itemVariableType isEvent=true isCollection=true isDefined=true/>
         ${var_name}.push(${itemVariableName})
         }
@@ -319,8 +365,8 @@ var messageType = clientMessage.getMessageType();
             <#local valueType = util.getSecondGenericParameterType(varType)>
             <#local keyVariableName= "${var_name}Key">
             <#local valVariableName= "${var_name}Val">
-        var ${keyVariableName}: ${util.getNodeTsType(keyType)};
-        var ${valVariableName}: ${util.getNodeTsType(valType)};
+        var ${keyVariableName}: ${util.getTsType(keyType)};
+        var ${valVariableName}: ${util.getTsType(valueType)};
             <@getterTextInternal var_name=keyVariableName isEvent=true varType=keyType />
             <@getterTextInternal var_name=valVariableName isEvent=true varType=valueType/>
         ${var_name} = [${keyVariableName}, ${valVariableName}];

--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@
 
     <properties>
         <!-- Hazelcast branch to download and compile with -->
-        <hazelcast.git.repo>vbekiaris</hazelcast.git.repo>
-        <hazelcast.git.branch>3-10-client-dynconfig-merge-policy</hazelcast.git.branch>
+        <hazelcast.git.repo>hazelcast</hazelcast.git.repo>
+        <hazelcast.git.branch>master</hazelcast.git.branch>
 
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.basedir}</main.basedir>


### PR DESCRIPTION
When java.lang.Long is used within a generic type in codec template, it was not converted to Node.js Client's `Long` primitive successfully. This PR fixes that problem. I bumped into this while generating PNCounter codecs.

Also, it includes some refactoring.