### PR TITLE
Remove eclipsesource JSON parser dependency

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -238,13 +238,6 @@
         </dependency>
 
         <dependency>
-            <groupId>com.eclipsesource.minimal-json</groupId>
-            <artifactId>minimal-json</artifactId>
-            <version>0.9.4</version>
-            <scope>compile</scope>
-        </dependency>
-
-        <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-code-generator</artifactId>
             <version>${project.version}</version>


### PR DESCRIPTION
Hazelcast core module newly includes the JSON related sources in the package `com.hazelcast.internal.json`.