### PR TITLE
Add next sequence to read from in ResultSet response

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@
 
     <properties>
         <!-- Hazelcast branch to download and compile with -->
-        <hazelcast.git.repo>hazelcast</hazelcast.git.repo>
-        <hazelcast.git.branch>master</hazelcast.git.branch>
+        <hazelcast.git.repo>mmedenjak</hazelcast.git.repo>
+        <hazelcast.git.branch>journal-catchup</hazelcast.git.branch>
 
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.basedir}</main.basedir>


### PR DESCRIPTION
Sometimes the reader of the ringbuffer is loss tolerant and we may
allow the reader to be slow and skip some items. To indicate this, we
send an additional sequence to indicate where the reader can continue
reading from number of lost items so that the reader may check if
items have been lost (overwritten) and act on that information.