### PR TITLE
Fix clean and download behaviour

### DIFF
--- a/hazelcast/pom.xml
+++ b/hazelcast/pom.xml
@@ -105,9 +105,6 @@
                             <goal>exec</goal>
                         </goals>
                         <configuration>
-                            <arguments>
-                                <argument>${hazelcast.git.branch}</argument>
-                            </arguments>
                             <executable>${basedir}/scripts/cleanDownloaded.sh</executable>
                         </configuration>
                     </execution>

--- a/hazelcast/scripts/cleanDownloaded.sh
+++ b/hazelcast/scripts/cleanDownloaded.sh
@@ -1,12 +1,4 @@
 #!/usr/bin/env bash
 
-# finds directory name by replacing `/` with `-` (e.g. `fix/3.8/abc` will become `fix-3.8-abc`)
-HAZELCAST_BRANCH="${1//\//-}"
-rm ${HAZELCAST_BRANCH}.zip*
-
-if ([[ ${HAZELCAST_BRANCH} == v* ]]); then
-   HAZELCAST_BRANCH=${HAZELCAST_BRANCH:1}
-fi
-
-rm -rf hazelcast-${HAZELCAST_BRANCH}
+rm -rf ./tempDownloaded
 rm -rf ../hazelcast/downloaded/

--- a/hazelcast/scripts/downloadHazelcast.sh
+++ b/hazelcast/scripts/downloadHazelcast.sh
@@ -1,5 +1,8 @@
 #!/usr/bin/env bash
 
+mkdir tempDownloaded
+cd tempDownloaded
+
 HAZELCAST_REPO="$1"
 HAZELCAST_BRANCH="$2"
 # finds downloaded-file-name by extracting string after rightmost slash.(e.g. extracted name from `fix/3.8/abc` will be `abc`)
@@ -19,4 +22,4 @@ echo "HAZELCAST_BRANCH: $HAZELCAST_BRANCH" >> download.info
 echo "DOWNLOADED_HAZELCAST_BRANCH: $DOWNLOADED_HAZELCAST_BRANCH" >> download.info
 echo "COPY_HAZELCAST_BRANCH: $DOWNLOADED_HAZELCAST_BRANCH" >> download.info
 
-cp -R ./hazelcast-${COPY_HAZELCAST_BRANCH}/hazelcast/src/main ../hazelcast/downloaded/
+cp -R ./hazelcast-${COPY_HAZELCAST_BRANCH}/hazelcast/src/main ../../hazelcast/downloaded/

--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,8 @@
                 <executions>
                     <execution>
                         <id>attach-sources</id>
+                        <!-- see http://blog.peterlynch.ca/2010/05/maven-how-to-prevent-generate-sources.html -->
+                        <phase>DISABLE_FORKED_LIFECYCLE_MSOURCES-13</phase>
                         <goals>
                             <goal>jar</goal>
                         </goals>


### PR DESCRIPTION
Clean was searching for a specific name and causing leftovers when
branch has changed. It will be downloaded to tempDownloaded directory
and all directory will be removed.

Download was working twice when mvn install is called. It is fixed
with <phase>DISABLE_FORKED_LIFECYCLE_MSOURCES-13</phase>