### PR TITLE
Incorporate client->member address translation in AddressCodec

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AddressCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AddressCodec.java
@@ -17,6 +17,7 @@
 package com.hazelcast.client.impl.protocol.codec;
 
 import com.hazelcast.annotation.Codec;
+import com.hazelcast.client.impl.ClientEngine;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.util.ParameterUtil;
 import com.hazelcast.core.HazelcastException;
@@ -32,10 +33,12 @@ public final class AddressCodec {
     }
 
     public static Address decode(ClientMessage clientMessage) {
+        ClientEngine clientEngine = clientMessage.getClientEngine();
         String host = clientMessage.getStringUtf8();
         int port = clientMessage.getInt();
         try {
-            return new Address(host, port);
+            Address address = new Address(host, port);
+            return clientEngine == null ? address : clientEngine.memberAddressOf(address);
         } catch (UnknownHostException e) {
             throw new HazelcastException(e);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -60,8 +60,8 @@
 
     <properties>
         <!-- Hazelcast branch to download and compile with -->
-        <hazelcast.git.repo>mdogan</hazelcast.git.repo>
-        <hazelcast.git.branch>cp-subsystem</hazelcast.git.branch>
+        <hazelcast.git.repo>vbekiaris</hazelcast.git.repo>
+        <hazelcast.git.branch>fixes/3.12/connmgr-client</hazelcast.git.branch>
 
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.basedir}</main.basedir>


### PR DESCRIPTION
When decoding a request from a client, translate the client
address to member-side address within the AddressCodec.
This is required so that clients that connect to members
configured with multiple endpoints can communicate with
their `CLIENT` sockets, while members still use the proper
`MEMBER` addresses for intra-cluster communication.

This translation is only executed on member-side, as the `ClientEngine`
will only be available in `ClientMessage` here: https://github.com/hazelcast/hazelcast/pull/14521/files#diff-62dfc5312563d71974e936132c44bd73R119

