### PR TITLE
Introduce new type for compat test and documentation

### DIFF
--- a/hazelcast-code-generator/src/main/resources/codec-template-md.ftl
+++ b/hazelcast-code-generator/src/main/resources/codec-template-md.ftl
@@ -495,6 +495,8 @@ Header only event message, no message body exist.
             <#return "array of string">
         <#case "java.util.List<java.lang.Long>">
             <#return "array of longs">
+        <#case "java.util.List<java.util.Map.Entry<java.lang.String,java.lang.String>>">
+             <#return "array of string pairs">
         <#default>
             <#return "Unknown Data Type " + javaType>
     </#switch>

--- a/hazelcast-code-generator/src/main/resources/compatibility-common.ftl
+++ b/hazelcast-code-generator/src/main/resources/compatibility-common.ftl
@@ -90,6 +90,8 @@
             <#return "evictionConfig">
         <#case "java.util.List<java.util.Map.Entry<java.lang.String,java.lang.Long>>">
             <#return "aListOfStringToLong">
+        <#case "java.util.List<java.util.Map.Entry<java.lang.String,java.lang.String>>">
+             <#return "aListOfStringToString">
         <#default>
             <#return "Unknown Data Type " + javaType>
     </#switch>


### PR DESCRIPTION
Related to https://github.com/hazelcast/hazelcast/pull/12435
With addition of a new message task, we needed a new type
for compatibility tests and documentation

Adds `aListOfStringToString` type
java.util.List<java.util.Map.Entry<java.lang.String,java.lang.String>>