### PR TITLE
Remove partitionId from executor.SubmitToPartition

### DIFF
--- a/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ExecutorServiceCodecTemplate.java
+++ b/hazelcast/src/main/java/com/hazelcast/client/impl/protocol/template/ExecutorServiceCodecTemplate.java
@@ -64,11 +64,10 @@ public interface ExecutorServiceCodecTemplate {
      * @param name        Name of the executor.
      * @param uuid        Unique id for the execution.
      * @param callable    The callable object to be executed.
-     * @param partitionId The id of the partition which the callable shall be executed on.
      * @return The result of the callable execution.
      */
     @Request(id = 5, retryable = false, response = ResponseMessageConst.DATA, partitionIdentifier = "partitionId")
-    Object submitToPartition(String name, String uuid, Data callable, int partitionId);
+    Object submitToPartition(String name, String uuid, Data callable);
 
     /**
      * @param name     Name of the executor.

--- a/pom.xml
+++ b/pom.xml
@@ -60,8 +60,8 @@
 
     <properties>
         <!-- Hazelcast branch to download and compile with -->
-        <hazelcast.git.repo>ihsandemir</hazelcast.git.repo>
-        <hazelcast.git.branch>memberAttributeEventMembersRemoval</hazelcast.git.branch>
+        <hazelcast.git.repo>sancar</hazelcast.git.repo>
+        <hazelcast.git.branch>cleanup/clientExecutorPartitionId/master</hazelcast.git.branch>
 
         <!-- needed for checkstyle/findbugs -->
         <main.basedir>${project.basedir}</main.basedir>


### PR DESCRIPTION
Partition id's already available on client message.
Requests should not carry a second partition id as parameter