### PR TITLE
Change XATransactionalCodecTemplate.collectTransactions to return Xid list instead of List of Data

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/constants/ResponseMessageConst.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/constants/ResponseMessageConst.java
@@ -61,6 +61,7 @@ public final class ResponseMessageConst {
     public static final int RAFT_SESSION_RESPONSE = 130;
     public static final int CLUSTER_METADATA = 131;
     public static final int LIST_LONG = 132;
+    public static final int LIST_XID = 133;
 
     private ResponseMessageConst() {
     }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ResponseTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ResponseTemplate.java
@@ -30,6 +30,7 @@ import com.hazelcast.nio.Address;
 import com.hazelcast.nio.serialization.Data;
 import com.hazelcast.scheduledexecutor.ScheduledTaskHandler;
 
+import javax.transaction.xa.Xid;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -306,5 +307,11 @@ public interface ResponseTemplate {
     @Response(ResponseMessageConst.CLUSTER_METADATA)
     void ClusterMetadata(String name, String version, long clusterTime, int state);
 
+    /**
+     * @param response  The operation result as an array of Xid's
+     */
+    @Since("1.8")
+    @Response(ResponseMessageConst.LIST_XID)
+    void ListXid(List<Xid> response);
 
 }

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/XATransactionalCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/XATransactionalCodecTemplate.java
@@ -34,7 +34,7 @@ public interface XATransactionalCodecTemplate {
     /**
      * @return Array of Xids.
      */
-    @Request(id = 2, retryable = false, response = ResponseMessageConst.LIST_DATA)
+    @Request(id = 2, retryable = false, response = ResponseMessageConst.LIST_XID)
     Object collectTransactions();
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
     <properties>
         <!-- Hazelcast branch to download and compile with -->
         <hazelcast.git.repo>ihsandemir</hazelcast.git.repo>
-        <hazelcast.git.branch>xidCodecChanges</hazelcast.git.branch>
+        <hazelcast.git.branch>removePartitionIdFix</hazelcast.git.branch>
 
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.basedir}</main.basedir>

--- a/pom.xml
+++ b/pom.xml
@@ -60,8 +60,8 @@
 
     <properties>
         <!-- Hazelcast branch to download and compile with -->
-        <hazelcast.git.repo>mdogan</hazelcast.git.repo>
-        <hazelcast.git.branch>remove-core-member</hazelcast.git.branch>
+        <hazelcast.git.repo>ihsandemir</hazelcast.git.repo>
+        <hazelcast.git.branch>xidCodecChanges</hazelcast.git.branch>
 
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.basedir}</main.basedir>


### PR DESCRIPTION
Changed XATransactionalCodecTemplate.collectTransactions to return Xid list instead of List of Data. This is needed for compatibility if Xid is extended later on.