### PR TITLE
Move merkle tree and event journal config inside map and cache config

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/EventJournalConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/EventJournalConfigCodec.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.codec;
+
+import com.hazelcast.annotation.Codec;
+import com.hazelcast.annotation.Since;
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.config.EventJournalConfig;
+import com.hazelcast.nio.Bits;
+
+@Codec(EventJournalConfig.class)
+@Since("2.0")
+public final class EventJournalConfigCodec {
+
+    private EventJournalConfigCodec() {
+    }
+
+    public static EventJournalConfig decode(ClientMessage clientMessage) {
+        boolean enabled = clientMessage.getBoolean();
+        int capacity = clientMessage.getInt();
+        int ttl = clientMessage.getInt();
+        EventJournalConfig config = new EventJournalConfig();
+        config.setEnabled(enabled);
+        config.setCapacity(capacity);
+        config.setTimeToLiveSeconds(ttl);
+        return config;
+    }
+
+    public static void encode(EventJournalConfig config, ClientMessage clientMessage) {
+        clientMessage.set(config.isEnabled())
+                     .set(config.getCapacity())
+                     .set(config.getTimeToLiveSeconds());
+    }
+
+    public static int calculateDataSize(EventJournalConfig config) {
+        return Bits.BOOLEAN_SIZE_IN_BYTES + 2 * Bits.INT_SIZE_IN_BYTES;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MerkleTreeConfigCodec.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/codec/MerkleTreeConfigCodec.java
@@ -1,0 +1,50 @@
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.hazelcast.client.impl.protocol.codec;
+
+import com.hazelcast.annotation.Codec;
+import com.hazelcast.annotation.Since;
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.config.HotRestartConfig;
+import com.hazelcast.config.MerkleTreeConfig;
+import com.hazelcast.nio.Bits;
+
+@Codec(MerkleTreeConfig.class)
+@Since("2.0")
+public final class MerkleTreeConfigCodec {
+
+    private MerkleTreeConfigCodec() {
+    }
+
+    public static MerkleTreeConfig decode(ClientMessage clientMessage) {
+        boolean enabled = clientMessage.getBoolean();
+        int depth = clientMessage.getInt();
+        MerkleTreeConfig config = new MerkleTreeConfig();
+        config.setEnabled(enabled);
+        config.setDepth(depth);
+        return config;
+    }
+
+    public static void encode(MerkleTreeConfig config, ClientMessage clientMessage) {
+        clientMessage.set(config.isEnabled())
+                     .set(config.getDepth());
+    }
+
+    public static int calculateDataSize(MerkleTreeConfig config) {
+        return Bits.BOOLEAN_SIZE_IN_BYTES + Bits.INT_SIZE_IN_BYTES;
+    }
+}

--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/DynamicConfigTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/DynamicConfigTemplate.java
@@ -30,9 +30,11 @@ import com.hazelcast.client.impl.protocol.task.dynamicconfig.QueueStoreConfigHol
 import com.hazelcast.client.impl.protocol.task.dynamicconfig.RingbufferStoreConfigHolder;
 import com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.TimedExpiryPolicyFactoryConfig;
 import com.hazelcast.config.CacheSimpleEntryListenerConfig;
+import com.hazelcast.config.EventJournalConfig;
 import com.hazelcast.config.HotRestartConfig;
 import com.hazelcast.config.MapAttributeConfig;
 import com.hazelcast.config.MapIndexConfig;
+import com.hazelcast.config.MerkleTreeConfig;
 import com.hazelcast.config.WanReplicationRef;
 import com.hazelcast.nio.serialization.Data;
 
@@ -357,6 +359,8 @@ public interface DynamicConfigTemplate {
                       @Nullable String partitioningStrategyClassName,
                       @Nullable Data partitioningStrategyImplementation,
                       @Nullable HotRestartConfig hotRestartConfig,
+                      @Nullable EventJournalConfig eventJournalConfig,
+                      @Nullable MerkleTreeConfig merkleTreeConfig,
                       @Since("1.6") int mergeBatchSize,
                       @Since("1.8") int metadataPolicy);
 
@@ -428,23 +432,8 @@ public interface DynamicConfigTemplate {
                         @Nullable List<CacheSimpleEntryListenerConfig> cacheEntryListeners,
                         @Nullable EvictionConfigHolder evictionConfig,
                         @Nullable WanReplicationRef wanReplicationRef,
+                        @Nullable EventJournalConfig eventJournalConfig,
                         @Nullable HotRestartConfig hotRestartConfig);
-
-    /**
-     * Adds a new event journal configuration to a running cluster.
-     * If an event journal configuration for the same map or cache name already exists, then
-     * the new configuration is ignored and the existing one is preserved.
-     *
-     * @param mapName           name of {@code IMap} to use as event source
-     * @param cacheName         name of {@code ICache} to use as event source
-     * @param enabled           {@code true} to enable this event journal configuration, otherwise {@code false}
-     * @param capacity          capacity of event journal
-     * @param timeToLiveSeconds time to live (in seconds). This is the time the event journal retains items before removing them
-     *                          from the journal.
-     */
-    @Request(id = 17, retryable = false, response = ResponseMessageConst.VOID)
-    void addEventJournalConfig(@Nullable String mapName, @Nullable String cacheName, boolean enabled, int capacity,
-                               int timeToLiveSeconds);
 
     /**
      * Adds a new flake ID generator configuration to a running cluster.
@@ -518,22 +507,4 @@ public interface DynamicConfigTemplate {
     @Request(id = 22, retryable = false, response = ResponseMessageConst.VOID)
     @Since("1.6")
     void addPNCounterConfig(String name, int replicaCount, boolean statisticsEnabled, @Nullable String quorumName);
-
-
-    /**
-     * Adds a new merkle tree configuration to a running cluster.
-     * If a merkle tree configuration with the given {@code name} already exists, then
-     * the new configuration is ignored and the existing one is preserved.
-     *
-     * @param mapName map name to which this config applies. Map names
-     *                are also matched by pattern and a merkle with map name "default"
-     *                applies to all maps that do not have more specific merkle tree configs.
-     * @param enabled {@code true} to enable this merkle tree configuration, otherwise {@code false}
-     * @param depth   depth of the merkle tree. The depth must be between
-     *                {@value com.hazelcast.config.MerkleTreeConfig#MIN_DEPTH}
-     *                and {@value com.hazelcast.config.MerkleTreeConfig#MAX_DEPTH} (exclusive).
-     */
-    @Request(id = 23, retryable = false, response = ResponseMessageConst.VOID)
-    @Since("1.7")
-    void addMerkleTreeConfig(String mapName, boolean enabled, int depth);
 }

--- a/pom.xml
+++ b/pom.xml
@@ -60,8 +60,8 @@
 
     <properties>
         <!-- Hazelcast branch to download and compile with -->
-        <hazelcast.git.repo>ihsandemir</hazelcast.git.repo>
-        <hazelcast.git.branch>memberAttributeEventMembersRemoval</hazelcast.git.branch>
+        <hazelcast.git.repo>mmedenjak</hazelcast.git.repo>
+        <hazelcast.git.branch>4.0-event-journal-config</hazelcast.git.branch>
 
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.basedir}</main.basedir>


### PR DESCRIPTION
In 4.0 we move the EventJournalConfig and MerkleTreeConfig inside
MapConfig and CacheConfig. Up until 4.0 there were top-level
configurations because CacheConfig was a BinaryInterface.

Also, because they are part of MapConfig and CacheConfig, they will no
longer have the mapName and cacheName fields.

Depends on: 
https://github.com/hazelcast/hazelcast/pull/15185
https://github.com/hazelcast/hazelcast/pull/15226