### PR TITLE
Hazelcast 4.x + added executorClassName to addReliableTopicConfig

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/DynamicConfigTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/DynamicConfigTemplate.java
@@ -373,10 +373,13 @@ public interface DynamicConfigTemplate {
      *                              {@code DISCARD_NEWEST}, {@code BLOCK} and {@code ERROR}.
      * @param executor              a serialized {@link java.util.concurrent.Executor} instance to use for executing
      *                              message listeners or {@code null}
+     * @param executorClassName     the class name of a {@link java.util.concurrent.Executor} implementation to use
+     *                              for executing message listeners or {@code null}
      */
     @Request(id = 15, retryable = false, response = ResponseMessageConst.VOID)
     void addReliableTopicConfig(String name, @Nullable List<ListenerConfigHolder> listenerConfigs, int readBatchSize,
-                                boolean statisticsEnabled, String topicOverloadPolicy, @Nullable Data executor);
+                                boolean statisticsEnabled, String topicOverloadPolicy, @Nullable Data executor,
+                                @Since("1.8") @Nullable String executorClassName);
 
     /**
      * Adds a new cache configuration to a running cluster.

--- a/pom.xml
+++ b/pom.xml
@@ -60,14 +60,14 @@
 
     <properties>
         <!-- Hazelcast branch to download and compile with -->
-        <hazelcast.git.repo>vbekiaris</hazelcast.git.repo>
-        <hazelcast.git.branch>fixes/3.12/connmgr-client</hazelcast.git.branch>
+        <hazelcast.git.repo>vojtechtoman</hazelcast.git.repo>
+        <hazelcast.git.branch>569-reliabletopic-executor</hazelcast.git.branch>
 
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.basedir}</main.basedir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-        <jdk.version>1.6</jdk.version>
+        <jdk.version>8</jdk.version>
         <target.dir>target</target.dir>
         <maven.build.timestamp.format>yyyyMMdd</maven.build.timestamp.format>
         <timestamp>${maven.build.timestamp}</timestamp>
@@ -110,6 +110,7 @@
         <powermock.version>1.6.3</powermock.version>
 
         <spotbugs.version>3.1.2</spotbugs.version>
+        <snakeyaml.engine.version>1.0</snakeyaml.engine.version>
 
         <sonar.jacoco.jar>${basedir}/lib/jacocoagent.jar</sonar.jacoco.jar>
         <!--<sonar.phase>post-integration-test</sonar.phase>-->
@@ -380,6 +381,13 @@
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-core</artifactId>
             <version>2.9.7</version>
+            <scope>provided</scope>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
+            <groupId>org.snakeyaml</groupId>
+            <artifactId>snakeyaml-engine</artifactId>
+            <version>${snakeyaml.engine.version}</version>
             <scope>provided</scope>
             <optional>true</optional>
         </dependency>


### PR DESCRIPTION
To support Hazelcast 4.x, increased the JDK version to 8
and added SnakeYAML as a dependency.

Added new "executorClassName" parameter to addReliableTopicConfig().

Part of https://github.com/hazelcast/hazelcast-enterprise/issues/569