### PR TITLE
Revert client->member address translation in AddressCodec

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AddressCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/AddressCodec.java
@@ -17,7 +17,6 @@
 package com.hazelcast.client.impl.protocol.codec;
 
 import com.hazelcast.annotation.Codec;
-import com.hazelcast.client.impl.ClientEngine;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.util.ParameterUtil;
 import com.hazelcast.core.HazelcastException;
@@ -33,12 +32,10 @@ public final class AddressCodec {
     }
 
     public static Address decode(ClientMessage clientMessage) {
-        ClientEngine clientEngine = clientMessage.getClientEngine();
         String host = clientMessage.getStringUtf8();
         int port = clientMessage.getInt();
         try {
-            Address address = new Address(host, port);
-            return clientEngine == null ? address : clientEngine.memberAddressOf(address);
+            return new Address(host, port);
         } catch (UnknownHostException e) {
             throw new HazelcastException(e);
         }


### PR DESCRIPTION
Fixes #176 

Requires a further PR that implements client->member address translation in individual `MessageTask`s implementations in hazelcast after this PR is merged and a new protocol version is released.