### PR TITLE
Remove partitionId from codec templates where the partition id is not needed ın parameters

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/CacheCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/CacheCodecTemplate.java
@@ -200,13 +200,12 @@ public interface CacheCodecTemplate {
      * has expired or has been evicted.
      *
      * @param name        Name of the cache.
-     * @param partitionId The partition id which owns this cache store.
      * @param tableIndex  The slot number (or index) to start the iterator
      * @param batch       The number of items to be batched
      * @return last index processed and list of data
      */
     @Request(id = 15, retryable = false, response = ResponseMessageConst.CACHE_KEY_ITERATOR_RESULT, partitionIdentifier = "partitionId")
-    Object iterate(String name, int partitionId, int tableIndex, int batch);
+    Object iterate(String name, int tableIndex, int batch);
 
     /**
      * @param name           Name of the cache.
@@ -364,14 +363,13 @@ public interface CacheCodecTemplate {
      * Fetches specified number of entries from the specified partition starting from specified table index.
      *
      * @param name        Name of the cache.
-     * @param partitionId The partition id which owns this cache store.
      * @param tableIndex  The slot number (or index) to start the iterator
      * @param batch       The number of items to be batched
      * @return last index processed and list of entries
      */
     @Request(id = 29, retryable = true, response = ResponseMessageConst.ENTRIES_WITH_CURSOR, partitionIdentifier = "partitionId")
     @Since("1.1")
-    Object iterateEntries(String name, int partitionId, int tableIndex, int batch);
+    Object iterateEntries(String name, int tableIndex, int batch);
 
     /**
      * Adds listener to cache. This listener will be used to listen near cache invalidation events.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ExecutorServiceCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ExecutorServiceCodecTemplate.java
@@ -45,12 +45,11 @@ public interface ExecutorServiceCodecTemplate {
 
     /**
      * @param uuid        Unique id for the execution.
-     * @param partitionId The id of the partition to execute this cancellation request.
      * @param interrupt   If true, then the thread interrupt call can be used to cancel the thread, otherwise interrupt can not be used.
      * @return True if cancelled successfully, false otherwise.
      */
     @Request(id = 3, retryable = false, response = ResponseMessageConst.BOOLEAN, partitionIdentifier = "partitionId")
-    Object cancelOnPartition(String uuid, int partitionId, boolean interrupt);
+    Object cancelOnPartition(String uuid, boolean interrupt);
 
     /**
      * @param uuid      Unique id for the execution.

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/MapCodecTemplate.java
@@ -730,27 +730,25 @@ public interface MapCodecTemplate {
      * Fetches specified number of keys from the specified partition starting from specified table index.
      *
      * @param name        Name of the map.
-     * @param partitionId The partition id which owns this record store.
      * @param tableIndex  The slot number (or index) to start the iterator
      * @param batch       The number of items to be batched
      * @return last index processed and list of keys
      */
     @Request(id = 60, retryable = true, response = ResponseMessageConst.CACHE_KEY_ITERATOR_RESULT, partitionIdentifier = "partitionId")
     @Since("1.1")
-    Object fetchKeys(String name, int partitionId, int tableIndex, int batch);
+    Object fetchKeys(String name, int tableIndex, int batch);
 
     /**
      * Fetches specified number of entries from the specified partition starting from specified table index.
      *
      * @param name        Name of the map.
-     * @param partitionId The partition id which owns this record store.
      * @param tableIndex  The slot number (or index) to start the iterator
      * @param batch       The number of items to be batched
      * @return last index processed and list of entries
      */
     @Request(id = 61, retryable = true, response = ResponseMessageConst.ENTRIES_WITH_CURSOR, partitionIdentifier = "partitionId")
     @Since("1.1")
-    Object fetchEntries(String name, int partitionId, int tableIndex, int batch);
+    Object fetchEntries(String name, int tableIndex, int batch);
 
     /**
      * Applies the aggregation logic on all map entries and returns the result

--- a/pom.xml
+++ b/pom.xml
@@ -60,8 +60,8 @@
 
     <properties>
         <!-- Hazelcast branch to download and compile with -->
-        <hazelcast.git.repo>mdogan</hazelcast.git.repo>
-        <hazelcast.git.branch>remove-core-member</hazelcast.git.branch>
+        <hazelcast.git.repo>ihsandemir</hazelcast.git.repo>
+        <hazelcast.git.branch>removePartitionIdFix</hazelcast.git.branch>
 
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.basedir}</main.basedir>


### PR DESCRIPTION
Removed partitionId from codec templates where the partition id is not needed in the codec parameters since it is already encoded in the ClientMessage itself.