### PR TITLE
Reverts unneccessary field in CacheCodecTemplate#setExpiryPolicy

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/CacheCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/CacheCodecTemplate.java
@@ -450,10 +450,8 @@ public interface CacheCodecTemplate {
      * @param name          name of the cache
      * @param keys          The keys that are associated with the specified expiry policy.
      * @param expiryPolicy  custom expiry policy for this operation
-     * @param completionId  user generated id which shall be received as a field of the cache event upon completion of
-     *                      the request in the cluster.
      */
     @Request(id = 35, retryable = false, response = ResponseMessageConst.VOID)
     @Since("1.7")
-    void setExpiryPolicy(String name, List<Data> keys, Data expiryPolicy, int completionId);
+    void setExpiryPolicy(String name, List<Data> keys, Data expiryPolicy);
 }

--- a/pom.xml
+++ b/pom.xml
@@ -55,8 +55,8 @@
 
     <properties>
         <!-- Hazelcast branch to download and compile with -->
-        <hazelcast.git.repo>sancar</hazelcast.git.repo>
-        <hazelcast.git.branch>ench/protocolEventHandlingImpr/master</hazelcast.git.branch>
+        <hazelcast.git.repo>hazelcast</hazelcast.git.repo>
+        <hazelcast.git.branch>master</hazelcast.git.branch>
 
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.basedir}</main.basedir>


### PR DESCRIPTION
Removes completionId. It is normally used for triggering synchronous listeners but
this particular operation shpuld not trigger any listener, therefore such field is
not neccessary.