### PR TITLE
Client labels in authentication message

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ClientMessageTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ClientMessageTemplate.java
@@ -42,7 +42,7 @@ public interface ClientMessageTemplate {
      * @param serializationVersion   client side supported version to inform server side
      * @param clientHazelcastVersion The Hazelcast version of the client. (e.g. 3.7.2)
      * @param clientName             the name of the client instance
-     * @param attributes             user defined attributes of the client instance
+     * @param labels                 User defined labels of the client instance
      * @param partitionCount         the expected partition count of the cluster. Checked on the server side when provided.
      *                               Authentication fails and 3:NOT_ALLOWED_IN_CLUSTER returned, in case of mismatch
      * @param clusterId              the expected id of the cluster. Checked on the server side when provided.
@@ -52,9 +52,8 @@ public interface ClientMessageTemplate {
     @Request(id = 2, retryable = true, response = ResponseMessageConst.AUTHENTICATION)
     Object authentication(String username, String password, @Nullable String uuid, @Nullable String ownerUuid,
                           boolean isOwnerConnection, String clientType, byte serializationVersion,
-                          @Since(value = "1.3") String clientHazelcastVersion,
-                          @Since(value = "1.8") String clientName,
-                          @Since(value = "1.8") List<Map.Entry<String, String>> attributes,
+                          @Since(value = "1.3") String clientHazelcastVersion, @Since(value = "1.8") String clientName,
+                          @Since(value = "1.8") List<String> labels,
                           @Since(value = "1.8") @Nullable Integer partitionCount,
                           @Since(value = "1.8") @Nullable String clusterId);
 
@@ -68,7 +67,7 @@ public interface ClientMessageTemplate {
      * @param serializationVersion   client side supported version to inform server side
      * @param clientHazelcastVersion The Hazelcast version of the client. (e.g. 3.7.2)
      * @param clientName             the name of the client instance
-     * @param attributes             user defined attributes of the client instance
+     * @param labels                 User defined labels of the client instance
      * @param partitionCount         the expected partition count of the cluster. Checked on the server side when provided.
      *                               Authentication fails and 3:NOT_ALLOWED_IN_CLUSTER returned, in case of mismatch
      * @param clusterId              the expected id of the cluster. Checked on the server side when provided.
@@ -78,10 +77,8 @@ public interface ClientMessageTemplate {
 
     @Request(id = 3, retryable = true, response = ResponseMessageConst.AUTHENTICATION)
     Object authenticationCustom(Data credentials, @Nullable String uuid, @Nullable String ownerUuid, boolean isOwnerConnection,
-                                String clientType, byte serializationVersion,
-                                @Since(value = "1.3") String clientHazelcastVersion,
-                                @Since(value = "1.8") String clientName,
-                                @Since(value = "1.8") List<Map.Entry<String, String>> attributes,
+                                String clientType, byte serializationVersion, @Since(value = "1.3") String clientHazelcastVersion,
+                                @Since(value = "1.8") String clientName, @Since(value = "1.8") List<String> labels,
                                 @Since(value = "1.8") @Nullable Integer partitionCount,
                                 @Since(value = "1.8") @Nullable String clusterId);
 

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
 
     <developers>
         <developer>
-            <id>ihsan</id>
+            <id>ihsandemir</id>
             <name>Ihsan Demir</name>
             <email>ihsan@hazelcast.com</email>
         </developer>
@@ -60,8 +60,8 @@
 
     <properties>
         <!-- Hazelcast branch to download and compile with -->
-        <hazelcast.git.repo>hazelcast</hazelcast.git.repo>
-        <hazelcast.git.branch>master</hazelcast.git.branch>
+        <hazelcast.git.repo>ihsandemir</hazelcast.git.repo>
+        <hazelcast.git.branch>clientLabels</hazelcast.git.branch>
 
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.basedir}</main.basedir>


### PR DESCRIPTION
Changed authentication codec template to use client labels instead of client attributes. This is for hazelcast PR https://github.com/hazelcast/hazelcast/pull/14464