### PR TITLE
Change protocol definitions to be compatible with the new id mechanism

### DIFF
--- a/java/codec-template.java.j2
+++ b/java/codec-template.java.j2
@@ -59,10 +59,8 @@ import com.hazelcast.logging.Logger;
 {% endfor %}
  */
 public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
-    //hex: {{ '0x%04X'|format(method.request.id) }}
-    public static final int REQUEST_MESSAGE_TYPE = {{ method.request.id }};
-    //hex: {{ '0x%04X'|format(method.response.id) }}
-    public static final int RESPONSE_MESSAGE_TYPE = {{ method.response.id }};
+    public static final int REQUEST_MESSAGE_TYPE = {{ '%s00'|format(method_id) }};
+    public static final int RESPONSE_MESSAGE_TYPE = {{ '%s01'|format(method_id) }};
 {#FIXED SIZED PARAMETER OFFSET CONSTANTS#}
 {% for param in fixed_params(method.request.params) %}
     private static final int REQUEST_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET = {% if loop.first %}PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES{% else %}REQUEST_{{ to_upper_snake_case(loop.previtem.name)}}_FIELD_OFFSET + {{loop.previtem.type.upper()}}_SIZE_IN_BYTES{% endif %};
@@ -89,8 +87,7 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
     {% else %}
     private static final int EVENT_{{ to_upper_snake_case(event.name)}}_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     {% endfor %}
-    //hex: {{ '0x%04X'|format(event.id) }}
-    private static final int EVENT_{{ to_upper_snake_case(event.name)}}_MESSAGE_TYPE = {{ event.id }};
+    private static final int EVENT_{{ to_upper_snake_case(event.name)}}_MESSAGE_TYPE = {{ '%s%02x'|format(method_id, 1 + loop.index) }};
 {% endfor %}
 
     private {{ service_name|capital }}{{ method.name|capital }}Codec() {

--- a/java/codec-template.java.j2
+++ b/java/codec-template.java.j2
@@ -59,8 +59,8 @@ import com.hazelcast.logging.Logger;
 {% endfor %}
  */
 public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
-    public static final int REQUEST_MESSAGE_TYPE = {{ '%s00'|format(method_id) }};
-    public static final int RESPONSE_MESSAGE_TYPE = {{ '%s01'|format(method_id) }};
+    public static final int REQUEST_MESSAGE_TYPE = {{ method.request.id }};
+    public static final int RESPONSE_MESSAGE_TYPE = {{ method.response.id }};
 {#FIXED SIZED PARAMETER OFFSET CONSTANTS#}
 {% for param in fixed_params(method.request.params) %}
     private static final int REQUEST_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET = {% if loop.first %}PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES{% else %}REQUEST_{{ to_upper_snake_case(loop.previtem.name)}}_FIELD_OFFSET + {{loop.previtem.type.upper()}}_SIZE_IN_BYTES{% endif %};
@@ -87,7 +87,7 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
     {% else %}
     private static final int EVENT_{{ to_upper_snake_case(event.name)}}_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     {% endfor %}
-    private static final int EVENT_{{ to_upper_snake_case(event.name)}}_MESSAGE_TYPE = {{ '%s%02x'|format(method_id, 1 + loop.index) }};
+    private static final int EVENT_{{ to_upper_snake_case(event.name)}}_MESSAGE_TYPE = {{ event.id }};
 {% endfor %}
 
     private {{ service_name|capital }}{{ method.name|capital }}Codec() {

--- a/java/codec-template.java.j2
+++ b/java/codec-template.java.j2
@@ -59,7 +59,9 @@ import com.hazelcast.logging.Logger;
 {% endfor %}
  */
 public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
+    //hex: {{ '0x%06X'|format(method.request.id) }}
     public static final int REQUEST_MESSAGE_TYPE = {{ method.request.id }};
+    //hex: {{ '0x%06X'|format(method.response.id) }}
     public static final int RESPONSE_MESSAGE_TYPE = {{ method.response.id }};
 {#FIXED SIZED PARAMETER OFFSET CONSTANTS#}
 {% for param in fixed_params(method.request.params) %}
@@ -87,6 +89,7 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
     {% else %}
     private static final int EVENT_{{ to_upper_snake_case(event.name)}}_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
     {% endfor %}
+    //hex: {{ '0x%06X'|format(event.id) }}
     private static final int EVENT_{{ to_upper_snake_case(event.name)}}_MESSAGE_TYPE = {{ event.id }};
 {% endfor %}
 

--- a/protocol-definitions/AtomicLong.yaml
+++ b/protocol-definitions/AtomicLong.yaml
@@ -1,6 +1,5 @@
 id: 10
 name: AtomicLong
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: apply

--- a/protocol-definitions/AtomicLong.yaml
+++ b/protocol-definitions/AtomicLong.yaml
@@ -6,7 +6,6 @@ methods:
     doc: |
       Applies a function on the value, the actual stored value will not change.
     request:
-      id: 0x0a01
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -24,7 +23,6 @@ methods:
           doc: |
             The function applied to the value, the value is not changed.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -33,11 +31,11 @@ methods:
           doc: |
             The result of the function application.
     since: 2.0
+    id: 1
   - name: alter
     doc: |
       Alters the currently stored value by applying a function on it.
     request:
-      id: 0x0a02
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -54,14 +52,13 @@ methods:
           since: 2.0
           doc: |
             The function applied to the currently stored value.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 2
   - name: alterAndGet
     doc: |
       Alters the currently stored value by applying a function on it and gets the result.
     request:
-      id: 0x0a03
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -79,7 +76,6 @@ methods:
           doc: |
             The function applied to the currently stored value.
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -88,11 +84,11 @@ methods:
           doc: |
             The result of the function application.
     since: 2.0
+    id: 3
   - name: getAndAlter
     doc: |
       Alters the currently stored value by applying a function on it on and gets the old value.
     request:
-      id: 0x0a04
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -110,7 +106,6 @@ methods:
           doc: |
             The function applied to the currently stored value.
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -119,11 +114,11 @@ methods:
           doc: |
             The old value before the function application.
     since: 2.0
+    id: 4
   - name: addAndGet
     doc: |
       Atomically adds the given value to the current value.
     request:
-      id: 0x0a05
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -141,7 +136,6 @@ methods:
           doc: |
             the value to add to the current value
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -150,11 +144,11 @@ methods:
           doc: |
             the updated value, the given value added to the current value
     since: 2.0
+    id: 5
   - name: compareAndSet
     doc: |
       Atomically sets the value to the given updated value only if the current value the expected value.
     request:
-      id: 0x0a06
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -178,7 +172,6 @@ methods:
           doc: |
             the new value
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -188,11 +181,11 @@ methods:
             true if successful; or false if the actual value
             was not equal to the expected value.
     since: 2.0
+    id: 6
   - name: decrementAndGet
     doc: |
       Atomically decrements the current value by one.
     request:
-      id: 0x0a07
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -204,7 +197,6 @@ methods:
           doc: |
             The name of this IAtomicLong instance.
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -213,11 +205,11 @@ methods:
           doc: |
             the updated value, the current value decremented by one
     since: 2.0
+    id: 7
   - name: get
     doc: |
       Gets the current value.
     request:
-      id: 0x0a08
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -229,7 +221,6 @@ methods:
           doc: |
             The name of this IAtomicLong instance.
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -238,11 +229,11 @@ methods:
           doc: |
             the current value
     since: 2.0
+    id: 8
   - name: getAndAdd
     doc: |
       Atomically adds the given value to the current value.
     request:
-      id: 0x0a09
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -260,7 +251,6 @@ methods:
           doc: |
             the value to add to the current value
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -269,11 +259,11 @@ methods:
           doc: |
             the old value before the add
     since: 2.0
+    id: 9
   - name: getAndSet
     doc: |
       Atomically sets the given value and returns the old value.
     request:
-      id: 0x0a0a
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -291,7 +281,6 @@ methods:
           doc: |
             the new value
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -300,11 +289,11 @@ methods:
           doc: |
             the old value
     since: 2.0
+    id: 10
   - name: incrementAndGet
     doc: |
       Atomically increments the current value by one.
     request:
-      id: 0x0a0b
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -316,7 +305,6 @@ methods:
           doc: |
             The name of this IAtomicLong instance.
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -325,11 +313,11 @@ methods:
           doc: |
             The updated value, the current value incremented by one
     since: 2.0
+    id: 11
   - name: getAndIncrement
     doc: |
       Atomically increments the current value by one.
     request:
-      id: 0x0a0c
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -341,7 +329,6 @@ methods:
           doc: |
             The name of this IAtomicLong instance.
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -350,11 +337,11 @@ methods:
           doc: |
             the old value
     since: 2.0
+    id: 12
   - name: set
     doc: |
       Atomically sets the given value.
     request:
-      id: 0x0a0d
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -371,6 +358,6 @@ methods:
           since: 2.0
           doc: |
             The new value
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 13

--- a/protocol-definitions/AtomicLong.yaml
+++ b/protocol-definitions/AtomicLong.yaml
@@ -2,7 +2,9 @@ id: 10
 name: AtomicLong
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: apply
+  - id: 1
+    name: apply
+    since: 2.0
     doc: |
       Applies a function on the value, the actual stored value will not change.
     request:
@@ -30,9 +32,9 @@ methods:
           since: 2.0
           doc: |
             The result of the function application.
+  - id: 2
+    name: alter
     since: 2.0
-    id: 1
-  - name: alter
     doc: |
       Alters the currently stored value by applying a function on it.
     request:
@@ -53,9 +55,9 @@ methods:
           doc: |
             The function applied to the currently stored value.
     response: {}
+  - id: 3
+    name: alterAndGet
     since: 2.0
-    id: 2
-  - name: alterAndGet
     doc: |
       Alters the currently stored value by applying a function on it and gets the result.
     request:
@@ -83,9 +85,9 @@ methods:
           since: 2.0
           doc: |
             The result of the function application.
+  - id: 4
+    name: getAndAlter
     since: 2.0
-    id: 3
-  - name: getAndAlter
     doc: |
       Alters the currently stored value by applying a function on it on and gets the old value.
     request:
@@ -113,9 +115,9 @@ methods:
           since: 2.0
           doc: |
             The old value before the function application.
+  - id: 5
+    name: addAndGet
     since: 2.0
-    id: 4
-  - name: addAndGet
     doc: |
       Atomically adds the given value to the current value.
     request:
@@ -143,9 +145,9 @@ methods:
           since: 2.0
           doc: |
             the updated value, the given value added to the current value
+  - id: 6
+    name: compareAndSet
     since: 2.0
-    id: 5
-  - name: compareAndSet
     doc: |
       Atomically sets the value to the given updated value only if the current value the expected value.
     request:
@@ -180,9 +182,9 @@ methods:
           doc: |
             true if successful; or false if the actual value
             was not equal to the expected value.
+  - id: 7
+    name: decrementAndGet
     since: 2.0
-    id: 6
-  - name: decrementAndGet
     doc: |
       Atomically decrements the current value by one.
     request:
@@ -204,9 +206,9 @@ methods:
           since: 2.0
           doc: |
             the updated value, the current value decremented by one
+  - id: 8
+    name: get
     since: 2.0
-    id: 7
-  - name: get
     doc: |
       Gets the current value.
     request:
@@ -228,9 +230,9 @@ methods:
           since: 2.0
           doc: |
             the current value
+  - id: 9
+    name: getAndAdd
     since: 2.0
-    id: 8
-  - name: getAndAdd
     doc: |
       Atomically adds the given value to the current value.
     request:
@@ -258,9 +260,9 @@ methods:
           since: 2.0
           doc: |
             the old value before the add
+  - id: 10
+    name: getAndSet
     since: 2.0
-    id: 9
-  - name: getAndSet
     doc: |
       Atomically sets the given value and returns the old value.
     request:
@@ -288,9 +290,9 @@ methods:
           since: 2.0
           doc: |
             the old value
+  - id: 11
+    name: incrementAndGet
     since: 2.0
-    id: 10
-  - name: incrementAndGet
     doc: |
       Atomically increments the current value by one.
     request:
@@ -312,9 +314,9 @@ methods:
           since: 2.0
           doc: |
             The updated value, the current value incremented by one
+  - id: 12
+    name: getAndIncrement
     since: 2.0
-    id: 11
-  - name: getAndIncrement
     doc: |
       Atomically increments the current value by one.
     request:
@@ -336,9 +338,9 @@ methods:
           since: 2.0
           doc: |
             the old value
+  - id: 13
+    name: set
     since: 2.0
-    id: 12
-  - name: set
     doc: |
       Atomically sets the given value.
     request:
@@ -359,5 +361,3 @@ methods:
           doc: |
             The new value
     response: {}
-    since: 2.0
-    id: 13

--- a/protocol-definitions/AtomicReference.yaml
+++ b/protocol-definitions/AtomicReference.yaml
@@ -1,6 +1,5 @@
 id: 11
 name: AtomicReference
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: apply

--- a/protocol-definitions/AtomicReference.yaml
+++ b/protocol-definitions/AtomicReference.yaml
@@ -2,7 +2,9 @@ id: 11
 name: AtomicReference
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: apply
+  - id: 1
+    name: apply
+    since: 2.0
     doc: |
       Applies a function on the value, the actual stored value will not change.
     request:
@@ -30,9 +32,9 @@ methods:
           since: 2.0
           doc: |
             the result of the function application
+  - id: 2
+    name: alter
     since: 2.0
-    id: 1
-  - name: alter
     doc: |
       Alters the currently stored reference by applying a function on it.
     request:
@@ -53,9 +55,9 @@ methods:
           doc: |
             the function that alters the currently stored reference
     response: {}
+  - id: 3
+    name: alterAndGet
     since: 2.0
-    id: 2
-  - name: alterAndGet
     doc: |
       Alters the currently stored reference by applying a function on it and gets the result.
     request:
@@ -83,9 +85,9 @@ methods:
           since: 2.0
           doc: |
             the new value, the result of the applied function.
+  - id: 4
+    name: getAndAlter
     since: 2.0
-    id: 3
-  - name: getAndAlter
     doc: |
       Alters the currently stored reference by applying a function on it on and gets the old value.
     request:
@@ -113,9 +115,9 @@ methods:
           since: 2.0
           doc: |
             the old value, the value before the function is applied
+  - id: 5
+    name: contains
     since: 2.0
-    id: 4
-  - name: contains
     doc: |
       Checks if the reference contains the value.
     request:
@@ -143,9 +145,9 @@ methods:
           since: 2.0
           doc: |
             true if the value is found, false otherwise.
+  - id: 6
+    name: compareAndSet
     since: 2.0
-    id: 5
-  - name: compareAndSet
     doc: |
       Atomically sets the value to the given updated value only if the current value the expected value.
     request:
@@ -180,9 +182,9 @@ methods:
           doc: |
             true if successful; or false if the actual value
             was not equal to the expected value.
+  - id: 8
+    name: get
     since: 2.0
-    id: 6
-  - name: get
     doc: |
       Gets the current value.
     request:
@@ -204,9 +206,9 @@ methods:
           since: 2.0
           doc: |
             the current value
+  - id: 9
+    name: set
     since: 2.0
-    id: 8
-  - name: set
     doc: |
       Atomically sets the given value.
     request:
@@ -227,9 +229,9 @@ methods:
           doc: |
             the new value
     response: {}
+  - id: 10
+    name: clear
     since: 2.0
-    id: 9
-  - name: clear
     doc: |
       Clears the current stored reference.
     request:
@@ -244,9 +246,9 @@ methods:
           doc: |
             Name of the AtomicReference distributed object instance.
     response: {}
+  - id: 11
+    name: getAndSet
     since: 2.0
-    id: 10
-  - name: getAndSet
     doc: |
       Gets the old value and sets the new value.
     request:
@@ -274,9 +276,9 @@ methods:
           since: 2.0
           doc: |
             the old value.
+  - id: 12
+    name: setAndGet
     since: 2.0
-    id: 11
-  - name: setAndGet
     doc: |
       Sets and gets the value.
     request:
@@ -304,9 +306,9 @@ methods:
           since: 2.0
           doc: |
             the new value
+  - id: 13
+    name: isNull
     since: 2.0
-    id: 12
-  - name: isNull
     doc: |
       Checks if the stored reference is null.
     request:
@@ -328,5 +330,3 @@ methods:
           since: 2.0
           doc: |
             true if null, false otherwise.
-    since: 2.0
-    id: 13

--- a/protocol-definitions/AtomicReference.yaml
+++ b/protocol-definitions/AtomicReference.yaml
@@ -6,7 +6,6 @@ methods:
     doc: |
       Applies a function on the value, the actual stored value will not change.
     request:
-      id: 0x0b01
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -24,7 +23,6 @@ methods:
           doc: |
             the function applied on the value, the stored value does not change
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -33,11 +31,11 @@ methods:
           doc: |
             the result of the function application
     since: 2.0
+    id: 1
   - name: alter
     doc: |
       Alters the currently stored reference by applying a function on it.
     request:
-      id: 0x0b02
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -54,14 +52,13 @@ methods:
           since: 2.0
           doc: |
             the function that alters the currently stored reference
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 2
   - name: alterAndGet
     doc: |
       Alters the currently stored reference by applying a function on it and gets the result.
     request:
-      id: 0x0b03
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -79,7 +76,6 @@ methods:
           doc: |
             the function that alters the currently stored reference
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -88,11 +84,11 @@ methods:
           doc: |
             the new value, the result of the applied function.
     since: 2.0
+    id: 3
   - name: getAndAlter
     doc: |
       Alters the currently stored reference by applying a function on it on and gets the old value.
     request:
-      id: 0x0b04
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -110,7 +106,6 @@ methods:
           doc: |
             the function that alters the currently stored reference
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -119,11 +114,11 @@ methods:
           doc: |
             the old value, the value before the function is applied
     since: 2.0
+    id: 4
   - name: contains
     doc: |
       Checks if the reference contains the value.
     request:
-      id: 0x0b05
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -141,7 +136,6 @@ methods:
           doc: |
             the value to check (is allowed to be null).
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -150,11 +144,11 @@ methods:
           doc: |
             true if the value is found, false otherwise.
     since: 2.0
+    id: 5
   - name: compareAndSet
     doc: |
       Atomically sets the value to the given updated value only if the current value the expected value.
     request:
-      id: 0x0b06
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -178,7 +172,6 @@ methods:
           doc: |
             the new value
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -188,11 +181,11 @@ methods:
             true if successful; or false if the actual value
             was not equal to the expected value.
     since: 2.0
+    id: 6
   - name: get
     doc: |
       Gets the current value.
     request:
-      id: 0x0b08
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -204,7 +197,6 @@ methods:
           doc: |
             Name of the AtomicReference distributed object instance.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -213,11 +205,11 @@ methods:
           doc: |
             the current value
     since: 2.0
+    id: 8
   - name: set
     doc: |
       Atomically sets the given value.
     request:
-      id: 0x0b09
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -234,14 +226,13 @@ methods:
           since: 2.0
           doc: |
             the new value
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 9
   - name: clear
     doc: |
       Clears the current stored reference.
     request:
-      id: 0x0b0a
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -252,14 +243,13 @@ methods:
           since: 2.0
           doc: |
             Name of the AtomicReference distributed object instance.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 10
   - name: getAndSet
     doc: |
       Gets the old value and sets the new value.
     request:
-      id: 0x0b0b
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -277,7 +267,6 @@ methods:
           doc: |
             the new value.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -286,11 +275,11 @@ methods:
           doc: |
             the old value.
     since: 2.0
+    id: 11
   - name: setAndGet
     doc: |
       Sets and gets the value.
     request:
-      id: 0x0b0c
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -308,7 +297,6 @@ methods:
           doc: |
             the new value
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -317,11 +305,11 @@ methods:
           doc: |
             the new value
     since: 2.0
+    id: 12
   - name: isNull
     doc: |
       Checks if the stored reference is null.
     request:
-      id: 0x0b0d
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -333,7 +321,6 @@ methods:
           doc: |
             Name of the AtomicReference distributed object instance.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -342,3 +329,4 @@ methods:
           doc: |
             true if null, false otherwise.
     since: 2.0
+    id: 13

--- a/protocol-definitions/CPAtomicLong.yaml
+++ b/protocol-definitions/CPAtomicLong.yaml
@@ -2,7 +2,9 @@ id: 35
 name: CPAtomicLong
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: apply
+  - id: 1
+    name: apply
+    since: 2.0
     doc: |
       Applies a function on the value, the actual stored value will not change
     request:
@@ -37,9 +39,9 @@ methods:
           since: 2.0
           doc: |
             The result of the function application.
+  - id: 2
+    name: alter
     since: 2.0
-    id: 1
-  - name: alter
     doc: |
       Alters the currently stored value by applying a function on it.
     request:
@@ -79,9 +81,9 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
+  - id: 3
+    name: addAndGet
     since: 2.0
-    id: 2
-  - name: addAndGet
     doc: |
       Atomically adds the given value to the current value.
     request:
@@ -115,9 +117,9 @@ methods:
           since: 2.0
           doc: |
             the updated value, the given value added to the current value
+  - id: 4
+    name: compareAndSet
     since: 2.0
-    id: 3
-  - name: compareAndSet
     doc: |
       Atomically sets the value to the given updated value only if the current
       value the expected value.
@@ -159,9 +161,9 @@ methods:
           doc: |
             true if successful; or false if the actual value
             was not equal to the expected value.
+  - id: 5
+    name: get
     since: 2.0
-    id: 4
-  - name: get
     doc: |
       Gets the current value.
     request:
@@ -189,9 +191,9 @@ methods:
           since: 2.0
           doc: |
             The current value
+  - id: 6
+    name: getAndAdd
     since: 2.0
-    id: 5
-  - name: getAndAdd
     doc: |
       Atomically adds the given value to the current value.
     request:
@@ -225,9 +227,9 @@ methods:
           since: 2.0
           doc: |
             the old value before the add
+  - id: 7
+    name: getAndSet
     since: 2.0
-    id: 6
-  - name: getAndSet
     doc: |
       Atomically sets the given value and returns the old value.
     request:
@@ -261,5 +263,3 @@ methods:
           since: 2.0
           doc: |
             the old value
-    since: 2.0
-    id: 7

--- a/protocol-definitions/CPAtomicLong.yaml
+++ b/protocol-definitions/CPAtomicLong.yaml
@@ -1,6 +1,5 @@
 id: 35
 name: CPAtomicLong
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: apply

--- a/protocol-definitions/CPAtomicLong.yaml
+++ b/protocol-definitions/CPAtomicLong.yaml
@@ -6,7 +6,6 @@ methods:
     doc: |
       Applies a function on the value, the actual stored value will not change
     request:
-      id: 0x2301
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -31,7 +30,6 @@ methods:
             The function applied to the value and the value is not
             changed.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -40,11 +38,11 @@ methods:
           doc: |
             The result of the function application.
     since: 2.0
+    id: 1
   - name: alter
     doc: |
       Alters the currently stored value by applying a function on it.
     request:
-      id: 0x2302
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -74,7 +72,6 @@ methods:
           doc: |
             0 returns the old value, 1 returns the new value
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -83,11 +80,11 @@ methods:
           doc: |
             TODO DOC
     since: 2.0
+    id: 2
   - name: addAndGet
     doc: |
       Atomically adds the given value to the current value.
     request:
-      id: 0x2303
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -111,7 +108,6 @@ methods:
           doc: |
             The value to add to the current value
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -120,12 +116,12 @@ methods:
           doc: |
             the updated value, the given value added to the current value
     since: 2.0
+    id: 3
   - name: compareAndSet
     doc: |
       Atomically sets the value to the given updated value only if the current
       value the expected value.
     request:
-      id: 0x2304
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -155,7 +151,6 @@ methods:
           doc: |
             The new value
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -165,11 +160,11 @@ methods:
             true if successful; or false if the actual value
             was not equal to the expected value.
     since: 2.0
+    id: 4
   - name: get
     doc: |
       Gets the current value.
     request:
-      id: 0x2305
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -187,7 +182,6 @@ methods:
           doc: |
             Name of this IAtomicLong instance.
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -196,11 +190,11 @@ methods:
           doc: |
             The current value
     since: 2.0
+    id: 5
   - name: getAndAdd
     doc: |
       Atomically adds the given value to the current value.
     request:
-      id: 0x2306
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -224,7 +218,6 @@ methods:
           doc: |
             The value to add to the current value
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -233,11 +226,11 @@ methods:
           doc: |
             the old value before the add
     since: 2.0
+    id: 6
   - name: getAndSet
     doc: |
       Atomically sets the given value and returns the old value.
     request:
-      id: 0x2307
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -261,7 +254,6 @@ methods:
           doc: |
             The new value
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -270,3 +262,4 @@ methods:
           doc: |
             the old value
     since: 2.0
+    id: 7

--- a/protocol-definitions/CPAtomicRef.yaml
+++ b/protocol-definitions/CPAtomicRef.yaml
@@ -1,6 +1,5 @@
 id: 36
 name: CPAtomicRef
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: apply

--- a/protocol-definitions/CPAtomicRef.yaml
+++ b/protocol-definitions/CPAtomicRef.yaml
@@ -2,7 +2,9 @@ id: 36
 name: CPAtomicRef
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: apply
+  - id: 1
+    name: apply
+    since: 2.0
     doc: |
       Applies a function on the value
     request:
@@ -50,9 +52,9 @@ methods:
           since: 2.0
           doc: |
             The result of the function application.
+  - id: 2
+    name: compareAndSet
     since: 2.0
-    id: 1
-  - name: compareAndSet
     doc: |
       Alters the currently stored value by applying a function on it.
     request:
@@ -93,9 +95,9 @@ methods:
           doc: |
             true if successful; or false if the actual value
             was not equal to the expected value.
+  - id: 3
+    name: contains
     since: 2.0
-    id: 2
-  - name: contains
     doc: |
       Checks if the reference contains the value.
     request:
@@ -129,9 +131,9 @@ methods:
           since: 2.0
           doc: |
             true if the value is found, false otherwise.
+  - id: 5
+    name: get
     since: 2.0
-    id: 3
-  - name: get
     doc: |
       Gets the current value.
     request:
@@ -159,9 +161,9 @@ methods:
           since: 2.0
           doc: |
             The current value
+  - id: 6
+    name: set
     since: 2.0
-    id: 5
-  - name: set
     doc: |
       Atomically sets the given value
     request:
@@ -202,5 +204,3 @@ methods:
           doc: |
             the old value or null, depending on
             the {
-    since: 2.0
-    id: 6

--- a/protocol-definitions/CPAtomicRef.yaml
+++ b/protocol-definitions/CPAtomicRef.yaml
@@ -6,7 +6,6 @@ methods:
     doc: |
       Applies a function on the value
     request:
-      id: 0x2401
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -44,7 +43,6 @@ methods:
             Denotes whether result of the function will be
             set to the IAtomicRefInstance
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -53,11 +51,11 @@ methods:
           doc: |
             The result of the function application.
     since: 2.0
+    id: 1
   - name: compareAndSet
     doc: |
       Alters the currently stored value by applying a function on it.
     request:
-      id: 0x2402
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -87,7 +85,6 @@ methods:
           doc: |
             The new value
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -97,11 +94,11 @@ methods:
             true if successful; or false if the actual value
             was not equal to the expected value.
     since: 2.0
+    id: 2
   - name: contains
     doc: |
       Checks if the reference contains the value.
     request:
-      id: 0x2403
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -125,7 +122,6 @@ methods:
           doc: |
             The value to check (is allowed to be null).
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -134,11 +130,11 @@ methods:
           doc: |
             true if the value is found, false otherwise.
     since: 2.0
+    id: 3
   - name: get
     doc: |
       Gets the current value.
     request:
-      id: 0x2405
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -156,7 +152,6 @@ methods:
           doc: |
             Name of this IAtomicReference instance.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -165,11 +160,11 @@ methods:
           doc: |
             The current value
     since: 2.0
+    id: 5
   - name: set
     doc: |
       Atomically sets the given value
     request:
-      id: 0x2406
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -199,7 +194,6 @@ methods:
           doc: |
             Denotes whether the old value is returned or not
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -209,3 +203,4 @@ methods:
             the old value or null, depending on
             the {
     since: 2.0
+    id: 6

--- a/protocol-definitions/CPCountDownLatch.yaml
+++ b/protocol-definitions/CPCountDownLatch.yaml
@@ -2,7 +2,9 @@ id: 37
 name: CPCountDownLatch
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: trySetCount
+  - id: 1
+    name: trySetCount
+    since: 2.0
     doc: |
       Sets the count to the given value if the current count is zero.
       If the count is not zero, then this method does nothing
@@ -40,9 +42,9 @@ methods:
           doc: |
             true if the new count was set,
             false if the current count is not zero.
+  - id: 2
+    name: await
     since: 2.0
-    id: 1
-  - name: await
     doc: |
       Causes the current thread to wait until the latch has counted down
       to zero, or an exception is thrown, or the specified waiting time
@@ -98,9 +100,9 @@ methods:
           doc: |
             true if the count reached zero, false if
             the waiting time elapsed before the count reached 0
+  - id: 3
+    name: countDown
     since: 2.0
-    id: 2
-  - name: countDown
     doc: |
       Decrements the count of the latch, releasing all waiting threads if
       the count reaches zero. If the current count is greater than zero, then
@@ -137,9 +139,9 @@ methods:
           doc: |
             The round this invocation will be performed on
     response: {}
+  - id: 4
+    name: getCount
     since: 2.0
-    id: 3
-  - name: getCount
     doc: |
       Returns the current count.
     request:
@@ -167,9 +169,9 @@ methods:
           since: 2.0
           doc: |
             The current count of this CountDownLatch instance
+  - id: 5
+    name: getRound
     since: 2.0
-    id: 4
-  - name: getRound
     doc: |
       Returns the current round. A round completes when the count value
       reaches to 0 and a new round starts afterwards.
@@ -198,5 +200,3 @@ methods:
           since: 2.0
           doc: |
             The current round of this CountDownLatch instance
-    since: 2.0
-    id: 5

--- a/protocol-definitions/CPCountDownLatch.yaml
+++ b/protocol-definitions/CPCountDownLatch.yaml
@@ -1,6 +1,5 @@
 id: 37
 name: CPCountDownLatch
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: trySetCount

--- a/protocol-definitions/CPCountDownLatch.yaml
+++ b/protocol-definitions/CPCountDownLatch.yaml
@@ -8,7 +8,6 @@ methods:
       If the count is not zero, then this method does nothing
       and returns false
     request:
-      id: 0x2501
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -33,7 +32,6 @@ methods:
             The number of times countDown must be invoked before
             threads can pass through await
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -43,6 +41,7 @@ methods:
             true if the new count was set,
             false if the current count is not zero.
     since: 2.0
+    id: 1
   - name: await
     doc: |
       Causes the current thread to wait until the latch has counted down
@@ -62,7 +61,6 @@ methods:
       waiting time elapses then the value false is returned.  If the time is
       less than or equal to zero, the method will not wait at all.
     request:
-      id: 0x2502
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -92,7 +90,6 @@ methods:
           doc: |
             The maximum time in milliseconds to wait
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -102,6 +99,7 @@ methods:
             true if the count reached zero, false if
             the waiting time elapsed before the count reached 0
     since: 2.0
+    id: 2
   - name: countDown
     doc: |
       Decrements the count of the latch, releasing all waiting threads if
@@ -110,7 +108,6 @@ methods:
       re-enabled for thread scheduling purposes, and Countdown owner is set to
       null. If the current count equals zero, then nothing happens.
     request:
-      id: 0x2503
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -139,14 +136,13 @@ methods:
           since: 2.0
           doc: |
             The round this invocation will be performed on
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 3
   - name: getCount
     doc: |
       Returns the current count.
     request:
-      id: 0x2504
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -164,7 +160,6 @@ methods:
           doc: |
             Name of the CountDownLatch instance
     response:
-      id: 0x0066
       params:
         - name: response
           type: int
@@ -173,12 +168,12 @@ methods:
           doc: |
             The current count of this CountDownLatch instance
     since: 2.0
+    id: 4
   - name: getRound
     doc: |
       Returns the current round. A round completes when the count value
       reaches to 0 and a new round starts afterwards.
     request:
-      id: 0x2505
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -196,7 +191,6 @@ methods:
           doc: |
             Name of the CountDownLatch instance
     response:
-      id: 0x0066
       params:
         - name: response
           type: int
@@ -205,3 +199,4 @@ methods:
           doc: |
             The current round of this CountDownLatch instance
     since: 2.0
+    id: 5

--- a/protocol-definitions/CPFencedLock.yaml
+++ b/protocol-definitions/CPFencedLock.yaml
@@ -1,6 +1,5 @@
 id: 38
 name: CPFencedLock
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: lock

--- a/protocol-definitions/CPFencedLock.yaml
+++ b/protocol-definitions/CPFencedLock.yaml
@@ -2,7 +2,9 @@ id: 38
 name: CPFencedLock
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: lock
+  - id: 1
+    name: lock
+    since: 2.0
     doc: |
       Acquires the given FencedLock on the given CP group. If the lock is
       acquired, a valid fencing token (positive number) is returned. If not
@@ -55,9 +57,9 @@ methods:
           doc: |
             a valid fencing token (positive number) if the lock
             is acquired, otherwise -1.
+  - id: 2
+    name: tryLock
     since: 2.0
-    id: 1
-  - name: tryLock
     doc: |
       Attempts to acquire the given FencedLock on the given CP group.
       If the lock is acquired, a valid fencing token (positive number) is
@@ -117,9 +119,9 @@ methods:
           doc: |
             a valid fencing token (positive number) if the lock
             is acquired, otherwise -1.
+  - id: 3
+    name: unlock
     since: 2.0
-    id: 2
-  - name: unlock
     doc: |
       Unlocks the given FencedLock on the given CP group. If the lock is
       not acquired, the call fails with {@link IllegalMonitorStateException}.
@@ -170,9 +172,9 @@ methods:
           doc: |
             true if the lock is still held by the caller after
             a successful unlock() call, false otherwise.
+  - id: 4
+    name: getLockOwnership
     since: 2.0
-    id: 3
-  - name: getLockOwnership
     doc: |
       Returns current lock ownership status of the given FencedLock instance.
     request:
@@ -218,5 +220,3 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
-    since: 2.0
-    id: 4

--- a/protocol-definitions/CPFencedLock.yaml
+++ b/protocol-definitions/CPFencedLock.yaml
@@ -12,7 +12,6 @@ methods:
       is closed between reentrant acquires, the call fails with
       {@code LockOwnershipLostException}.
     request:
-      id: 0x2601
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -48,7 +47,6 @@ methods:
           doc: |
             UID of this invocation
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -58,6 +56,7 @@ methods:
             a valid fencing token (positive number) if the lock
             is acquired, otherwise -1.
     since: 2.0
+    id: 1
   - name: tryLock
     doc: |
       Attempts to acquire the given FencedLock on the given CP group.
@@ -69,7 +68,6 @@ methods:
       duration passes. If the session is closed between reentrant acquires,
       the call fails with {@code LockOwnershipLostException}.
     request:
-      id: 0x2602
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -111,7 +109,6 @@ methods:
           doc: |
             Duration to wait for lock acquire
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -121,6 +118,7 @@ methods:
             a valid fencing token (positive number) if the lock
             is acquired, otherwise -1.
     since: 2.0
+    id: 2
   - name: unlock
     doc: |
       Unlocks the given FencedLock on the given CP group. If the lock is
@@ -129,7 +127,6 @@ methods:
       {@code LockOwnershipLostException}. Returns true if the lock is still
       held by the caller after a successful unlock() call, false otherwise.
     request:
-      id: 0x2603
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -165,7 +162,6 @@ methods:
           doc: |
             UID of this invocation
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -175,11 +171,11 @@ methods:
             true if the lock is still held by the caller after
             a successful unlock() call, false otherwise.
     since: 2.0
+    id: 3
   - name: getLockOwnership
     doc: |
       Returns current lock ownership status of the given FencedLock instance.
     request:
-      id: 0x2604
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -197,7 +193,6 @@ methods:
           doc: |
             Name of this FencedLock instance
     response:
-      id: 0x0081
       params:
         - name: fence
           type: long
@@ -224,3 +219,4 @@ methods:
           doc: |
             TODO DOC
     since: 2.0
+    id: 4

--- a/protocol-definitions/CPGroup.yaml
+++ b/protocol-definitions/CPGroup.yaml
@@ -6,7 +6,6 @@ methods:
     doc: |
       Creates a new CP group with the given name
     request:
-      id: 0x2101
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -18,7 +17,6 @@ methods:
           doc: |
             The proxy name of this data structure instance
     response:
-      id: 0x0080
       params:
         - name: groupId
           type: RaftGroupId
@@ -27,12 +25,12 @@ methods:
           doc: |
             ID of the CP group that contains the CP object
     since: 2.0
+    id: 1
   - name: destroyCPObject
     doc: |
       Destroys the distributed object with the given name on the requested
       CP group
     request:
-      id: 0x2102
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -55,6 +53,6 @@ methods:
           since: 2.0
           doc: |
             The name of this distributed object
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 2

--- a/protocol-definitions/CPGroup.yaml
+++ b/protocol-definitions/CPGroup.yaml
@@ -2,7 +2,9 @@ id: 33
 name: CPGroup
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: createCPGroup
+  - id: 1
+    name: createCPGroup
+    since: 2.0
     doc: |
       Creates a new CP group with the given name
     request:
@@ -24,9 +26,9 @@ methods:
           since: 2.0
           doc: |
             ID of the CP group that contains the CP object
+  - id: 2
+    name: destroyCPObject
     since: 2.0
-    id: 1
-  - name: destroyCPObject
     doc: |
       Destroys the distributed object with the given name on the requested
       CP group
@@ -54,5 +56,3 @@ methods:
           doc: |
             The name of this distributed object
     response: {}
-    since: 2.0
-    id: 2

--- a/protocol-definitions/CPGroup.yaml
+++ b/protocol-definitions/CPGroup.yaml
@@ -1,6 +1,5 @@
 id: 33
 name: CPGroup
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: createCPGroup

--- a/protocol-definitions/CPSemaphore.yaml
+++ b/protocol-definitions/CPSemaphore.yaml
@@ -1,6 +1,5 @@
 id: 39
 name: CPSemaphore
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: init

--- a/protocol-definitions/CPSemaphore.yaml
+++ b/protocol-definitions/CPSemaphore.yaml
@@ -7,7 +7,6 @@ methods:
       Initializes the ISemaphore instance with the given permit number, if not
       initialized before.
     request:
-      id: 0x2701
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -31,7 +30,6 @@ methods:
           doc: |
             Number of permits to initialize this ISemaphore
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -40,6 +38,7 @@ methods:
           doc: |
             true if the ISemaphore is initialized with this call
     since: 2.0
+    id: 1
   - name: acquire
     doc: |
       Acquires the requested amount of permits if available, reducing
@@ -47,7 +46,6 @@ methods:
       then the current thread becomes disabled for thread scheduling purposes
       and lies dormant until other threads release enough permits.
     request:
-      id: 0x2702
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -95,7 +93,6 @@ methods:
           doc: |
             Duration to wait for permit acquire
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -105,12 +102,12 @@ methods:
             true if requested permits are acquired,
             false otherwise
     since: 2.0
+    id: 2
   - name: release
     doc: |
       Releases the given number of permits and increases the number of
       available permits by that amount.
     request:
-      id: 0x2703
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -152,7 +149,6 @@ methods:
           doc: |
             number of permits to release
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -161,11 +157,11 @@ methods:
           doc: |
             true
     since: 2.0
+    id: 3
   - name: drain
     doc: |
       Acquires all available permits at once and returns immediately.
     request:
-      id: 0x2704
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -201,7 +197,6 @@ methods:
           doc: |
             UID of this invocation
     response:
-      id: 0x0066
       params:
         - name: response
           type: int
@@ -210,11 +205,11 @@ methods:
           doc: |
             number of acquired permits
     since: 2.0
+    id: 4
   - name: change
     doc: |
       Increases or decreases the number of permits by the given value.
     request:
-      id: 0x2705
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -256,7 +251,6 @@ methods:
           doc: |
             number of permits to increase / decrease
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -265,11 +259,11 @@ methods:
           doc: |
             true
     since: 2.0
+    id: 5
   - name: availablePermits
     doc: |
       Returns the number of available permits.
     request:
-      id: 0x2706
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -287,7 +281,6 @@ methods:
           doc: |
             Name of this ISemaphore instance
     response:
-      id: 0x0066
       params:
         - name: response
           type: int
@@ -296,11 +289,11 @@ methods:
           doc: |
             number of available permits
     since: 2.0
+    id: 6
   - name: getSemaphoreType
     doc: |
       Returns true if the semaphore is JDK compatible
     request:
-      id: 0x2707
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -312,7 +305,6 @@ methods:
           doc: |
             Name of the ISemaphore proxy
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -321,3 +313,4 @@ methods:
           doc: |
             true if the semaphore is JDK compatible
     since: 2.0
+    id: 7

--- a/protocol-definitions/CPSemaphore.yaml
+++ b/protocol-definitions/CPSemaphore.yaml
@@ -2,7 +2,9 @@ id: 39
 name: CPSemaphore
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: init
+  - id: 1
+    name: init
+    since: 2.0
     doc: |
       Initializes the ISemaphore instance with the given permit number, if not
       initialized before.
@@ -37,9 +39,9 @@ methods:
           since: 2.0
           doc: |
             true if the ISemaphore is initialized with this call
+  - id: 2
+    name: acquire
     since: 2.0
-    id: 1
-  - name: acquire
     doc: |
       Acquires the requested amount of permits if available, reducing
       the number of available permits. If no enough permits are available,
@@ -101,9 +103,9 @@ methods:
           doc: |
             true if requested permits are acquired,
             false otherwise
+  - id: 3
+    name: release
     since: 2.0
-    id: 2
-  - name: release
     doc: |
       Releases the given number of permits and increases the number of
       available permits by that amount.
@@ -156,9 +158,9 @@ methods:
           since: 2.0
           doc: |
             true
+  - id: 4
+    name: drain
     since: 2.0
-    id: 3
-  - name: drain
     doc: |
       Acquires all available permits at once and returns immediately.
     request:
@@ -204,9 +206,9 @@ methods:
           since: 2.0
           doc: |
             number of acquired permits
+  - id: 5
+    name: change
     since: 2.0
-    id: 4
-  - name: change
     doc: |
       Increases or decreases the number of permits by the given value.
     request:
@@ -258,9 +260,9 @@ methods:
           since: 2.0
           doc: |
             true
+  - id: 6
+    name: availablePermits
     since: 2.0
-    id: 5
-  - name: availablePermits
     doc: |
       Returns the number of available permits.
     request:
@@ -288,9 +290,9 @@ methods:
           since: 2.0
           doc: |
             number of available permits
+  - id: 7
+    name: getSemaphoreType
     since: 2.0
-    id: 6
-  - name: getSemaphoreType
     doc: |
       Returns true if the semaphore is JDK compatible
     request:
@@ -312,5 +314,3 @@ methods:
           since: 2.0
           doc: |
             true if the semaphore is JDK compatible
-    since: 2.0
-    id: 7

--- a/protocol-definitions/CPSession.yaml
+++ b/protocol-definitions/CPSession.yaml
@@ -2,7 +2,9 @@ id: 34
 name: CPSession
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: createSession
+  - id: 1
+    name: createSession
+    since: 2.0
     doc: |
       Creates a session for the caller on the given CP group.
     request:
@@ -42,9 +44,9 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
+  - id: 2
+    name: closeSession
     since: 2.0
-    id: 1
-  - name: closeSession
     doc: |
       Closes the given session on the given CP group
     request:
@@ -73,9 +75,9 @@ methods:
           doc: |
             true if the session is found & closed,
             false otherwise.
+  - id: 3
+    name: heartbeatSession
     since: 2.0
-    id: 2
-  - name: heartbeatSession
     doc: |
       Commits a heartbeat for the given session on the given cP group and
       extends its session expiration time.
@@ -97,9 +99,9 @@ methods:
           doc: |
             ID of the session
     response: {}
+  - id: 4
+    name: generateThreadId
     since: 2.0
-    id: 3
-  - name: generateThreadId
     doc: |
       Generates a new ID for the caller thread. The ID is unique in the given
       CP group.
@@ -122,5 +124,3 @@ methods:
           since: 2.0
           doc: |
             A unique ID for the caller thread
-    since: 2.0
-    id: 4

--- a/protocol-definitions/CPSession.yaml
+++ b/protocol-definitions/CPSession.yaml
@@ -6,7 +6,6 @@ methods:
     doc: |
       Creates a session for the caller on the given CP group.
     request:
-      id: 0x2201
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -24,7 +23,6 @@ methods:
           doc: |
             Name of the caller HazelcastInstance
     response:
-      id: 0x0082
       params:
         - name: sessionId
           type: long
@@ -45,11 +43,11 @@ methods:
           doc: |
             TODO DOC
     since: 2.0
+    id: 1
   - name: closeSession
     doc: |
       Closes the given session on the given CP group
     request:
-      id: 0x2202
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -67,7 +65,6 @@ methods:
           doc: |
             ID of the session
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -77,12 +74,12 @@ methods:
             true if the session is found & closed,
             false otherwise.
     since: 2.0
+    id: 2
   - name: heartbeatSession
     doc: |
       Commits a heartbeat for the given session on the given cP group and
       extends its session expiration time.
     request:
-      id: 0x2203
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -99,15 +96,14 @@ methods:
           since: 2.0
           doc: |
             ID of the session
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 3
   - name: generateThreadId
     doc: |
       Generates a new ID for the caller thread. The ID is unique in the given
       CP group.
     request:
-      id: 0x2204
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -119,7 +115,6 @@ methods:
           doc: |
             ID of the CP group
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -128,3 +123,4 @@ methods:
           doc: |
             A unique ID for the caller thread
     since: 2.0
+    id: 4

--- a/protocol-definitions/CPSession.yaml
+++ b/protocol-definitions/CPSession.yaml
@@ -1,6 +1,5 @@
 id: 34
 name: CPSession
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: createSession

--- a/protocol-definitions/Cache.yaml
+++ b/protocol-definitions/Cache.yaml
@@ -2,7 +2,9 @@ id: 21
 name: Cache
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: addEntryListener
+  - id: 1
+    name: addEntryListener
+    since: 2.0
     doc: |
       TODO DOC
     request:
@@ -51,9 +53,9 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
+  - id: 2
+    name: addInvalidationListener
     since: 2.0
-    id: 1
-  - name: addInvalidationListener
     doc: |
       TODO DOC
     request:
@@ -146,9 +148,9 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
+  - id: 3
+    name: clear
     since: 2.0
-    id: 2
-  - name: clear
     doc: |
       Clears the contents of the cache, without notifying listeners or CacheWriters.
     request:
@@ -163,9 +165,9 @@ methods:
           doc: |
             Name of the cache.
     response: {}
+  - id: 4
+    name: removeAllKeys
     since: 2.0
-    id: 3
-  - name: removeAllKeys
     doc: |
       Removes entries for the specified keys. The order in which the individual entries are removed is undefined.
       For every entry in the key set, the following are called: any registered CacheEntryRemovedListeners if the cache
@@ -195,9 +197,9 @@ methods:
             User generated id which shall be received as a field of the cache event upon completion of
             the request in the cluster.
     response: {}
+  - id: 5
+    name: removeAll
     since: 2.0
-    id: 4
-  - name: removeAll
     doc: |
       Removes all of the mappings from this cache. The order that the individual entries are removed is undefined.
       For every mapping that exists the following are called: any registered CacheEntryRemovedListener if the cache is
@@ -222,9 +224,9 @@ methods:
             User generated id which shall be received as a field of the cache event upon completion of
             the request in the cluster.
     response: {}
+  - id: 6
+    name: containsKey
     since: 2.0
-    id: 5
-  - name: containsKey
     doc: |
       Determines if the Cache contains an entry for the specified key. More formally, returns true if and only if this
       cache contains a mapping for a key k such that key.equals(k). (There can be at most one such mapping.)
@@ -253,9 +255,9 @@ methods:
           since: 2.0
           doc: |
             Returns true if cache value for the key exists, false otherwise.
+  - id: 7
+    name: createConfig
     since: 2.0
-    id: 6
-  - name: createConfig
     doc: |
       TODO DOC
     request:
@@ -285,9 +287,9 @@ methods:
           doc: |
             The created configuration object. Byte-array which is serialized from an object implementing
             javax.cache.configuration.Configuration interface.
+  - id: 8
+    name: destroy
     since: 2.0
-    id: 7
-  - name: destroy
     doc: |
       Closes the cache. Clears the internal content and releases any resource.
     request:
@@ -302,9 +304,9 @@ methods:
           doc: |
             Name of the cache.
     response: {}
+  - id: 9
+    name: entryProcessor
     since: 2.0
-    id: 8
-  - name: entryProcessor
     doc: |
       TODO DOC
     request:
@@ -352,9 +354,9 @@ methods:
           since: 2.0
           doc: |
             the result of the processing, if any, defined by the EntryProcessor implementation
+  - id: 10
+    name: getAll
     since: 2.0
-    id: 9
-  - name: getAll
     doc: |
       Gets a collection of entries from the cache with custom expiry policy, returning them as Map of the values
       associated with the set of keys requested. If the cache is configured for read-through operation mode, the underlying
@@ -393,9 +395,9 @@ methods:
           doc: |
             A map of entries that were found for the given keys. Keys not found
             in the cache are not in the returned map.
+  - id: 11
+    name: getAndRemove
     since: 2.0
-    id: 10
-  - name: getAndRemove
     doc: |
       Atomically removes the entry for a key only if currently mapped to some value.
     request:
@@ -430,9 +432,9 @@ methods:
           since: 2.0
           doc: |
             the value if one existed or null if no mapping existed for this key
+  - id: 12
+    name: getAndReplace
     since: 2.0
-    id: 11
-  - name: getAndReplace
     doc: |
       Atomically replaces the assigned value of the given key by the specified value using a custom
       javax.cache.expiry.ExpiryPolicy and returns the previously assigned value. If the cache is configured for
@@ -483,9 +485,9 @@ methods:
           since: 2.0
           doc: |
             The old value previously assigned to the given key.
+  - id: 13
+    name: getConfig
     since: 2.0
-    id: 12
-  - name: getConfig
     doc: |
       TODO DOC
     request:
@@ -514,9 +516,9 @@ methods:
           doc: |
             The cache configuration. Byte-array which is serialized from an object implementing
             javax.cache.configuration.Configuration interface.
+  - id: 14
+    name: get
     since: 2.0
-    id: 13
-  - name: get
     doc: |
       Retrieves the mapped value of the given key using a custom javax.cache.expiry.ExpiryPolicy. If no mapping exists
       null is returned. If the cache is configured for read-through operation mode, the underlying configured
@@ -553,9 +555,9 @@ methods:
           since: 2.0
           doc: |
             The value assigned to the given key, or null if not assigned.
+  - id: 15
+    name: iterate
     since: 2.0
-    id: 14
-  - name: iterate
     doc: |
       The ordering of iteration over entries is undefined. During iteration, any entries that are a). read will have
       their appropriate CacheEntryReadListeners notified and b). removed will have their appropriate
@@ -598,9 +600,9 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
+  - id: 16
+    name: listenerRegistration
     since: 2.0
-    id: 15
-  - name: listenerRegistration
     doc: |
       TODO DOC
     request:
@@ -634,9 +636,9 @@ methods:
           doc: |
             The address of the member server for which the listener is being registered for.
     response: {}
+  - id: 17
+    name: loadAll
     since: 2.0
-    id: 16
-  - name: loadAll
     doc: |
       TODO DOC
     request:
@@ -664,9 +666,9 @@ methods:
             when true existing values in the Cache will
             be replaced by those loaded from a CacheLoader
     response: {}
+  - id: 18
+    name: managementConfig
     since: 2.0
-    id: 17
-  - name: managementConfig
     doc: |
       TODO DOC
     request:
@@ -699,9 +701,9 @@ methods:
           doc: |
             the address of the host to enable.
     response: {}
+  - id: 19
+    name: putIfAbsent
     since: 2.0
-    id: 18
-  - name: putIfAbsent
     doc: |
       Associates the specified key with the given value if and only if there is not yet a mapping defined for the
       specified key. If the cache is configured for write-through operation mode, the underlying configured
@@ -751,9 +753,9 @@ methods:
           since: 2.0
           doc: |
             true if a value was set, false otherwise.
+  - id: 20
+    name: put
     since: 2.0
-    id: 19
-  - name: put
     doc: |
       TODO DOC
     request:
@@ -807,9 +809,9 @@ methods:
           since: 2.0
           doc: |
             The value previously assigned to the given key, or null if not assigned.
+  - id: 21
+    name: removeEntryListener
     since: 2.0
-    id: 20
-  - name: removeEntryListener
     doc: |
       TODO DOC
     request:
@@ -837,9 +839,9 @@ methods:
           since: 2.0
           doc: |
             true if the listener is de-registered, false otherwise
+  - id: 22
+    name: removeInvalidationListener
     since: 2.0
-    id: 21
-  - name: removeInvalidationListener
     doc: |
       TODO DOC
     request:
@@ -867,9 +869,9 @@ methods:
           since: 2.0
           doc: |
             true if the listener is de-registered, false otherwise
+  - id: 23
+    name: remove
     since: 2.0
-    id: 22
-  - name: remove
     doc: |
       Atomically removes the mapping for a key only if currently mapped to the given value.
     request:
@@ -910,9 +912,9 @@ methods:
           since: 2.0
           doc: |
             returns false if there was no matching key
+  - id: 24
+    name: replace
     since: 2.0
-    id: 23
-  - name: replace
     doc: |
       Atomically replaces the currently assigned value for the given key with the specified newValue if and only if the
       currently assigned value equals the value of oldValue using a custom javax.cache.expiry.ExpiryPolicy
@@ -969,9 +971,9 @@ methods:
           since: 2.0
           doc: |
             The replaced value.
+  - id: 25
+    name: size
     since: 2.0
-    id: 24
-  - name: size
     doc: |
       Total entry count
     request:
@@ -993,9 +995,9 @@ methods:
           since: 2.0
           doc: |
             total entry count
+  - id: 26
+    name: addPartitionLostListener
     since: 2.0
-    id: 25
-  - name: addPartitionLostListener
     doc: |
       Adds a CachePartitionLostListener. The addPartitionLostListener returns a registration ID. This ID is needed to remove the
       CachePartitionLostListener using the #removePartitionLostListener(String) method. There is no check for duplicate
@@ -1042,9 +1044,9 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
+  - id: 27
+    name: removePartitionLostListener
     since: 2.0
-    id: 26
-  - name: removePartitionLostListener
     doc: |
       Removes the specified cache partition lost listener. Returns silently if there is no such listener added before
     request:
@@ -1072,9 +1074,9 @@ methods:
           since: 2.0
           doc: |
             true if registration is removed, false otherwise.
+  - id: 28
+    name: putAll
     since: 2.0
-    id: 27
-  - name: putAll
     doc: |
       TODO DOC
     request:
@@ -1109,9 +1111,9 @@ methods:
             user generated id which shall be received as a field of the cache event upon completion of
             the request in the cluster.
     response: {}
+  - id: 29
+    name: iterateEntries
     since: 2.0
-    id: 28
-  - name: iterateEntries
     doc: |
       Fetches specified number of entries from the specified partition starting from specified table index.
     request:
@@ -1151,9 +1153,9 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
+  - id: 30
+    name: addNearCacheInvalidationListener
     since: 2.0
-    id: 29
-  - name: addNearCacheInvalidationListener
     doc: |
       Adds listener to cache. This listener will be used to listen near cache invalidation events.
       Eventually consistent client near caches should use this method to add invalidation listeners
@@ -1248,9 +1250,9 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
+  - id: 31
+    name: fetchNearCacheInvalidationMetadata
     since: 2.0
-    id: 30
-  - name: fetchNearCacheInvalidationMetadata
     doc: |
       Fetches invalidation metadata from partitions of map.
     request:
@@ -1284,9 +1286,9 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
+  - id: 32
+    name: assignAndGetUuids
     since: 2.0
-    id: 31
-  - name: assignAndGetUuids
     doc: |
       TODO DOC
     request:
@@ -1301,9 +1303,9 @@ methods:
           since: 2.0
           doc: |
             partitionId to assigned uuid entry list
+  - id: 33
+    name: eventJournalSubscribe
     since: 2.0
-    id: 32
-  - name: eventJournalSubscribe
     doc: |
       Performs the initial subscription to the cache event journal.
       This includes retrieving the event journal sequences of the
@@ -1333,9 +1335,9 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
+  - id: 34
+    name: eventJournalRead
     since: 2.0
-    id: 33
-  - name: eventJournalRead
     doc: |
       Reads from the cache event journal in batches. You may specify the start sequence,
       the minimum required number of items in the response, the maximum number of items
@@ -1412,9 +1414,9 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
+  - id: 35
+    name: setExpiryPolicy
     since: 2.0
-    id: 34
-  - name: setExpiryPolicy
     doc: |
       Associates the specified key with the given {@link javax.cache.expiry.ExpiryPolicy}.
       {@code expiryPolicy} takes precedence for these particular {@code keys} against any cache wide expiry policy.
@@ -1450,5 +1452,3 @@ methods:
           since: 2.0
           doc: |
             {
-    since: 2.0
-    id: 35

--- a/protocol-definitions/Cache.yaml
+++ b/protocol-definitions/Cache.yaml
@@ -6,7 +6,6 @@ methods:
     doc: |
       TODO DOC
     request:
-      id: 0x1501
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -24,7 +23,6 @@ methods:
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -33,8 +31,7 @@ methods:
           doc: |
             Registration id for the registered listener.
     events:
-      - id: 0x00d2
-        name: Cache
+      - name: Cache
         params:
           - name: type
             type: int
@@ -55,11 +52,11 @@ methods:
             doc: |
               TODO DOC
     since: 2.0
+    id: 1
   - name: addInvalidationListener
     doc: |
       TODO DOC
     request:
-      id: 0x1502
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -77,7 +74,6 @@ methods:
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -86,8 +82,7 @@ methods:
           doc: |
             Registration id for the registered listener.
     events:
-      - id: 0x00d0
-        name: CacheInvalidation
+      - name: CacheInvalidation
         params:
           - name: name
             type: String
@@ -119,8 +114,7 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
-      - id: 0x00d3
-        name: CacheBatchInvalidation
+      - name: CacheBatchInvalidation
         params:
           - name: name
             type: String
@@ -153,11 +147,11 @@ methods:
             doc: |
               TODO DOC
     since: 2.0
+    id: 2
   - name: clear
     doc: |
       Clears the contents of the cache, without notifying listeners or CacheWriters.
     request:
-      id: 0x1503
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -168,16 +162,15 @@ methods:
           since: 2.0
           doc: |
             Name of the cache.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 3
   - name: removeAllKeys
     doc: |
       Removes entries for the specified keys. The order in which the individual entries are removed is undefined.
       For every entry in the key set, the following are called: any registered CacheEntryRemovedListeners if the cache
       is a write-through cache, the CacheWriter. If the key set is empty, the CacheWriter is not called.
     request:
-      id: 0x1504
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -201,9 +194,9 @@ methods:
           doc: |
             User generated id which shall be received as a field of the cache event upon completion of
             the request in the cluster.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 4
   - name: removeAll
     doc: |
       Removes all of the mappings from this cache. The order that the individual entries are removed is undefined.
@@ -211,7 +204,6 @@ methods:
       a write-through cache, the CacheWriter.If the cache is empty, the CacheWriter is not called.
       This is potentially an expensive operation as listeners are invoked. Use  #clear() to avoid this.
     request:
-      id: 0x1505
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -229,15 +221,14 @@ methods:
           doc: |
             User generated id which shall be received as a field of the cache event upon completion of
             the request in the cluster.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 5
   - name: containsKey
     doc: |
       Determines if the Cache contains an entry for the specified key. More formally, returns true if and only if this
       cache contains a mapping for a key k such that key.equals(k). (There can be at most one such mapping.)
     request:
-      id: 0x1506
       retryable: true
       acquiresResource: false
       partitionIdentifier: key
@@ -255,7 +246,6 @@ methods:
           doc: |
             The key whose presence in this cache is to be tested.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -264,11 +254,11 @@ methods:
           doc: |
             Returns true if cache value for the key exists, false otherwise.
     since: 2.0
+    id: 6
   - name: createConfig
     doc: |
       TODO DOC
     request:
-      id: 0x1507
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -287,7 +277,6 @@ methods:
           doc: |
             True if the configuration shall be created on all members, false otherwise.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -297,11 +286,11 @@ methods:
             The created configuration object. Byte-array which is serialized from an object implementing
             javax.cache.configuration.Configuration interface.
     since: 2.0
+    id: 7
   - name: destroy
     doc: |
       Closes the cache. Clears the internal content and releases any resource.
     request:
-      id: 0x1508
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -312,14 +301,13 @@ methods:
           since: 2.0
           doc: |
             Name of the cache.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 8
   - name: entryProcessor
     doc: |
       TODO DOC
     request:
-      id: 0x1509
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -357,7 +345,6 @@ methods:
             User generated id which shall be received as a field of the cache event upon completion of
             the request in the cluster.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -366,6 +353,7 @@ methods:
           doc: |
             the result of the processing, if any, defined by the EntryProcessor implementation
     since: 2.0
+    id: 9
   - name: getAll
     doc: |
       Gets a collection of entries from the cache with custom expiry policy, returning them as Map of the values
@@ -373,7 +361,6 @@ methods:
       configured javax.cache.integration.CacheLoader might be called to retrieve the values of the keys from any kind
       of external resource.
     request:
-      id: 0x150a
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -398,7 +385,6 @@ methods:
             Expiry policy for the entry. Byte-array which is serialized from an object implementing
             javax.cache.expiry.ExpiryPolicy interface.
     response:
-      id: 0x0075
       params:
         - name: response
           type: Map_Data_Data
@@ -408,11 +394,11 @@ methods:
             A map of entries that were found for the given keys. Keys not found
             in the cache are not in the returned map.
     since: 2.0
+    id: 10
   - name: getAndRemove
     doc: |
       Atomically removes the entry for a key only if currently mapped to some value.
     request:
-      id: 0x150b
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -437,7 +423,6 @@ methods:
             User generated id which shall be received as a field of the cache event upon completion of
             the request in the cluster.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -446,6 +431,7 @@ methods:
           doc: |
             the value if one existed or null if no mapping existed for this key
     since: 2.0
+    id: 11
   - name: getAndReplace
     doc: |
       Atomically replaces the assigned value of the given key by the specified value using a custom
@@ -453,7 +439,6 @@ methods:
       write-through operation mode, the underlying configured javax.cache.integration.CacheWriter might be called to
       store the value of the key to any kind of external resource.
     request:
-      id: 0x150c
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -491,7 +476,6 @@ methods:
             User generated id which shall be received as a field of the cache event upon completion of
             the request in the cluster.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -500,11 +484,11 @@ methods:
           doc: |
             The old value previously assigned to the given key.
     since: 2.0
+    id: 12
   - name: getConfig
     doc: |
       TODO DOC
     request:
-      id: 0x150d
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -522,7 +506,6 @@ methods:
           doc: |
             Name of the cache without prefix.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -532,13 +515,13 @@ methods:
             The cache configuration. Byte-array which is serialized from an object implementing
             javax.cache.configuration.Configuration interface.
     since: 2.0
+    id: 13
   - name: get
     doc: |
       Retrieves the mapped value of the given key using a custom javax.cache.expiry.ExpiryPolicy. If no mapping exists
       null is returned. If the cache is configured for read-through operation mode, the underlying configured
       javax.cache.integration.CacheLoader might be called to retrieve the value of the key from any kind of external resource.
     request:
-      id: 0x150e
       retryable: true
       acquiresResource: false
       partitionIdentifier: key
@@ -563,7 +546,6 @@ methods:
             Expiry policy for the entry. Byte-array which is serialized from an object implementing
             javax.cache.expiry.ExpiryPolicy interface.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -572,6 +554,7 @@ methods:
           doc: |
             The value assigned to the given key, or null if not assigned.
     since: 2.0
+    id: 14
   - name: iterate
     doc: |
       The ordering of iteration over entries is undefined. During iteration, any entries that are a). read will have
@@ -579,7 +562,6 @@ methods:
       CacheEntryRemoveListeners notified. java.util.Iterator#next() may return null if the entry is no longer present,
       has expired or has been evicted.
     request:
-      id: 0x150f
       retryable: false
       acquiresResource: false
       partitionIdentifier: partitionId
@@ -603,7 +585,6 @@ methods:
           doc: |
             The number of items to be batched
     response:
-      id: 0x0074
       params:
         - name: tableIndex
           type: int
@@ -618,11 +599,11 @@ methods:
           doc: |
             TODO DOC
     since: 2.0
+    id: 15
   - name: listenerRegistration
     doc: |
       TODO DOC
     request:
-      id: 0x1510
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -652,14 +633,13 @@ methods:
           since: 2.0
           doc: |
             The address of the member server for which the listener is being registered for.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 16
   - name: loadAll
     doc: |
       TODO DOC
     request:
-      id: 0x1511
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -683,14 +663,13 @@ methods:
           doc: |
             when true existing values in the Cache will
             be replaced by those loaded from a CacheLoader
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 17
   - name: managementConfig
     doc: |
       TODO DOC
     request:
-      id: 0x1512
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -719,16 +698,15 @@ methods:
           since: 2.0
           doc: |
             the address of the host to enable.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 18
   - name: putIfAbsent
     doc: |
       Associates the specified key with the given value if and only if there is not yet a mapping defined for the
       specified key. If the cache is configured for write-through operation mode, the underlying configured
       javax.cache.integration.CacheWriter might be called to store the value of the key to any kind of external resource.
     request:
-      id: 0x1513
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -766,7 +744,6 @@ methods:
             User generated id which shall be received as a field of the cache event upon completion of
             the request in the cluster.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -775,11 +752,11 @@ methods:
           doc: |
             true if a value was set, false otherwise.
     since: 2.0
+    id: 19
   - name: put
     doc: |
       TODO DOC
     request:
-      id: 0x1514
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -823,7 +800,6 @@ methods:
             User generated id which shall be received as a field of the cache event upon completion of
             the request in the cluster.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -832,11 +808,11 @@ methods:
           doc: |
             The value previously assigned to the given key, or null if not assigned.
     since: 2.0
+    id: 20
   - name: removeEntryListener
     doc: |
       TODO DOC
     request:
-      id: 0x1515
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -854,7 +830,6 @@ methods:
           doc: |
             The id assigned during the registration for the listener which shall be removed.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -863,11 +838,11 @@ methods:
           doc: |
             true if the listener is de-registered, false otherwise
     since: 2.0
+    id: 21
   - name: removeInvalidationListener
     doc: |
       TODO DOC
     request:
-      id: 0x1516
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -885,7 +860,6 @@ methods:
           doc: |
             The id assigned during the registration for the listener which shall be removed.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -894,11 +868,11 @@ methods:
           doc: |
             true if the listener is de-registered, false otherwise
     since: 2.0
+    id: 22
   - name: remove
     doc: |
       Atomically removes the mapping for a key only if currently mapped to the given value.
     request:
-      id: 0x1517
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -929,7 +903,6 @@ methods:
             User generated id which shall be received as a field of the cache event upon completion of
             the request in the cluster.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -938,6 +911,7 @@ methods:
           doc: |
             returns false if there was no matching key
     since: 2.0
+    id: 23
   - name: replace
     doc: |
       Atomically replaces the currently assigned value for the given key with the specified newValue if and only if the
@@ -945,7 +919,6 @@ methods:
       If the cache is configured for write-through operation mode, the underlying configured
       javax.cache.integration.CacheWriter might be called to store the value of the key to any kind of external resource.
     request:
-      id: 0x1518
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -989,7 +962,6 @@ methods:
             User generated id which shall be received as a field of the cache event upon completion of
             the request in the cluster.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -998,11 +970,11 @@ methods:
           doc: |
             The replaced value.
     since: 2.0
+    id: 24
   - name: size
     doc: |
       Total entry count
     request:
-      id: 0x1519
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -1014,7 +986,6 @@ methods:
           doc: |
             Name of the cache.
     response:
-      id: 0x0066
       params:
         - name: response
           type: int
@@ -1023,6 +994,7 @@ methods:
           doc: |
             total entry count
     since: 2.0
+    id: 25
   - name: addPartitionLostListener
     doc: |
       Adds a CachePartitionLostListener. The addPartitionLostListener returns a registration ID. This ID is needed to remove the
@@ -1030,7 +1002,6 @@ methods:
       registrations, so if you register the listener twice, it will get events twice.Listeners registered from
       HazelcastClient may miss some of the cache partition lost events due to design limitations.
     request:
-      id: 0x151a
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -1049,7 +1020,6 @@ methods:
             if true only node that has the partition sends the request, if false
             sends all partition lost events.
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -1058,8 +1028,7 @@ methods:
           doc: |
             returns the registration id for the CachePartitionLostListener.
     events:
-      - id: 0x00d6
-        name: CachePartitionLost
+      - name: CachePartitionLost
         params:
           - name: partitionId
             type: int
@@ -1074,11 +1043,11 @@ methods:
             doc: |
               TODO DOC
     since: 2.0
+    id: 26
   - name: removePartitionLostListener
     doc: |
       Removes the specified cache partition lost listener. Returns silently if there is no such listener added before
     request:
-      id: 0x151b
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -1096,7 +1065,6 @@ methods:
           doc: |
             ID of registered listener.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -1105,11 +1073,11 @@ methods:
           doc: |
             true if registration is removed, false otherwise.
     since: 2.0
+    id: 27
   - name: putAll
     doc: |
       TODO DOC
     request:
-      id: 0x151c
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -1140,14 +1108,13 @@ methods:
           doc: |
             user generated id which shall be received as a field of the cache event upon completion of
             the request in the cluster.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 28
   - name: iterateEntries
     doc: |
       Fetches specified number of entries from the specified partition starting from specified table index.
     request:
-      id: 0x151d
       retryable: true
       acquiresResource: false
       partitionIdentifier: partitionId
@@ -1171,7 +1138,6 @@ methods:
           doc: |
             The number of items to be batched
     response:
-      id: 0x0076
       params:
         - name: tableIndex
           type: int
@@ -1186,13 +1152,13 @@ methods:
           doc: |
             TODO DOC
     since: 2.0
+    id: 29
   - name: addNearCacheInvalidationListener
     doc: |
       Adds listener to cache. This listener will be used to listen near cache invalidation events.
       Eventually consistent client near caches should use this method to add invalidation listeners
       instead of {@link #addInvalidationListener(String, boolean)}
     request:
-      id: 0x151e
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -1210,7 +1176,6 @@ methods:
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -1219,8 +1184,7 @@ methods:
           doc: |
             Registration id for the registered listener.
     events:
-      - id: 0x00d0
-        name: CacheInvalidation
+      - name: CacheInvalidation
         params:
           - name: name
             type: String
@@ -1252,8 +1216,7 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
-      - id: 0x00d3
-        name: CacheBatchInvalidation
+      - name: CacheBatchInvalidation
         params:
           - name: name
             type: String
@@ -1286,11 +1249,11 @@ methods:
             doc: |
               TODO DOC
     since: 2.0
+    id: 30
   - name: fetchNearCacheInvalidationMetadata
     doc: |
       Fetches invalidation metadata from partitions of map.
     request:
-      id: 0x151f
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -1308,7 +1271,6 @@ methods:
           doc: |
             TODO DOC
     response:
-      id: 0x007a
       params:
         - name: namePartitionSequenceList
           type: Map_String_Map_Integer_Long
@@ -1323,16 +1285,15 @@ methods:
           doc: |
             TODO DOC
     since: 2.0
+    id: 31
   - name: assignAndGetUuids
     doc: |
       TODO DOC
     request:
-      id: 0x1520
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
     response:
-      id: 0x007b
       params:
         - name: partitionUuidList
           type: Map_Integer_UUID
@@ -1341,13 +1302,13 @@ methods:
           doc: |
             partitionId to assigned uuid entry list
     since: 2.0
+    id: 32
   - name: eventJournalSubscribe
     doc: |
       Performs the initial subscription to the cache event journal.
       This includes retrieving the event journal sequences of the
       oldest and newest event in the journal.
     request:
-      id: 0x1521
       retryable: true
       acquiresResource: false
       partitionIdentifier: partitionId
@@ -1359,7 +1320,6 @@ methods:
           doc: |
             name of the cache
     response:
-      id: 0x007d
       params:
         - name: oldestSequence
           type: long
@@ -1374,6 +1334,7 @@ methods:
           doc: |
             TODO DOC
     since: 2.0
+    id: 33
   - name: eventJournalRead
     doc: |
       Reads from the cache event journal in batches. You may specify the start sequence,
@@ -1385,7 +1346,6 @@ methods:
       The predicate, filter and projection may be {@code null} in which case all elements are returned
       and no projection is applied.
     request:
-      id: 0x1522
       retryable: true
       acquiresResource: false
       partitionIdentifier: partitionId
@@ -1427,7 +1387,6 @@ methods:
           doc: |
             the projection to apply to journal events
     response:
-      id: 0x0073
       params:
         - name: readCount
           type: int
@@ -1454,13 +1413,13 @@ methods:
           doc: |
             TODO DOC
     since: 2.0
+    id: 34
   - name: setExpiryPolicy
     doc: |
       Associates the specified key with the given {@link javax.cache.expiry.ExpiryPolicy}.
       {@code expiryPolicy} takes precedence for these particular {@code keys} against any cache wide expiry policy.
       If some keys in {@code keys} do not exist or are already expired, this call has no effect for those.
     request:
-      id: 0x1523
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -1484,7 +1443,6 @@ methods:
           doc: |
             custom expiry policy for this operation
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -1493,3 +1451,4 @@ methods:
           doc: |
             {
     since: 2.0
+    id: 35

--- a/protocol-definitions/Cache.yaml
+++ b/protocol-definitions/Cache.yaml
@@ -1,6 +1,5 @@
 id: 21
 name: Cache
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: addEntryListener

--- a/protocol-definitions/CardinalityEstimator.yaml
+++ b/protocol-definitions/CardinalityEstimator.yaml
@@ -7,7 +7,6 @@ methods:
       Add a new hash in the estimation set. This is the method you want to
       use to feed hash values into the estimator.
     request:
-      id: 0x1c01
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -26,15 +25,14 @@ methods:
             64bit hash code value to add
 
             @since 1.3
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 1
   - name: estimate
     doc: |
       Estimates the cardinality of the aggregation so far.
       If it was previously estimated and never invalidated, then the cached version is used.
     request:
-      id: 0x1c02
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -46,7 +44,6 @@ methods:
           doc: |
             The name of CardinalityEstimator
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -55,3 +52,4 @@ methods:
           doc: |
             the previous cached estimation or the newly computed one.
     since: 2.0
+    id: 2

--- a/protocol-definitions/CardinalityEstimator.yaml
+++ b/protocol-definitions/CardinalityEstimator.yaml
@@ -2,7 +2,9 @@ id: 28
 name: CardinalityEstimator
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: add
+  - id: 1
+    name: add
+    since: 2.0
     doc: |
       Add a new hash in the estimation set. This is the method you want to
       use to feed hash values into the estimator.
@@ -26,9 +28,9 @@ methods:
 
             @since 1.3
     response: {}
+  - id: 2
+    name: estimate
     since: 2.0
-    id: 1
-  - name: estimate
     doc: |
       Estimates the cardinality of the aggregation so far.
       If it was previously estimated and never invalidated, then the cached version is used.
@@ -51,5 +53,3 @@ methods:
           since: 2.0
           doc: |
             the previous cached estimation or the newly computed one.
-    since: 2.0
-    id: 2

--- a/protocol-definitions/CardinalityEstimator.yaml
+++ b/protocol-definitions/CardinalityEstimator.yaml
@@ -1,6 +1,5 @@
 id: 28
 name: CardinalityEstimator
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: add

--- a/protocol-definitions/Client.yaml
+++ b/protocol-definitions/Client.yaml
@@ -2,7 +2,9 @@ id: 0
 name: Client
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: authentication
+  - id: 2
+    name: authentication
+    since: 2.0
     doc: |
       TODO DOC
     request:
@@ -144,9 +146,9 @@ methods:
           doc: |
             the expected id of the cluster. Checked on the server side when provided.
             Authentication fails and 3:NOT_ALLOWED_IN_CLUSTER returned, in case of mismatch
+  - id: 3
+    name: authenticationCustom
     since: 2.0
-    id: 2
-  - name: authenticationCustom
     doc: |
       TODO DOC
     request:
@@ -282,9 +284,9 @@ methods:
           doc: |
             the expected id of the cluster. Checked on the server side when provided.
             Authentication fails and 3:NOT_ALLOWED_IN_CLUSTER returned, in case of mismatch
+  - id: 4
+    name: addMembershipListener
     since: 2.0
-    id: 3
-  - name: addMembershipListener
     doc: |
       TODO DOC
     request:
@@ -362,9 +364,9 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
+  - id: 5
+    name: createProxy
     since: 2.0
-    id: 4
-  - name: createProxy
     doc: |
       TODO DOC
     request:
@@ -410,9 +412,9 @@ methods:
           doc: |
             TODO DOC
     response: {}
+  - id: 6
+    name: destroyProxy
     since: 2.0
-    id: 5
-  - name: destroyProxy
     doc: |
       TODO DOC
     request:
@@ -452,9 +454,9 @@ methods:
             "hz:core:txManagerService"
             "hz:impl:xaService"
     response: {}
+  - id: 8
+    name: getPartitions
     since: 2.0
-    id: 6
-  - name: getPartitions
     doc: |
       TODO DOC
     request:
@@ -475,9 +477,9 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
+  - id: 9
+    name: removeAllListeners
     since: 2.0
-    id: 8
-  - name: removeAllListeners
     doc: |
       TODO DOC
     request:
@@ -485,9 +487,9 @@ methods:
       acquiresResource: false
       partitionIdentifier: -1
     response: {}
+  - id: 10
+    name: addPartitionLostListener
     since: 2.0
-    id: 9
-  - name: addPartitionLostListener
     doc: |
       TODO DOC
     request:
@@ -531,9 +533,9 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
+  - id: 11
+    name: removePartitionLostListener
     since: 2.0
-    id: 10
-  - name: removePartitionLostListener
     doc: |
       TODO DOC
     request:
@@ -555,9 +557,9 @@ methods:
           since: 2.0
           doc: |
             true if the listener existed and removed, false otherwise.
+  - id: 12
+    name: getDistributedObjects
     since: 2.0
-    id: 11
-  - name: getDistributedObjects
     doc: |
       TODO DOC
     request:
@@ -572,9 +574,9 @@ methods:
           since: 2.0
           doc: |
             An array of distributed object info in the cluster.
+  - id: 13
+    name: addDistributedObjectListener
     since: 2.0
-    id: 12
-  - name: addDistributedObjectListener
     doc: |
       TODO DOC
     request:
@@ -618,9 +620,9 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
+  - id: 14
+    name: removeDistributedObjectListener
     since: 2.0
-    id: 13
-  - name: removeDistributedObjectListener
     doc: |
       TODO DOC
     request:
@@ -642,9 +644,9 @@ methods:
           since: 2.0
           doc: |
             true if the listener existed and removed, false otherwise.
+  - id: 15
+    name: ping
     since: 2.0
-    id: 14
-  - name: ping
     doc: |
       TODO DOC
     request:
@@ -652,9 +654,9 @@ methods:
       acquiresResource: false
       partitionIdentifier: -1
     response: {}
+  - id: 16
+    name: statistics
     since: 2.0
-    id: 15
-  - name: statistics
     doc: |
       The statistics is a String that is composed of key=value pairs separated by ',' . The following characters
       ('=' '.' ',' '\') should be escaped in IMap and ICache names by the escape character ('\'). E.g. if the map name is
@@ -817,9 +819,9 @@ methods:
           doc: |
             The key=value pairs separated by the ',' character
     response: {}
+  - id: 17
+    name: deployClasses
     since: 2.0
-    id: 16
-  - name: deployClasses
     doc: |
       Deploys the list of classes to cluster
       Each item is a Map.Entry<String, byte[]> in the list.
@@ -836,9 +838,9 @@ methods:
           doc: |
             list of class definitions
     response: {}
+  - id: 18
+    name: addPartitionListener
     since: 2.0
-    id: 17
-  - name: addPartitionListener
     doc: |
       TODO DOC
     request:
@@ -861,9 +863,9 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
+  - id: 19
+    name: createProxies
     since: 2.0
-    id: 18
-  - name: createProxies
     doc: |
       Proxies will be created on all cluster members.
       If the member is  a lite member, a replicated map will not be created.
@@ -885,9 +887,9 @@ methods:
             Each entry's value is service name.
             For possible service names see createProxy message.
     response: {}
+  - id: 20
+    name: isFailoverSupported
     since: 2.0
-    id: 19
-  - name: isFailoverSupported
     doc: |
       TODO DOC
     request:
@@ -902,5 +904,3 @@ methods:
           since: 2.0
           doc: |
             Returns true if server supports cluster failover
-    since: 2.0
-    id: 20

--- a/protocol-definitions/Client.yaml
+++ b/protocol-definitions/Client.yaml
@@ -6,7 +6,6 @@ methods:
     doc: |
       TODO DOC
     request:
-      id: 0x0002
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -87,7 +86,6 @@ methods:
             the expected id of the cluster. Checked on the server side when provided.
             Authentication fails and 3:NOT_ALLOWED_IN_CLUSTER returned, in case of mismatch
     response:
-      id: 0x006b
       params:
         - name: status
           type: byte
@@ -147,11 +145,11 @@ methods:
             the expected id of the cluster. Checked on the server side when provided.
             Authentication fails and 3:NOT_ALLOWED_IN_CLUSTER returned, in case of mismatch
     since: 2.0
+    id: 2
   - name: authenticationCustom
     doc: |
       TODO DOC
     request:
-      id: 0x0003
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -226,7 +224,6 @@ methods:
             the expected id of the cluster. Checked on the server side when provided.
             Authentication fails and 3:NOT_ALLOWED_IN_CLUSTER returned, in case of mismatch
     response:
-      id: 0x006b
       params:
         - name: status
           type: byte
@@ -286,11 +283,11 @@ methods:
             the expected id of the cluster. Checked on the server side when provided.
             Authentication fails and 3:NOT_ALLOWED_IN_CLUSTER returned, in case of mismatch
     since: 2.0
+    id: 3
   - name: addMembershipListener
     doc: |
       TODO DOC
     request:
-      id: 0x0004
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -303,7 +300,6 @@ methods:
             if true only master node sends events, otherwise all registered nodes send all membership
             changes.
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -312,8 +308,7 @@ methods:
           doc: |
             Returns the registration id for the listener.
     events:
-      - id: 0x00c8
-        name: Member
+      - name: Member
         params:
           - name: member
             type: Member
@@ -327,8 +322,7 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
-      - id: 0x00c9
-        name: MemberList
+      - name: MemberList
         params:
           - name: members
             type: List_Member
@@ -336,8 +330,7 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
-      - id: 0x00ca
-        name: MemberAttributeChange
+      - name: MemberAttributeChange
         params:
           - name: member
             type: Member
@@ -370,11 +363,11 @@ methods:
             doc: |
               TODO DOC
     since: 2.0
+    id: 4
   - name: createProxy
     doc: |
       TODO DOC
     request:
-      id: 0x0005
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -416,14 +409,13 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 5
   - name: destroyProxy
     doc: |
       TODO DOC
     request:
-      id: 0x0006
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -459,19 +451,17 @@ methods:
             "hz:impl:topicService"
             "hz:core:txManagerService"
             "hz:impl:xaService"
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 6
   - name: getPartitions
     doc: |
       TODO DOC
     request:
-      id: 0x0008
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
     response:
-      id: 0x006c
       params:
         - name: partitions
           type: Map_Address_List_Integer
@@ -486,22 +476,21 @@ methods:
           doc: |
             TODO DOC
     since: 2.0
+    id: 8
   - name: removeAllListeners
     doc: |
       TODO DOC
     request:
-      id: 0x0009
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 9
   - name: addPartitionLostListener
     doc: |
       TODO DOC
     request:
-      id: 0x000a
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -514,7 +503,6 @@ methods:
             if true only node that has the partition sends the request, if false
             sends all partition lost events.
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -523,8 +511,7 @@ methods:
           doc: |
             The listener registration id.
     events:
-      - id: 0x00ce
-        name: PartitionLost
+      - name: PartitionLost
         params:
           - name: partitionId
             type: int
@@ -545,11 +532,11 @@ methods:
             doc: |
               TODO DOC
     since: 2.0
+    id: 10
   - name: removePartitionLostListener
     doc: |
       TODO DOC
     request:
-      id: 0x000b
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -561,7 +548,6 @@ methods:
           doc: |
             The id assigned during the listener registration.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -570,16 +556,15 @@ methods:
           doc: |
             true if the listener existed and removed, false otherwise.
     since: 2.0
+    id: 11
   - name: getDistributedObjects
     doc: |
       TODO DOC
     request:
-      id: 0x000c
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
     response:
-      id: 0x006e
       params:
         - name: response
           type: List_DistributedObjectInfo
@@ -588,11 +573,11 @@ methods:
           doc: |
             An array of distributed object info in the cluster.
     since: 2.0
+    id: 12
   - name: addDistributedObjectListener
     doc: |
       TODO DOC
     request:
-      id: 0x000d
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -605,7 +590,6 @@ methods:
             If set to true, the server adds the listener only to itself, otherwise the listener is is added for all
             members in the cluster.
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -614,8 +598,7 @@ methods:
           doc: |
             The registration id for the distributed object listener.
     events:
-      - id: 0x00cf
-        name: DistributedObject
+      - name: DistributedObject
         params:
           - name: name
             type: String
@@ -636,11 +619,11 @@ methods:
             doc: |
               TODO DOC
     since: 2.0
+    id: 13
   - name: removeDistributedObjectListener
     doc: |
       TODO DOC
     request:
-      id: 0x000e
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -652,7 +635,6 @@ methods:
           doc: |
             The id assigned during the registration.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -661,17 +643,17 @@ methods:
           doc: |
             true if the listener existed and removed, false otherwise.
     since: 2.0
+    id: 14
   - name: ping
     doc: |
       TODO DOC
     request:
-      id: 0x000f
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 15
   - name: statistics
     doc: |
       The statistics is a String that is composed of key=value pairs separated by ',' . The following characters
@@ -824,7 +806,6 @@ methods:
       nc.hz/StatICacheName.lastPersistenceWrittenBytes=0,nc.hz/StatICacheName.misses=1,nc.hz/StatICacheName.ownedEntryCount=1,
       nc.hz/StatICacheName.expirations=0,nc.hz/StatICacheName.ownedEntryMemoryCost=140
     request:
-      id: 0x0010
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -835,16 +816,15 @@ methods:
           since: 2.0
           doc: |
             The key=value pairs separated by the ',' character
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 16
   - name: deployClasses
     doc: |
       Deploys the list of classes to cluster
       Each item is a Map.Entry<String, byte[]> in the list.
       key of entry is full class name, and byte[] is the class definition.
     request:
-      id: 0x0011
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -855,22 +835,19 @@ methods:
           since: 2.0
           doc: |
             list of class definitions
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 17
   - name: addPartitionListener
     doc: |
       TODO DOC
     request:
-      id: 0x0012
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
-    response:
-      id: 0x0064
+    response: {}
     events:
-      - id: 0x00d9
-        name: Partitions
+      - name: Partitions
         params:
           - name: partitions
             type: Map_Address_List_Integer
@@ -885,6 +862,7 @@ methods:
             doc: |
               TODO DOC
     since: 2.0
+    id: 18
   - name: createProxies
     doc: |
       Proxies will be created on all cluster members.
@@ -893,7 +871,6 @@ methods:
       Exceptions related to a proxy creation failure is not send to the client.
       A proxy creation failure does not cancel this operation, all proxies will be attempted to be created.
     request:
-      id: 0x0013
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -907,19 +884,17 @@ methods:
             Each entry's key is distributed object name.
             Each entry's value is service name.
             For possible service names see createProxy message.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 19
   - name: isFailoverSupported
     doc: |
       TODO DOC
     request:
-      id: 0x0014
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -928,3 +903,4 @@ methods:
           doc: |
             Returns true if server supports cluster failover
     since: 2.0
+    id: 20

--- a/protocol-definitions/Client.yaml
+++ b/protocol-definitions/Client.yaml
@@ -1,6 +1,5 @@
 id: 0
 name: Client
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 2
     name: authentication

--- a/protocol-definitions/Condition.yaml
+++ b/protocol-definitions/Condition.yaml
@@ -1,6 +1,5 @@
 id: 8
 name: Condition
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: await

--- a/protocol-definitions/Condition.yaml
+++ b/protocol-definitions/Condition.yaml
@@ -6,7 +6,6 @@ methods:
     doc: |
       Causes the current thread to wait until it is signalled or interrupted, or the specified waiting time elapses.
     request:
-      id: 0x0801
       retryable: true
       acquiresResource: false
       partitionIdentifier: lockName
@@ -42,7 +41,6 @@ methods:
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -51,6 +49,7 @@ methods:
           doc: |
             False if the waiting time detectably elapsed before return from the method, else true
     since: 2.0
+    id: 1
   - name: beforeAwait
     doc: |
       Causes the current thread to wait until it is signalled or Thread#interrupt interrupted. The lock associated with
@@ -70,7 +69,6 @@ methods:
       An implementation can favor responding to an interrupt over normal method return in response to a signal. In that
       case the implementation must ensure that the signal is redirected to another waiting thread, if there is one.
     request:
-      id: 0x0802
       retryable: true
       acquiresResource: false
       partitionIdentifier: lockName
@@ -99,9 +97,9 @@ methods:
           since: 2.0
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 2
   - name: signal
     doc: |
       If any threads are waiting on this condition then one is selected for waking up.That thread must then re-acquire
@@ -110,7 +108,6 @@ methods:
       document this precondition and any actions taken if the lock is not held. Typically, an exception such as
       ILLEGAL_MONITOR_STATE will be thrown.
     request:
-      id: 0x0803
       retryable: false
       acquiresResource: false
       partitionIdentifier: lockName
@@ -133,15 +130,14 @@ methods:
           since: 2.0
           doc: |
             Name of the lock to wait on.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 3
   - name: signalAll
     doc: |
       If any threads are waiting on this condition then they are all woken up. Each thread must re-acquire the lock
       before it can return from
     request:
-      id: 0x0804
       retryable: false
       acquiresResource: false
       partitionIdentifier: lockName
@@ -164,6 +160,6 @@ methods:
           since: 2.0
           doc: |
             Name of the lock to wait on.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 4

--- a/protocol-definitions/Condition.yaml
+++ b/protocol-definitions/Condition.yaml
@@ -2,7 +2,9 @@ id: 8
 name: Condition
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: await
+  - id: 1
+    name: await
+    since: 2.0
     doc: |
       Causes the current thread to wait until it is signalled or interrupted, or the specified waiting time elapses.
     request:
@@ -48,9 +50,9 @@ methods:
           since: 2.0
           doc: |
             False if the waiting time detectably elapsed before return from the method, else true
+  - id: 2
+    name: beforeAwait
     since: 2.0
-    id: 1
-  - name: beforeAwait
     doc: |
       Causes the current thread to wait until it is signalled or Thread#interrupt interrupted. The lock associated with
       this Condition is atomically released and the current thread becomes disabled for thread scheduling purposes and
@@ -98,9 +100,9 @@ methods:
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
     response: {}
+  - id: 3
+    name: signal
     since: 2.0
-    id: 2
-  - name: signal
     doc: |
       If any threads are waiting on this condition then one is selected for waking up.That thread must then re-acquire
       the lock before returning from await. An implementation may (and typically does) require that the
@@ -131,9 +133,9 @@ methods:
           doc: |
             Name of the lock to wait on.
     response: {}
+  - id: 4
+    name: signalAll
     since: 2.0
-    id: 3
-  - name: signalAll
     doc: |
       If any threads are waiting on this condition then they are all woken up. Each thread must re-acquire the lock
       before it can return from
@@ -161,5 +163,3 @@ methods:
           doc: |
             Name of the lock to wait on.
     response: {}
-    since: 2.0
-    id: 4

--- a/protocol-definitions/ContinuousQuery.yaml
+++ b/protocol-definitions/ContinuousQuery.yaml
@@ -2,7 +2,9 @@ id: 24
 name: ContinuousQuery
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: publisherCreateWithValue
+  - id: 1
+    name: publisherCreateWithValue
+    since: 2.0
     doc: |
       TODO DOC
     request:
@@ -67,9 +69,9 @@ methods:
           since: 2.0
           doc: |
             Array of key-value pairs.
+  - id: 2
+    name: publisherCreate
     since: 2.0
-    id: 1
-  - name: publisherCreate
     doc: |
       TODO DOC
     request:
@@ -134,9 +136,9 @@ methods:
           since: 2.0
           doc: |
             Array of keys.
+  - id: 3
+    name: madePublishable
     since: 2.0
-    id: 2
-  - name: madePublishable
     doc: |
       TODO DOC
     request:
@@ -164,9 +166,9 @@ methods:
           since: 2.0
           doc: |
             True if successfully set as publishable, false otherwise.
+  - id: 4
+    name: addListener
     since: 2.0
-    id: 3
-  - name: addListener
     doc: |
       TODO DOC
     request:
@@ -223,9 +225,9 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
+  - id: 5
+    name: setReadCursor
     since: 2.0
-    id: 4
-  - name: setReadCursor
     doc: |
       This method can be used to recover from a possible event loss situation.
       This method tries to make consistent the data in this `QueryCache` with the data in the underlying `IMap`
@@ -264,9 +266,9 @@ methods:
           since: 2.0
           doc: |
             True if the cursor position could be set, false otherwise.
+  - id: 6
+    name: destroyCache
     since: 2.0
-    id: 5
-  - name: destroyCache
     doc: |
       TODO DOC
     request:
@@ -294,5 +296,3 @@ methods:
           since: 2.0
           doc: |
             True if all cache is destroyed, false otherwise.
-    since: 2.0
-    id: 6

--- a/protocol-definitions/ContinuousQuery.yaml
+++ b/protocol-definitions/ContinuousQuery.yaml
@@ -1,6 +1,5 @@
 id: 24
 name: ContinuousQuery
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: publisherCreateWithValue

--- a/protocol-definitions/ContinuousQuery.yaml
+++ b/protocol-definitions/ContinuousQuery.yaml
@@ -6,7 +6,6 @@ methods:
     doc: |
       TODO DOC
     request:
-      id: 0x1801
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -61,7 +60,6 @@ methods:
             Flag to enable/disable coalescing. If true, then only the last updated value for a key is placed in the
             batch, otherwise all changed values are included in the update.
     response:
-      id: 0x0075
       params:
         - name: response
           type: Map_Data_Data
@@ -70,11 +68,11 @@ methods:
           doc: |
             Array of key-value pairs.
     since: 2.0
+    id: 1
   - name: publisherCreate
     doc: |
       TODO DOC
     request:
-      id: 0x1802
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -129,7 +127,6 @@ methods:
             Flag to enable/disable coalescing. If true, then only the last updated value for a key is placed in the
             batch, otherwise all changed values are included in the update.
     response:
-      id: 0x006a
       params:
         - name: response
           type: List_Data
@@ -138,11 +135,11 @@ methods:
           doc: |
             Array of keys.
     since: 2.0
+    id: 2
   - name: madePublishable
     doc: |
       TODO DOC
     request:
-      id: 0x1803
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -160,7 +157,6 @@ methods:
           doc: |
             Name of query cache.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -169,11 +165,11 @@ methods:
           doc: |
             True if successfully set as publishable, false otherwise.
     since: 2.0
+    id: 3
   - name: addListener
     doc: |
       TODO DOC
     request:
-      id: 0x1804
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -191,7 +187,6 @@ methods:
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -200,8 +195,7 @@ methods:
           doc: |
             Registration id for the listener.
     events:
-      - id: 0x00d4
-        name: QueryCacheSingle
+      - name: QueryCacheSingle
         params:
           - name: data
             type: QueryCacheEventData
@@ -209,8 +203,7 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
-      - id: 0x00d5
-        name: QueryCacheBatch
+      - name: QueryCacheBatch
         params:
           - name: events
             type: List_QueryCacheEventData
@@ -231,6 +224,7 @@ methods:
             doc: |
               TODO DOC
     since: 2.0
+    id: 4
   - name: setReadCursor
     doc: |
       This method can be used to recover from a possible event loss situation.
@@ -240,7 +234,6 @@ methods:
       This method returns `false` if the event is not in the buffer of event publisher side. That means recovery is not
       possible.
     request:
-      id: 0x1805
       retryable: false
       acquiresResource: false
       partitionIdentifier: associated key with sequence
@@ -264,7 +257,6 @@ methods:
           doc: |
             The cursor position of the accumulator to be set.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -273,11 +265,11 @@ methods:
           doc: |
             True if the cursor position could be set, false otherwise.
     since: 2.0
+    id: 5
   - name: destroyCache
     doc: |
       TODO DOC
     request:
-      id: 0x1806
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -295,7 +287,6 @@ methods:
           doc: |
             Name of query cache.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -304,3 +295,4 @@ methods:
           doc: |
             True if all cache is destroyed, false otherwise.
     since: 2.0
+    id: 6

--- a/protocol-definitions/CountDownLatch.yaml
+++ b/protocol-definitions/CountDownLatch.yaml
@@ -1,6 +1,5 @@
 id: 12
 name: CountDownLatch
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: await

--- a/protocol-definitions/CountDownLatch.yaml
+++ b/protocol-definitions/CountDownLatch.yaml
@@ -2,7 +2,9 @@ id: 12
 name: CountDownLatch
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: await
+  - id: 1
+    name: await
+    since: 2.0
     doc: |
       Causes the current thread to wait until the latch has counted down to zero, or an exception is thrown, or the
       specified waiting time elapses. If the current count is zero then this method returns immediately with the value
@@ -39,9 +41,9 @@ methods:
           since: 2.0
           doc: |
             True if the count reached zero, false if the waiting time elapsed before the count reached zero
+  - id: 2
+    name: countDown
     since: 2.0
-    id: 1
-  - name: countDown
     doc: |
       Decrements the count of the latch, releasing all waiting threads if the count reaches zero. If the current count
       is greater than zero, then it is decremented. If the new count is zero: All waiting threads are re-enabled for
@@ -58,9 +60,9 @@ methods:
           doc: |
             Name of the CountDownLatch
     response: {}
+  - id: 3
+    name: getCount
     since: 2.0
-    id: 2
-  - name: getCount
     doc: |
       Returns the current count.
     request:
@@ -82,9 +84,9 @@ methods:
           since: 2.0
           doc: |
             The current count for the latch.
+  - id: 4
+    name: trySetCount
     since: 2.0
-    id: 3
-  - name: trySetCount
     doc: |
       Sets the count to the given value if the current count is zero. If the count is not zero, then this method does
       nothing and returns false
@@ -113,5 +115,3 @@ methods:
           since: 2.0
           doc: |
             True if the new count was set, false if the current count is not zero.
-    since: 2.0
-    id: 4

--- a/protocol-definitions/CountDownLatch.yaml
+++ b/protocol-definitions/CountDownLatch.yaml
@@ -15,7 +15,6 @@ methods:
       and the current thread's interrupted status is cleared. If the specified waiting time elapses then the value false
       is returned.  If the time is less than or equal to zero, the method will not wait at all.
     request:
-      id: 0x0c01
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -33,7 +32,6 @@ methods:
           doc: |
             The maximum time in milliseconds to wait
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -42,13 +40,13 @@ methods:
           doc: |
             True if the count reached zero, false if the waiting time elapsed before the count reached zero
     since: 2.0
+    id: 1
   - name: countDown
     doc: |
       Decrements the count of the latch, releasing all waiting threads if the count reaches zero. If the current count
       is greater than zero, then it is decremented. If the new count is zero: All waiting threads are re-enabled for
       thread scheduling purposes, and Countdown owner is set to null. If the current count equals zero, then nothing happens.
     request:
-      id: 0x0c02
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -59,14 +57,13 @@ methods:
           since: 2.0
           doc: |
             Name of the CountDownLatch
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 2
   - name: getCount
     doc: |
       Returns the current count.
     request:
-      id: 0x0c03
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -78,7 +75,6 @@ methods:
           doc: |
             Name of the CountDownLatch
     response:
-      id: 0x0066
       params:
         - name: response
           type: int
@@ -87,12 +83,12 @@ methods:
           doc: |
             The current count for the latch.
     since: 2.0
+    id: 3
   - name: trySetCount
     doc: |
       Sets the count to the given value if the current count is zero. If the count is not zero, then this method does
       nothing and returns false
     request:
-      id: 0x0c04
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -110,7 +106,6 @@ methods:
           doc: |
             The number of times countDown must be invoked before threads can pass through await
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -119,3 +114,4 @@ methods:
           doc: |
             True if the new count was set, false if the current count is not zero.
     since: 2.0
+    id: 4

--- a/protocol-definitions/DurableExecutor.yaml
+++ b/protocol-definitions/DurableExecutor.yaml
@@ -2,7 +2,9 @@ id: 27
 name: DurableExecutor
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: shutdown
+  - id: 1
+    name: shutdown
+    since: 2.0
     doc: |
       Initiates an orderly shutdown in which previously submitted tasks are executed, but no new tasks will be accepted.
       Invocation has no additional effect if already shut down.
@@ -18,9 +20,9 @@ methods:
           doc: |
             Name of the executor.
     response: {}
+  - id: 2
+    name: isShutdown
     since: 2.0
-    id: 1
-  - name: isShutdown
     doc: |
       Returns true if this executor has been shut down.
     request:
@@ -42,9 +44,9 @@ methods:
           since: 2.0
           doc: |
             true if this executor has been shut down
+  - id: 3
+    name: submitToPartition
     since: 2.0
-    id: 2
-  - name: submitToPartition
     doc: |
       Submits the task to partition for execution
     request:
@@ -72,9 +74,9 @@ methods:
           since: 2.0
           doc: |
             the sequence for the submitted execution.
+  - id: 4
+    name: retrieveResult
     since: 2.0
-    id: 3
-  - name: retrieveResult
     doc: |
       Retrieves the result of the execution with the given sequence
     request:
@@ -102,9 +104,9 @@ methods:
           since: 2.0
           doc: |
             The result of the callable execution with the given sequence.
+  - id: 5
+    name: disposeResult
     since: 2.0
-    id: 4
-  - name: disposeResult
     doc: |
       Disposes the result of the execution with the given sequence
     request:
@@ -125,9 +127,9 @@ methods:
           doc: |
             Sequence of the execution.
     response: {}
+  - id: 6
+    name: retrieveAndDisposeResult
     since: 2.0
-    id: 5
-  - name: retrieveAndDisposeResult
     doc: |
       Retrieves and disposes the result of the execution with the given sequence
     request:
@@ -155,5 +157,3 @@ methods:
           since: 2.0
           doc: |
             The result of the callable execution with the given sequence.
-    since: 2.0
-    id: 6

--- a/protocol-definitions/DurableExecutor.yaml
+++ b/protocol-definitions/DurableExecutor.yaml
@@ -7,7 +7,6 @@ methods:
       Initiates an orderly shutdown in which previously submitted tasks are executed, but no new tasks will be accepted.
       Invocation has no additional effect if already shut down.
     request:
-      id: 0x1b01
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -18,14 +17,13 @@ methods:
           since: 2.0
           doc: |
             Name of the executor.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 1
   - name: isShutdown
     doc: |
       Returns true if this executor has been shut down.
     request:
-      id: 0x1b02
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -37,7 +35,6 @@ methods:
           doc: |
             Name of the executor.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -46,11 +43,11 @@ methods:
           doc: |
             true if this executor has been shut down
     since: 2.0
+    id: 2
   - name: submitToPartition
     doc: |
       Submits the task to partition for execution
     request:
-      id: 0x1b03
       retryable: true
       acquiresResource: false
       partitionIdentifier: partitionId
@@ -68,7 +65,6 @@ methods:
           doc: |
             The callable object to be executed.
     response:
-      id: 0x0066
       params:
         - name: response
           type: int
@@ -77,11 +73,11 @@ methods:
           doc: |
             the sequence for the submitted execution.
     since: 2.0
+    id: 3
   - name: retrieveResult
     doc: |
       Retrieves the result of the execution with the given sequence
     request:
-      id: 0x1b04
       retryable: true
       acquiresResource: false
       partitionIdentifier: partitionId
@@ -99,7 +95,6 @@ methods:
           doc: |
             Sequence of the execution.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -108,11 +103,11 @@ methods:
           doc: |
             The result of the callable execution with the given sequence.
     since: 2.0
+    id: 4
   - name: disposeResult
     doc: |
       Disposes the result of the execution with the given sequence
     request:
-      id: 0x1b05
       retryable: true
       acquiresResource: false
       partitionIdentifier: partitionId
@@ -129,14 +124,13 @@ methods:
           since: 2.0
           doc: |
             Sequence of the execution.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 5
   - name: retrieveAndDisposeResult
     doc: |
       Retrieves and disposes the result of the execution with the given sequence
     request:
-      id: 0x1b06
       retryable: true
       acquiresResource: false
       partitionIdentifier: partitionId
@@ -154,7 +148,6 @@ methods:
           doc: |
             Sequence of the execution.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -163,3 +156,4 @@ methods:
           doc: |
             The result of the callable execution with the given sequence.
     since: 2.0
+    id: 6

--- a/protocol-definitions/DurableExecutor.yaml
+++ b/protocol-definitions/DurableExecutor.yaml
@@ -1,6 +1,5 @@
 id: 27
 name: DurableExecutor
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: shutdown

--- a/protocol-definitions/DynamicConfig.yaml
+++ b/protocol-definitions/DynamicConfig.yaml
@@ -2,7 +2,9 @@ id: 30
 name: DynamicConfig
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: addMultiMapConfig
+  - id: 1
+    name: addMultiMapConfig
+    since: 2.0
     doc: |
       Adds a new multimap config to a running cluster.
       If a multimap configuration with the given {@code name} already exists, then
@@ -76,9 +78,9 @@ methods:
           doc: |
             TODO DOC
     response: {}
+  - id: 2
+    name: addRingbufferConfig
     since: 2.0
-    id: 1
-  - name: addRingbufferConfig
     doc: |
       Adds a new ringbuffer configuration to a running cluster.
       If a ringbuffer configuration with the given {@code name} already exists, then
@@ -152,9 +154,9 @@ methods:
           doc: |
             TODO DOC
     response: {}
+  - id: 3
+    name: addCardinalityEstimatorConfig
     since: 2.0
-    id: 2
-  - name: addCardinalityEstimatorConfig
     doc: |
       Adds a new cardinality estimator configuration to a running cluster.
       If a cardinality estimator configuration with the given {@code name} already exists, then
@@ -203,9 +205,9 @@ methods:
           doc: |
             TODO DOC
     response: {}
+  - id: 4
+    name: addLockConfig
     since: 2.0
-    id: 3
-  - name: addLockConfig
     doc: |
       Adds a new lock configuration to a running cluster.
       If a lock configuration with the given {@code name} already exists, then
@@ -230,9 +232,9 @@ methods:
             required in the cluster for the lock to remain functional. When {@code null}, quorum does not
             apply to this lock configuration's operations.
     response: {}
+  - id: 5
+    name: addListConfig
     since: 2.0
-    id: 4
-  - name: addListConfig
     doc: |
       Adds a new list configuration to a running cluster.
       If a list configuration with the given {@code name} already exists, then
@@ -299,9 +301,9 @@ methods:
           doc: |
             TODO DOC
     response: {}
+  - id: 6
+    name: addSetConfig
     since: 2.0
-    id: 5
-  - name: addSetConfig
     doc: |
       Adds a new set configuration to a running cluster.
       If a set configuration with the given {@code name} already exists, then
@@ -368,9 +370,9 @@ methods:
           doc: |
             TODO DOC
     response: {}
+  - id: 7
+    name: addReplicatedMapConfig
     since: 2.0
-    id: 6
-  - name: addReplicatedMapConfig
     doc: |
       Adds a new replicated map configuration to a running cluster.
       If a replicated map configuration with the given {@code name} already exists, then
@@ -435,9 +437,9 @@ methods:
           doc: |
             TODO DOC
     response: {}
+  - id: 8
+    name: addTopicConfig
     since: 2.0
-    id: 7
-  - name: addTopicConfig
     doc: |
       Adds a new topic configuration to a running cluster.
       If a topic configuration with the given {@code name} already exists, then
@@ -480,9 +482,9 @@ methods:
           doc: |
             message listener configurations
     response: {}
+  - id: 9
+    name: addExecutorConfig
     since: 2.0
-    id: 8
-  - name: addExecutorConfig
     doc: |
       Adds a new executor configuration to a running cluster.
       If an executor configuration with the given {@code name} already exists, then
@@ -525,9 +527,9 @@ methods:
             required in the cluster for the lock to remain functional. When {@code null}, quorum does not
             apply to this lock configuration's operations.
     response: {}
+  - id: 10
+    name: addDurableExecutorConfig
     since: 2.0
-    id: 9
-  - name: addDurableExecutorConfig
     doc: |
       Adds a new durable executor configuration to a running cluster.
       If a durable executor configuration with the given {@code name} already exists, then
@@ -570,9 +572,9 @@ methods:
             required in the cluster for the lock to remain functional. When {@code null}, quorum does not
             apply to this lock configuration's operations.
     response: {}
+  - id: 11
+    name: addScheduledExecutorConfig
     since: 2.0
-    id: 10
-  - name: addScheduledExecutorConfig
     doc: |
       Adds a new scheduled executor configuration to a running cluster.
       If a scheduled executor configuration with the given {@code name} already exists, then
@@ -627,9 +629,9 @@ methods:
           doc: |
             TODO DOC
     response: {}
+  - id: 12
+    name: addSemaphoreConfig
     since: 2.0
-    id: 11
-  - name: addSemaphoreConfig
     doc: |
       Adds a new semaphore configuration to a running cluster.
       If a semaphore configuration with the given {@code name} already exists, then
@@ -672,9 +674,9 @@ methods:
             required in the cluster for the lock to remain functional. When {@code null}, quorum does not
             apply to this lock configuration's operations.
     response: {}
+  - id: 13
+    name: addQueueConfig
     since: 2.0
-    id: 12
-  - name: addQueueConfig
     doc: |
       Adds a new queue configuration to a running cluster.
       If a queue configuration with the given {@code name} already exists, then
@@ -753,9 +755,9 @@ methods:
           doc: |
             TODO DOC
     response: {}
+  - id: 14
+    name: addMapConfig
     since: 2.0
-    id: 13
-  - name: addMapConfig
     doc: |
       Adds a new map configuration to a running cluster.
       If a map configuration with the given {@code name} already exists, then
@@ -963,9 +965,9 @@ methods:
             metadata policy configuration for the supported data types. Valid values
             are {@code CREATE_ON_UPDATE} and {@code OFF}
     response: {}
+  - id: 15
+    name: addReliableTopicConfig
     since: 2.0
-    id: 14
-  - name: addReliableTopicConfig
     doc: |
       Adds a new reliable topic configuration to a running cluster.
       If a reliable topic configuration with the given {@code name} already exists, then
@@ -1014,9 +1016,9 @@ methods:
             a serialized {@link java.util.concurrent.Executor} instance to use for executing
             message listeners or {@code null}
     response: {}
+  - id: 16
+    name: addCacheConfig
     since: 2.0
-    id: 15
-  - name: addCacheConfig
     doc: |
       Adds a new cache configuration to a running cluster.
       If a cache configuration with the given {@code name} already exists, then
@@ -1184,9 +1186,9 @@ methods:
           doc: |
             hot restart configuration
     response: {}
+  - id: 18
+    name: addFlakeIdGeneratorConfig
     since: 2.0
-    id: 16
-  - name: addFlakeIdGeneratorConfig
     doc: |
       Adds a new flake ID generator configuration to a running cluster.
       If a flake ID generator configuration for the same name already exists, then
@@ -1233,9 +1235,9 @@ methods:
           doc: |
             TODO DOC
     response: {}
+  - id: 19
+    name: addAtomicLongConfig
     since: 2.0
-    id: 18
-  - name: addAtomicLongConfig
     doc: |
       Adds a new atomic long configuration to a running cluster.
       If an executor configuration with the given {@code name} already exists, then
@@ -1272,9 +1274,9 @@ methods:
           doc: |
             TODO DOC
     response: {}
+  - id: 20
+    name: addAtomicReferenceConfig
     since: 2.0
-    id: 19
-  - name: addAtomicReferenceConfig
     doc: |
       Adds a new atomic reference configuration to a running cluster.
       If an executor configuration with the given {@code name} already exists, then
@@ -1311,9 +1313,9 @@ methods:
           doc: |
             TODO DOC
     response: {}
+  - id: 21
+    name: addCountDownLatchConfig
     since: 2.0
-    id: 20
-  - name: addCountDownLatchConfig
     doc: |
       Adds a new count down latch configuration to a running cluster.
       If an executor configuration with the given {@code name} already exists, then
@@ -1338,9 +1340,9 @@ methods:
             required in the cluster for the lock to remain functional. When {@code null}, quorum does not
             apply to this lock configuration's operations.
     response: {}
+  - id: 22
+    name: addPNCounterConfig
     since: 2.0
-    id: 21
-  - name: addPNCounterConfig
     doc: |
       Adds a new CRDT PN counter configuration to a running cluster.
       If a PN counter configuration with the given {@code name} already exists, then
@@ -1377,5 +1379,3 @@ methods:
             required in the cluster for the lock to remain functional. When {@code null}, quorum does not
             apply to this lock configuration's operations.
     response: {}
-    since: 2.0
-    id: 22

--- a/protocol-definitions/DynamicConfig.yaml
+++ b/protocol-definitions/DynamicConfig.yaml
@@ -1,6 +1,5 @@
 id: 30
 name: DynamicConfig
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: addMultiMapConfig

--- a/protocol-definitions/DynamicConfig.yaml
+++ b/protocol-definitions/DynamicConfig.yaml
@@ -8,7 +8,6 @@ methods:
       If a multimap configuration with the given {@code name} already exists, then
       the new multimap config is ignored and the existing one is preserved.
     request:
-      id: 0x1e01
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -76,16 +75,15 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 1
   - name: addRingbufferConfig
     doc: |
       Adds a new ringbuffer configuration to a running cluster.
       If a ringbuffer configuration with the given {@code name} already exists, then
       the new ringbuffer config is ignored and the existing one is preserved.
     request:
-      id: 0x1e02
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -153,16 +151,15 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 2
   - name: addCardinalityEstimatorConfig
     doc: |
       Adds a new cardinality estimator configuration to a running cluster.
       If a cardinality estimator configuration with the given {@code name} already exists, then
       the new configuration is ignored and the existing one is preserved.
     request:
-      id: 0x1e03
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -205,16 +202,15 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 3
   - name: addLockConfig
     doc: |
       Adds a new lock configuration to a running cluster.
       If a lock configuration with the given {@code name} already exists, then
       the new configuration is ignored and the existing one is preserved.
     request:
-      id: 0x1e04
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -233,16 +229,15 @@ methods:
             name of an existing configured quorum to be used to determine the minimum number of members
             required in the cluster for the lock to remain functional. When {@code null}, quorum does not
             apply to this lock configuration's operations.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 4
   - name: addListConfig
     doc: |
       Adds a new list configuration to a running cluster.
       If a list configuration with the given {@code name} already exists, then
       the new configuration is ignored and the existing one is preserved.
     request:
-      id: 0x1e05
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -303,16 +298,15 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 5
   - name: addSetConfig
     doc: |
       Adds a new set configuration to a running cluster.
       If a set configuration with the given {@code name} already exists, then
       the new configuration is ignored and the existing one is preserved.
     request:
-      id: 0x1e06
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -373,16 +367,15 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 6
   - name: addReplicatedMapConfig
     doc: |
       Adds a new replicated map configuration to a running cluster.
       If a replicated map configuration with the given {@code name} already exists, then
       the new configuration is ignored and the existing one is preserved.
     request:
-      id: 0x1e07
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -441,16 +434,15 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 7
   - name: addTopicConfig
     doc: |
       Adds a new topic configuration to a running cluster.
       If a topic configuration with the given {@code name} already exists, then
       the new configuration is ignored and the existing one is preserved.
     request:
-      id: 0x1e08
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -487,16 +479,15 @@ methods:
           since: 2.0
           doc: |
             message listener configurations
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 8
   - name: addExecutorConfig
     doc: |
       Adds a new executor configuration to a running cluster.
       If an executor configuration with the given {@code name} already exists, then
       the new configuration is ignored and the existing one is preserved.
     request:
-      id: 0x1e09
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -533,16 +524,15 @@ methods:
             name of an existing configured quorum to be used to determine the minimum number of members
             required in the cluster for the lock to remain functional. When {@code null}, quorum does not
             apply to this lock configuration's operations.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 9
   - name: addDurableExecutorConfig
     doc: |
       Adds a new durable executor configuration to a running cluster.
       If a durable executor configuration with the given {@code name} already exists, then
       the new configuration is ignored and the existing one is preserved.
     request:
-      id: 0x1e0a
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -579,16 +569,15 @@ methods:
             name of an existing configured quorum to be used to determine the minimum number of members
             required in the cluster for the lock to remain functional. When {@code null}, quorum does not
             apply to this lock configuration's operations.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 10
   - name: addScheduledExecutorConfig
     doc: |
       Adds a new scheduled executor configuration to a running cluster.
       If a scheduled executor configuration with the given {@code name} already exists, then
       the new configuration is ignored and the existing one is preserved.
     request:
-      id: 0x1e0b
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -637,16 +626,15 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 11
   - name: addSemaphoreConfig
     doc: |
       Adds a new semaphore configuration to a running cluster.
       If a semaphore configuration with the given {@code name} already exists, then
       the new configuration is ignored and the existing one is preserved.
     request:
-      id: 0x1e0c
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -683,16 +671,15 @@ methods:
             name of an existing configured quorum to be used to determine the minimum number of members
             required in the cluster for the lock to remain functional. When {@code null}, quorum does not
             apply to this lock configuration's operations.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 12
   - name: addQueueConfig
     doc: |
       Adds a new queue configuration to a running cluster.
       If a queue configuration with the given {@code name} already exists, then
       the new configuration is ignored and the existing one is preserved.
     request:
-      id: 0x1e0d
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -765,16 +752,15 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 13
   - name: addMapConfig
     doc: |
       Adds a new map configuration to a running cluster.
       If a map configuration with the given {@code name} already exists, then
       the new configuration is ignored and the existing one is preserved.
     request:
-      id: 0x1e0e
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -976,16 +962,15 @@ methods:
           doc: |
             metadata policy configuration for the supported data types. Valid values
             are {@code CREATE_ON_UPDATE} and {@code OFF}
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 14
   - name: addReliableTopicConfig
     doc: |
       Adds a new reliable topic configuration to a running cluster.
       If a reliable topic configuration with the given {@code name} already exists, then
       the new configuration is ignored and the existing one is preserved.
     request:
-      id: 0x1e0f
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -1028,16 +1013,15 @@ methods:
           doc: |
             a serialized {@link java.util.concurrent.Executor} instance to use for executing
             message listeners or {@code null}
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 15
   - name: addCacheConfig
     doc: |
       Adds a new cache configuration to a running cluster.
       If a cache configuration with the given {@code name} already exists, then
       the new configuration is ignored and the existing one is preserved.
     request:
-      id: 0x1e10
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -1199,16 +1183,15 @@ methods:
           since: 2.0
           doc: |
             hot restart configuration
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 16
   - name: addFlakeIdGeneratorConfig
     doc: |
       Adds a new flake ID generator configuration to a running cluster.
       If a flake ID generator configuration for the same name already exists, then
       the new configuration is ignored and the existing one is preserved.
     request:
-      id: 0x1e12
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -1249,16 +1232,15 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 18
   - name: addAtomicLongConfig
     doc: |
       Adds a new atomic long configuration to a running cluster.
       If an executor configuration with the given {@code name} already exists, then
       the new configuration is ignored and the existing one is preserved.
     request:
-      id: 0x1e13
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -1289,16 +1271,15 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 19
   - name: addAtomicReferenceConfig
     doc: |
       Adds a new atomic reference configuration to a running cluster.
       If an executor configuration with the given {@code name} already exists, then
       the new configuration is ignored and the existing one is preserved.
     request:
-      id: 0x1e14
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -1329,16 +1310,15 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 20
   - name: addCountDownLatchConfig
     doc: |
       Adds a new count down latch configuration to a running cluster.
       If an executor configuration with the given {@code name} already exists, then
       the new configuration is ignored and the existing one is preserved.
     request:
-      id: 0x1e15
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -1357,16 +1337,15 @@ methods:
             name of an existing configured quorum to be used to determine the minimum number of members
             required in the cluster for the lock to remain functional. When {@code null}, quorum does not
             apply to this lock configuration's operations.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 21
   - name: addPNCounterConfig
     doc: |
       Adds a new CRDT PN counter configuration to a running cluster.
       If a PN counter configuration with the given {@code name} already exists, then
       the new configuration is ignored and the existing one is preserved.
     request:
-      id: 0x1e16
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -1397,6 +1376,6 @@ methods:
             name of an existing configured quorum to be used to determine the minimum number of members
             required in the cluster for the lock to remain functional. When {@code null}, quorum does not
             apply to this lock configuration's operations.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 22

--- a/protocol-definitions/ExecutorService.yaml
+++ b/protocol-definitions/ExecutorService.yaml
@@ -7,7 +7,6 @@ methods:
       Initiates an orderly shutdown in which previously submitted tasks are executed, but no new tasks will be accepted.
       Invocation has no additional effect if already shut down.
     request:
-      id: 0x0901
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -18,14 +17,13 @@ methods:
           since: 2.0
           doc: |
             Name of the executor.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 1
   - name: isShutdown
     doc: |
       Returns true if this executor has been shut down.
     request:
-      id: 0x0902
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -37,7 +35,6 @@ methods:
           doc: |
             Name of the executor.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -46,11 +43,11 @@ methods:
           doc: |
             true if this executor has been shut down
     since: 2.0
+    id: 2
   - name: cancelOnPartition
     doc: |
       TODO DOC
     request:
-      id: 0x0903
       retryable: false
       acquiresResource: false
       partitionIdentifier: partitionId
@@ -68,7 +65,6 @@ methods:
           doc: |
             If true, then the thread interrupt call can be used to cancel the thread, otherwise interrupt can not be used.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -77,11 +73,11 @@ methods:
           doc: |
             True if cancelled successfully, false otherwise.
     since: 2.0
+    id: 3
   - name: cancelOnAddress
     doc: |
       TODO DOC
     request:
-      id: 0x0904
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -105,7 +101,6 @@ methods:
           doc: |
             If true, then the thread interrupt call can be used to cancel the thread, otherwise interrupt can not be used.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -114,11 +109,11 @@ methods:
           doc: |
             True if cancelled successfully, false otherwise.
     since: 2.0
+    id: 4
   - name: submitToPartition
     doc: |
       TODO DOC
     request:
-      id: 0x0905
       retryable: false
       acquiresResource: false
       partitionIdentifier: partitionId
@@ -148,7 +143,6 @@ methods:
           doc: |
             The id of the partition which the callable shall be executed on.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -157,11 +151,11 @@ methods:
           doc: |
             The result of the callable execution.
     since: 2.0
+    id: 5
   - name: submitToAddress
     doc: |
       TODO DOC
     request:
-      id: 0x0906
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -191,7 +185,6 @@ methods:
           doc: |
             The member host on which the callable shall be executed on.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -200,3 +193,4 @@ methods:
           doc: |
             The result of the callable execution.
     since: 2.0
+    id: 6

--- a/protocol-definitions/ExecutorService.yaml
+++ b/protocol-definitions/ExecutorService.yaml
@@ -1,6 +1,5 @@
 id: 9
 name: ExecutorService
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: shutdown

--- a/protocol-definitions/ExecutorService.yaml
+++ b/protocol-definitions/ExecutorService.yaml
@@ -2,7 +2,9 @@ id: 9
 name: ExecutorService
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: shutdown
+  - id: 1
+    name: shutdown
+    since: 2.0
     doc: |
       Initiates an orderly shutdown in which previously submitted tasks are executed, but no new tasks will be accepted.
       Invocation has no additional effect if already shut down.
@@ -18,9 +20,9 @@ methods:
           doc: |
             Name of the executor.
     response: {}
+  - id: 2
+    name: isShutdown
     since: 2.0
-    id: 1
-  - name: isShutdown
     doc: |
       Returns true if this executor has been shut down.
     request:
@@ -42,9 +44,9 @@ methods:
           since: 2.0
           doc: |
             true if this executor has been shut down
+  - id: 3
+    name: cancelOnPartition
     since: 2.0
-    id: 2
-  - name: cancelOnPartition
     doc: |
       TODO DOC
     request:
@@ -72,9 +74,9 @@ methods:
           since: 2.0
           doc: |
             True if cancelled successfully, false otherwise.
+  - id: 4
+    name: cancelOnAddress
     since: 2.0
-    id: 3
-  - name: cancelOnAddress
     doc: |
       TODO DOC
     request:
@@ -108,9 +110,9 @@ methods:
           since: 2.0
           doc: |
             True if cancelled successfully, false otherwise.
+  - id: 5
+    name: submitToPartition
     since: 2.0
-    id: 4
-  - name: submitToPartition
     doc: |
       TODO DOC
     request:
@@ -150,9 +152,9 @@ methods:
           since: 2.0
           doc: |
             The result of the callable execution.
+  - id: 6
+    name: submitToAddress
     since: 2.0
-    id: 5
-  - name: submitToAddress
     doc: |
       TODO DOC
     request:
@@ -192,5 +194,3 @@ methods:
           since: 2.0
           doc: |
             The result of the callable execution.
-    since: 2.0
-    id: 6

--- a/protocol-definitions/FlakeIdGenerator.yaml
+++ b/protocol-definitions/FlakeIdGenerator.yaml
@@ -1,6 +1,5 @@
 id: 31
 name: FlakeIdGenerator
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: newIdBatch

--- a/protocol-definitions/FlakeIdGenerator.yaml
+++ b/protocol-definitions/FlakeIdGenerator.yaml
@@ -6,7 +6,6 @@ methods:
     doc: |
       TODO DOC
     request:
-      id: 0x1f01
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -24,7 +23,6 @@ methods:
           doc: |
             TODO DOC
     response:
-      id: 0x007e
       params:
         - name: base
           type: long
@@ -45,3 +43,4 @@ methods:
           doc: |
             TODO DOC
     since: 2.0
+    id: 1

--- a/protocol-definitions/FlakeIdGenerator.yaml
+++ b/protocol-definitions/FlakeIdGenerator.yaml
@@ -2,7 +2,9 @@ id: 31
 name: FlakeIdGenerator
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: newIdBatch
+  - id: 1
+    name: newIdBatch
+    since: 2.0
     doc: |
       TODO DOC
     request:
@@ -42,5 +44,3 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
-    since: 2.0
-    id: 1

--- a/protocol-definitions/List.yaml
+++ b/protocol-definitions/List.yaml
@@ -7,7 +7,6 @@ methods:
       Returns the number of elements in this list.  If this list contains more than Integer.MAX_VALUE elements, returns
       Integer.MAX_VALUE.
     request:
-      id: 0x0501
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -19,7 +18,6 @@ methods:
           doc: |
             Name of List
     response:
-      id: 0x0066
       params:
         - name: response
           type: int
@@ -28,11 +26,11 @@ methods:
           doc: |
             The number of elements in this list
     since: 2.0
+    id: 1
   - name: contains
     doc: |
       Returns true if this list contains the specified element.
     request:
-      id: 0x0502
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -50,7 +48,6 @@ methods:
           doc: |
             Element whose presence in this list is to be tested
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -59,11 +56,11 @@ methods:
           doc: |
             True if this list contains the specified element, false otherwise
     since: 2.0
+    id: 2
   - name: containsAll
     doc: |
       Returns true if this list contains all of the elements of the specified collection.
     request:
-      id: 0x0503
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -81,7 +78,6 @@ methods:
           doc: |
             Collection to be checked for containment in this list
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -91,6 +87,7 @@ methods:
             True if this list contains all of the elements of the
             specified collection
     since: 2.0
+    id: 3
   - name: add
     doc: |
       Appends the specified element to the end of this list (optional operation). Lists that support this operation may
@@ -98,7 +95,6 @@ methods:
       elements, and others will impose restrictions on the type of elements that may be added. List classes should
       clearly specify in their documentation any restrictions on what elements may be added.
     request:
-      id: 0x0504
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -116,7 +112,6 @@ methods:
           doc: |
             Element to be appended to this list
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -125,13 +120,13 @@ methods:
           doc: |
             true if this list changed as a result of the call, false otherwise
     since: 2.0
+    id: 4
   - name: remove
     doc: |
       Removes the first occurrence of the specified element from this list, if it is present (optional operation).
       If this list does not contain the element, it is unchanged.
       Returns true if this list contained the specified element (or equivalently, if this list changed as a result of the call).
     request:
-      id: 0x0505
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -149,7 +144,6 @@ methods:
           doc: |
             Element to be removed from this list, if present
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -158,6 +152,7 @@ methods:
           doc: |
             True if this list contained the specified element, false otherwise
     since: 2.0
+    id: 5
   - name: addAll
     doc: |
       Appends all of the elements in the specified collection to the end of this list, in the order that they are
@@ -165,7 +160,6 @@ methods:
       The behavior of this operation is undefined if the specified collection is modified while the operation is in progress.
       (Note that this will occur if the specified collection is this list, and it's nonempty.)
     request:
-      id: 0x0506
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -183,7 +177,6 @@ methods:
           doc: |
             Collection containing elements to be added to this list
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -192,11 +185,11 @@ methods:
           doc: |
             True if this list changed as a result of the call, false otherwise
     since: 2.0
+    id: 6
   - name: compareAndRemoveAll
     doc: |
       Removes from this list all of its elements that are contained in the specified collection (optional operation).
     request:
-      id: 0x0507
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -214,7 +207,6 @@ methods:
           doc: |
             The list of values to compare for removal.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -223,12 +215,12 @@ methods:
           doc: |
             True if removed at least one of the items, false otherwise.
     since: 2.0
+    id: 7
   - name: compareAndRetainAll
     doc: |
       Retains only the elements in this list that are contained in the specified collection (optional operation).
       In other words, removes from this list all of its elements that are not contained in the specified collection.
     request:
-      id: 0x0508
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -246,7 +238,6 @@ methods:
           doc: |
             The list of values to compare for retaining.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -255,11 +246,11 @@ methods:
           doc: |
             True if this list changed as a result of the call, false otherwise.
     since: 2.0
+    id: 8
   - name: clear
     doc: |
       Removes all of the elements from this list (optional operation). The list will be empty after this call returns.
     request:
-      id: 0x0509
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -270,14 +261,13 @@ methods:
           since: 2.0
           doc: |
             Name of the List
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 9
   - name: getAll
     doc: |
       Return the all elements of this collection
     request:
-      id: 0x050a
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -289,7 +279,6 @@ methods:
           doc: |
             Name of the List
     response:
-      id: 0x006a
       params:
         - name: response
           type: List_Data
@@ -298,11 +287,11 @@ methods:
           doc: |
             An array of all item values in the list.
     since: 2.0
+    id: 10
   - name: addListener
     doc: |
       Adds an item listener for this collection. Listener will be notified for all collection add/remove events.
     request:
-      id: 0x050b
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -326,7 +315,6 @@ methods:
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -335,8 +323,7 @@ methods:
           doc: |
             Registration id for the listener.
     events:
-      - id: 0x00cc
-        name: Item
+      - name: Item
         params:
           - name: item
             type: Data
@@ -357,11 +344,11 @@ methods:
             doc: |
               TODO DOC
     since: 2.0
+    id: 11
   - name: removeListener
     doc: |
       Removes the specified item listener. Returns silently if the specified listener was not added before.
     request:
-      id: 0x050c
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -379,7 +366,6 @@ methods:
           doc: |
             The id of the listener which was provided during registration.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -388,11 +374,11 @@ methods:
           doc: |
             True if unregistered, false otherwise.
     since: 2.0
+    id: 12
   - name: isEmpty
     doc: |
       Returns true if this list contains no elements
     request:
-      id: 0x050d
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -404,7 +390,6 @@ methods:
           doc: |
             Name of the List
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -413,6 +398,7 @@ methods:
           doc: |
             True if this list contains no elements
     since: 2.0
+    id: 13
   - name: addAllWithIndex
     doc: |
       Inserts all of the elements in the specified collection into this list at the specified position (optional operation).
@@ -421,7 +407,6 @@ methods:
       The behavior of this operation is undefined if the specified collection is modified while the operation is in progress.
       (Note that this will occur if the specified collection is this list, and it's nonempty.)
     request:
-      id: 0x050e
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -445,7 +430,6 @@ methods:
           doc: |
             The list of value to insert into the list.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -454,11 +438,11 @@ methods:
           doc: |
             True if this list changed as a result of the call, false otherwise.
     since: 2.0
+    id: 14
   - name: get
     doc: |
       Returns the element at the specified position in this list
     request:
-      id: 0x050f
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -476,7 +460,6 @@ methods:
           doc: |
             Index of the element to return
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -485,11 +468,11 @@ methods:
           doc: |
             The element at the specified position in this list
     since: 2.0
+    id: 15
   - name: set
     doc: |
       The element previously at the specified position
     request:
-      id: 0x0510
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -513,7 +496,6 @@ methods:
           doc: |
             Element to be stored at the specified position
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -522,12 +504,12 @@ methods:
           doc: |
             The element previously at the specified position
     since: 2.0
+    id: 16
   - name: addWithIndex
     doc: |
       Inserts the specified element at the specified position in this list (optional operation). Shifts the element
       currently at that position (if any) and any subsequent elements to the right (adds one to their indices).
     request:
-      id: 0x0511
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -550,15 +532,14 @@ methods:
           since: 2.0
           doc: |
             Value to be inserted.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 17
   - name: removeWithIndex
     doc: |
       Removes the element at the specified position in this list (optional operation). Shifts any subsequent elements
       to the left (subtracts one from their indices). Returns the element that was removed from the list.
     request:
-      id: 0x0512
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -576,7 +557,6 @@ methods:
           doc: |
             The index of the element to be removed
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -585,12 +565,12 @@ methods:
           doc: |
             The element previously at the specified position
     since: 2.0
+    id: 18
   - name: lastIndexOf
     doc: |
       Returns the index of the last occurrence of the specified element in this list, or -1 if this list does not
       contain the element.
     request:
-      id: 0x0513
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -608,7 +588,6 @@ methods:
           doc: |
             Element to search for
     response:
-      id: 0x0066
       params:
         - name: response
           type: int
@@ -618,12 +597,12 @@ methods:
             the index of the last occurrence of the specified element in
             this list, or -1 if this list does not contain the element
     since: 2.0
+    id: 19
   - name: indexOf
     doc: |
       Returns the index of the first occurrence of the specified element in this list, or -1 if this list does not
       contain the element.
     request:
-      id: 0x0514
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -641,7 +620,6 @@ methods:
           doc: |
             Element to search for
     response:
-      id: 0x0066
       params:
         - name: response
           type: int
@@ -651,6 +629,7 @@ methods:
             The index of the first occurrence of the specified element in
             this list, or -1 if this list does not contain the element
     since: 2.0
+    id: 20
   - name: sub
     doc: |
       Returns a view of the portion of this list between the specified from, inclusive, and to, exclusive.(If from and
@@ -665,7 +644,6 @@ methods:
       structurally modified in any way other than via the returned list.(Structural modifications are those that change
       the size of this list, or otherwise perturb it in such a fashion that iterations in progress may yield incorrect results.)
     request:
-      id: 0x0515
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -689,7 +667,6 @@ methods:
           doc: |
             High endpoint (exclusive) of the subList
     response:
-      id: 0x006a
       params:
         - name: response
           type: List_Data
@@ -698,11 +675,11 @@ methods:
           doc: |
             A view of the specified range within this list
     since: 2.0
+    id: 21
   - name: iterator
     doc: |
       Returns an iterator over the elements in this list in proper sequence.
     request:
-      id: 0x0516
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -714,7 +691,6 @@ methods:
           doc: |
             Name of the List
     response:
-      id: 0x006a
       params:
         - name: response
           type: List_Data
@@ -723,6 +699,7 @@ methods:
           doc: |
             An iterator over the elements in this list in proper sequence
     since: 2.0
+    id: 22
   - name: listIterator
     doc: |
       Returns a list iterator over the elements in this list (in proper sequence), starting at the specified position
@@ -730,7 +707,6 @@ methods:
       ListIterator#next next. An initial call to ListIterator#previous previous would return the element with the
       specified index minus one.
     request:
-      id: 0x0517
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -748,7 +724,6 @@ methods:
           doc: |
             index of the first element to be returned from the list iterator next
     response:
-      id: 0x006a
       params:
         - name: response
           type: List_Data
@@ -758,3 +733,4 @@ methods:
             a list iterator over the elements in this list (in proper
             sequence), starting at the specified position in the list
     since: 2.0
+    id: 23

--- a/protocol-definitions/List.yaml
+++ b/protocol-definitions/List.yaml
@@ -1,6 +1,5 @@
 id: 5
 name: List
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: size

--- a/protocol-definitions/List.yaml
+++ b/protocol-definitions/List.yaml
@@ -2,7 +2,9 @@ id: 5
 name: List
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: size
+  - id: 1
+    name: size
+    since: 2.0
     doc: |
       Returns the number of elements in this list.  If this list contains more than Integer.MAX_VALUE elements, returns
       Integer.MAX_VALUE.
@@ -25,9 +27,9 @@ methods:
           since: 2.0
           doc: |
             The number of elements in this list
+  - id: 2
+    name: contains
     since: 2.0
-    id: 1
-  - name: contains
     doc: |
       Returns true if this list contains the specified element.
     request:
@@ -55,9 +57,9 @@ methods:
           since: 2.0
           doc: |
             True if this list contains the specified element, false otherwise
+  - id: 3
+    name: containsAll
     since: 2.0
-    id: 2
-  - name: containsAll
     doc: |
       Returns true if this list contains all of the elements of the specified collection.
     request:
@@ -86,9 +88,9 @@ methods:
           doc: |
             True if this list contains all of the elements of the
             specified collection
+  - id: 4
+    name: add
     since: 2.0
-    id: 3
-  - name: add
     doc: |
       Appends the specified element to the end of this list (optional operation). Lists that support this operation may
       place limitations on what elements may be added to this list.  In particular, some lists will refuse to add null
@@ -119,9 +121,9 @@ methods:
           since: 2.0
           doc: |
             true if this list changed as a result of the call, false otherwise
+  - id: 5
+    name: remove
     since: 2.0
-    id: 4
-  - name: remove
     doc: |
       Removes the first occurrence of the specified element from this list, if it is present (optional operation).
       If this list does not contain the element, it is unchanged.
@@ -151,9 +153,9 @@ methods:
           since: 2.0
           doc: |
             True if this list contained the specified element, false otherwise
+  - id: 6
+    name: addAll
     since: 2.0
-    id: 5
-  - name: addAll
     doc: |
       Appends all of the elements in the specified collection to the end of this list, in the order that they are
       returned by the specified collection's iterator (optional operation).
@@ -184,9 +186,9 @@ methods:
           since: 2.0
           doc: |
             True if this list changed as a result of the call, false otherwise
+  - id: 7
+    name: compareAndRemoveAll
     since: 2.0
-    id: 6
-  - name: compareAndRemoveAll
     doc: |
       Removes from this list all of its elements that are contained in the specified collection (optional operation).
     request:
@@ -214,9 +216,9 @@ methods:
           since: 2.0
           doc: |
             True if removed at least one of the items, false otherwise.
+  - id: 8
+    name: compareAndRetainAll
     since: 2.0
-    id: 7
-  - name: compareAndRetainAll
     doc: |
       Retains only the elements in this list that are contained in the specified collection (optional operation).
       In other words, removes from this list all of its elements that are not contained in the specified collection.
@@ -245,9 +247,9 @@ methods:
           since: 2.0
           doc: |
             True if this list changed as a result of the call, false otherwise.
+  - id: 9
+    name: clear
     since: 2.0
-    id: 8
-  - name: clear
     doc: |
       Removes all of the elements from this list (optional operation). The list will be empty after this call returns.
     request:
@@ -262,9 +264,9 @@ methods:
           doc: |
             Name of the List
     response: {}
+  - id: 10
+    name: getAll
     since: 2.0
-    id: 9
-  - name: getAll
     doc: |
       Return the all elements of this collection
     request:
@@ -286,9 +288,9 @@ methods:
           since: 2.0
           doc: |
             An array of all item values in the list.
+  - id: 11
+    name: addListener
     since: 2.0
-    id: 10
-  - name: addListener
     doc: |
       Adds an item listener for this collection. Listener will be notified for all collection add/remove events.
     request:
@@ -343,9 +345,9 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
+  - id: 12
+    name: removeListener
     since: 2.0
-    id: 11
-  - name: removeListener
     doc: |
       Removes the specified item listener. Returns silently if the specified listener was not added before.
     request:
@@ -373,9 +375,9 @@ methods:
           since: 2.0
           doc: |
             True if unregistered, false otherwise.
+  - id: 13
+    name: isEmpty
     since: 2.0
-    id: 12
-  - name: isEmpty
     doc: |
       Returns true if this list contains no elements
     request:
@@ -397,9 +399,9 @@ methods:
           since: 2.0
           doc: |
             True if this list contains no elements
+  - id: 14
+    name: addAllWithIndex
     since: 2.0
-    id: 13
-  - name: addAllWithIndex
     doc: |
       Inserts all of the elements in the specified collection into this list at the specified position (optional operation).
       Shifts the element currently at that position (if any) and any subsequent elements to the right (increases their indices).
@@ -437,9 +439,9 @@ methods:
           since: 2.0
           doc: |
             True if this list changed as a result of the call, false otherwise.
+  - id: 15
+    name: get
     since: 2.0
-    id: 14
-  - name: get
     doc: |
       Returns the element at the specified position in this list
     request:
@@ -467,9 +469,9 @@ methods:
           since: 2.0
           doc: |
             The element at the specified position in this list
+  - id: 16
+    name: set
     since: 2.0
-    id: 15
-  - name: set
     doc: |
       The element previously at the specified position
     request:
@@ -503,9 +505,9 @@ methods:
           since: 2.0
           doc: |
             The element previously at the specified position
+  - id: 17
+    name: addWithIndex
     since: 2.0
-    id: 16
-  - name: addWithIndex
     doc: |
       Inserts the specified element at the specified position in this list (optional operation). Shifts the element
       currently at that position (if any) and any subsequent elements to the right (adds one to their indices).
@@ -533,9 +535,9 @@ methods:
           doc: |
             Value to be inserted.
     response: {}
+  - id: 18
+    name: removeWithIndex
     since: 2.0
-    id: 17
-  - name: removeWithIndex
     doc: |
       Removes the element at the specified position in this list (optional operation). Shifts any subsequent elements
       to the left (subtracts one from their indices). Returns the element that was removed from the list.
@@ -564,9 +566,9 @@ methods:
           since: 2.0
           doc: |
             The element previously at the specified position
+  - id: 19
+    name: lastIndexOf
     since: 2.0
-    id: 18
-  - name: lastIndexOf
     doc: |
       Returns the index of the last occurrence of the specified element in this list, or -1 if this list does not
       contain the element.
@@ -596,9 +598,9 @@ methods:
           doc: |
             the index of the last occurrence of the specified element in
             this list, or -1 if this list does not contain the element
+  - id: 20
+    name: indexOf
     since: 2.0
-    id: 19
-  - name: indexOf
     doc: |
       Returns the index of the first occurrence of the specified element in this list, or -1 if this list does not
       contain the element.
@@ -628,9 +630,9 @@ methods:
           doc: |
             The index of the first occurrence of the specified element in
             this list, or -1 if this list does not contain the element
+  - id: 21
+    name: sub
     since: 2.0
-    id: 20
-  - name: sub
     doc: |
       Returns a view of the portion of this list between the specified from, inclusive, and to, exclusive.(If from and
       to are equal, the returned list is empty.) The returned list is backed by this list, so non-structural changes in
@@ -674,9 +676,9 @@ methods:
           since: 2.0
           doc: |
             A view of the specified range within this list
+  - id: 22
+    name: iterator
     since: 2.0
-    id: 21
-  - name: iterator
     doc: |
       Returns an iterator over the elements in this list in proper sequence.
     request:
@@ -698,9 +700,9 @@ methods:
           since: 2.0
           doc: |
             An iterator over the elements in this list in proper sequence
+  - id: 23
+    name: listIterator
     since: 2.0
-    id: 22
-  - name: listIterator
     doc: |
       Returns a list iterator over the elements in this list (in proper sequence), starting at the specified position
       in the list. The specified index indicates the first element that would be returned by an initial call to
@@ -732,5 +734,3 @@ methods:
           doc: |
             a list iterator over the elements in this list (in proper
             sequence), starting at the specified position in the list
-    since: 2.0
-    id: 23

--- a/protocol-definitions/Lock.yaml
+++ b/protocol-definitions/Lock.yaml
@@ -6,7 +6,6 @@ methods:
     doc: |
       Returns whether this lock is locked or not.
     request:
-      id: 0x0701
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -18,7 +17,6 @@ methods:
           doc: |
             Name of the Lock
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -27,11 +25,11 @@ methods:
           doc: |
             True if this lock is locked, false otherwise.
     since: 2.0
+    id: 1
   - name: isLockedByCurrentThread
     doc: |
       Returns whether this lock is locked by current thread or not.
     request:
-      id: 0x0702
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -49,7 +47,6 @@ methods:
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -58,11 +55,11 @@ methods:
           doc: |
             True if this lock is locked by current thread, false otherwise.
     since: 2.0
+    id: 2
   - name: getLockCount
     doc: |
       Returns re-entrant lock hold count, regardless of lock ownership.
     request:
-      id: 0x0703
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -74,7 +71,6 @@ methods:
           doc: |
             Name of the Lock
     response:
-      id: 0x0066
       params:
         - name: response
           type: int
@@ -83,11 +79,11 @@ methods:
           doc: |
             The lock hold count.
     since: 2.0
+    id: 3
   - name: getRemainingLeaseTime
     doc: |
       Returns remaining lease time in milliseconds. If the lock is not locked then -1 will be returned
     request:
-      id: 0x0704
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -99,7 +95,6 @@ methods:
           doc: |
             Name of the Lock
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -108,13 +103,13 @@ methods:
           doc: |
             Remaining lease time in milliseconds.
     since: 2.0
+    id: 4
   - name: lock
     doc: |
       Acquires the lock for the specified lease time.After lease time, lock will be released.If the lock is not
       available then the current thread becomes disabled for thread scheduling purposes and lies dormant until the lock
       has been acquired.
     request:
-      id: 0x0705
       retryable: true
       acquiresResource: true
       partitionIdentifier: name
@@ -143,14 +138,13 @@ methods:
           since: 2.0
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 5
   - name: unlock
     doc: |
       Releases the lock.
     request:
-      id: 0x0706
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -173,15 +167,14 @@ methods:
           since: 2.0
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 6
   - name: forceUnlock
     doc: |
       Releases the lock regardless of the lock owner. It always successfully unlocks, never blocks,
       and returns immediately.
     request:
-      id: 0x0707
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -198,9 +191,9 @@ methods:
           since: 2.0
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 7
   - name: tryLock
     doc: |
       Tries to acquire the lock for the specified lease time.After lease time, the lock will be released.
@@ -208,7 +201,6 @@ methods:
       dormant until one of two things happens: the lock is acquired by the current thread, or the specified waiting
       time elapses.
     request:
-      id: 0x0708
       retryable: true
       acquiresResource: true
       partitionIdentifier: name
@@ -244,7 +236,6 @@ methods:
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -253,3 +244,4 @@ methods:
           doc: |
             true if the lock was acquired and false if the waiting time elapsed before the lock was acquired.
     since: 2.0
+    id: 8

--- a/protocol-definitions/Lock.yaml
+++ b/protocol-definitions/Lock.yaml
@@ -1,6 +1,5 @@
 id: 7
 name: Lock
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: isLocked

--- a/protocol-definitions/Lock.yaml
+++ b/protocol-definitions/Lock.yaml
@@ -2,7 +2,9 @@ id: 7
 name: Lock
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: isLocked
+  - id: 1
+    name: isLocked
+    since: 2.0
     doc: |
       Returns whether this lock is locked or not.
     request:
@@ -24,9 +26,9 @@ methods:
           since: 2.0
           doc: |
             True if this lock is locked, false otherwise.
+  - id: 2
+    name: isLockedByCurrentThread
     since: 2.0
-    id: 1
-  - name: isLockedByCurrentThread
     doc: |
       Returns whether this lock is locked by current thread or not.
     request:
@@ -54,9 +56,9 @@ methods:
           since: 2.0
           doc: |
             True if this lock is locked by current thread, false otherwise.
+  - id: 3
+    name: getLockCount
     since: 2.0
-    id: 2
-  - name: getLockCount
     doc: |
       Returns re-entrant lock hold count, regardless of lock ownership.
     request:
@@ -78,9 +80,9 @@ methods:
           since: 2.0
           doc: |
             The lock hold count.
+  - id: 4
+    name: getRemainingLeaseTime
     since: 2.0
-    id: 3
-  - name: getRemainingLeaseTime
     doc: |
       Returns remaining lease time in milliseconds. If the lock is not locked then -1 will be returned
     request:
@@ -102,9 +104,9 @@ methods:
           since: 2.0
           doc: |
             Remaining lease time in milliseconds.
+  - id: 5
+    name: lock
     since: 2.0
-    id: 4
-  - name: lock
     doc: |
       Acquires the lock for the specified lease time.After lease time, lock will be released.If the lock is not
       available then the current thread becomes disabled for thread scheduling purposes and lies dormant until the lock
@@ -139,9 +141,9 @@ methods:
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
     response: {}
+  - id: 6
+    name: unlock
     since: 2.0
-    id: 5
-  - name: unlock
     doc: |
       Releases the lock.
     request:
@@ -168,9 +170,9 @@ methods:
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
     response: {}
+  - id: 7
+    name: forceUnlock
     since: 2.0
-    id: 6
-  - name: forceUnlock
     doc: |
       Releases the lock regardless of the lock owner. It always successfully unlocks, never blocks,
       and returns immediately.
@@ -192,9 +194,9 @@ methods:
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
     response: {}
+  - id: 8
+    name: tryLock
     since: 2.0
-    id: 7
-  - name: tryLock
     doc: |
       Tries to acquire the lock for the specified lease time.After lease time, the lock will be released.
       If the lock is not available, then the current thread becomes disabled for thread scheduling purposes and lies
@@ -243,5 +245,3 @@ methods:
           since: 2.0
           doc: |
             true if the lock was acquired and false if the waiting time elapsed before the lock was acquired.
-    since: 2.0
-    id: 8

--- a/protocol-definitions/Map.yaml
+++ b/protocol-definitions/Map.yaml
@@ -2,7 +2,9 @@ id: 1
 name: Map
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: put
+  - id: 1
+    name: put
+    since: 2.0
     doc: |
       Puts an entry into this map with a given ttl (time to live) value.Entry will expire and get evicted after the ttl
       If ttl is 0, then the entry lives forever.This method returns a clone of the previous value, not the original
@@ -51,9 +53,9 @@ methods:
           since: 2.0
           doc: |
             old value of the entry
+  - id: 2
+    name: get
     since: 2.0
-    id: 1
-  - name: get
     doc: |
       This method returns a clone of the original value, so modifying the returned value does not change the actual
       value in the map. You should put the modified value back to make changes visible to all nodes.
@@ -88,9 +90,9 @@ methods:
           since: 2.0
           doc: |
             The value for the key if exists
+  - id: 3
+    name: remove
     since: 2.0
-    id: 2
-  - name: remove
     doc: |
       Removes the mapping for a key from this map if it is present (optional operation).
       Returns the value to which this map previously associated the key, or null if the map contained no mapping for the key.
@@ -128,9 +130,9 @@ methods:
           since: 2.0
           doc: |
             Clone of the removed value, not the original (identically equal) value previously put into the map.
+  - id: 4
+    name: replace
     since: 2.0
-    id: 3
-  - name: replace
     doc: |
       Replaces the entry for a key only if currently mapped to a given value.
     request:
@@ -170,9 +172,9 @@ methods:
           since: 2.0
           doc: |
             Clone of the previous value, not the original (identically equal) value previously put into the map.
+  - id: 5
+    name: replaceIfSame
     since: 2.0
-    id: 4
-  - name: replaceIfSame
     doc: |
       Replaces the the entry for a key only if existing values equal to the testValue
     request:
@@ -218,9 +220,9 @@ methods:
           since: 2.0
           doc: |
             true if value is replaced with new one, false otherwise
+  - id: 9
+    name: containsKey
     since: 2.0
-    id: 5
-  - name: containsKey
     doc: |
       Returns true if this map contains a mapping for the specified key.
     request:
@@ -254,9 +256,9 @@ methods:
           since: 2.0
           doc: |
             Returns true if the key exists, otherwise returns false.
+  - id: 10
+    name: containsValue
     since: 2.0
-    id: 9
-  - name: containsValue
     doc: |
       Returns true if this map maps one or more keys to the specified value.This operation will probably require time
       linear in the map size for most implementations of the Map interface.
@@ -285,9 +287,9 @@ methods:
           since: 2.0
           doc: |
             Returns true if the value exists, otherwise returns false.
+  - id: 11
+    name: removeIfSame
     since: 2.0
-    id: 10
-  - name: removeIfSame
     doc: |
       Removes the mapping for a key from this map if existing value equal to the this value
     request:
@@ -327,9 +329,9 @@ methods:
           since: 2.0
           doc: |
             Returns true if the key exists and removed, otherwise returns false.
+  - id: 12
+    name: delete
     since: 2.0
-    id: 11
-  - name: delete
     doc: |
       Removes the mapping for a key from this map if it is present.Unlike remove(Object), this operation does not return
       the removed value, which avoids the serialization cost of the returned value.If the removed value will not be used,
@@ -361,9 +363,9 @@ methods:
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response: {}
+  - id: 13
+    name: flush
     since: 2.0
-    id: 12
-  - name: flush
     doc: |
       If this map has a MapStore, this method flushes all the local dirty entries by calling MapStore.storeAll()
       and/or MapStore.deleteAll().
@@ -379,9 +381,9 @@ methods:
           doc: |
             Name of the map.
     response: {}
+  - id: 14
+    name: tryRemove
     since: 2.0
-    id: 13
-  - name: tryRemove
     doc: |
       Tries to remove the entry with the given key from this map within the specified timeout value.
       If the key is already locked by another thread and/or member, then this operation will wait the timeout
@@ -423,9 +425,9 @@ methods:
           since: 2.0
           doc: |
             Returns true if successful, otherwise returns false
+  - id: 15
+    name: tryPut
     since: 2.0
-    id: 14
-  - name: tryPut
     doc: |
       Tries to put the given key and value into this map within a specified timeout value. If this method returns false,
       it means that the caller thread could not acquire the lock for the key within the timeout duration,
@@ -473,9 +475,9 @@ methods:
           since: 2.0
           doc: |
             Returns true if successful, otherwise returns false
+  - id: 16
+    name: putTransient
     since: 2.0
-    id: 15
-  - name: putTransient
     doc: |
       Same as put except that MapStore, if defined, will not be called to store/persist the entry.
       If ttl is 0, then the entry lives forever.
@@ -515,9 +517,9 @@ methods:
           doc: |
             The duration in milliseconds after which this entry shall be deleted. O means infinite.
     response: {}
+  - id: 17
+    name: putIfAbsent
     since: 2.0
-    id: 16
-  - name: putIfAbsent
     doc: |
       Puts an entry into this map with a given ttl (time to live) value if the specified key is not already associated
       with a value. Entry will expire and get evicted after the ttl.
@@ -564,9 +566,9 @@ methods:
           since: 2.0
           doc: |
             returns a clone of the previous value, not the original (identically equal) value previously put into the map.
+  - id: 18
+    name: set
     since: 2.0
-    id: 17
-  - name: set
     doc: |
       Puts an entry into this map with a given ttl (time to live) value.Entry will expire and get evicted after the ttl
       If ttl is 0, then the entry lives forever. Similar to the put operation except that set doesn't
@@ -607,9 +609,9 @@ methods:
           doc: |
             The duration in milliseconds after which this entry shall be deleted. O means infinite.
     response: {}
+  - id: 19
+    name: lock
     since: 2.0
-    id: 18
-  - name: lock
     doc: |
       Acquires the lock for the specified lease time.After lease time, lock will be released.If the lock is not
       available then the current thread becomes disabled for thread scheduling purposes and lies dormant until the lock
@@ -652,9 +654,9 @@ methods:
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
     response: {}
+  - id: 20
+    name: tryLock
     since: 2.0
-    id: 19
-  - name: tryLock
     doc: |
       Tries to acquire the lock for the specified key for the specified lease time.After lease time, the lock will be
       released.If the lock is not available, then the current thread becomes disabled for thread scheduling
@@ -709,9 +711,9 @@ methods:
           since: 2.0
           doc: |
             Returns true if successful, otherwise returns false
+  - id: 21
+    name: isLocked
     since: 2.0
-    id: 20
-  - name: isLocked
     doc: |
       Checks the lock for the specified key.If the lock is acquired then returns true, else returns false.
     request:
@@ -739,9 +741,9 @@ methods:
           since: 2.0
           doc: |
             Returns true if the entry is locked, otherwise returns false
+  - id: 22
+    name: unlock
     since: 2.0
-    id: 21
-  - name: unlock
     doc: |
       Releases the lock for the specified key. It never blocks and returns immediately.
       If the current thread is the holder of this lock, then the hold count is decremented.If the hold count is zero,
@@ -777,9 +779,9 @@ methods:
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
     response: {}
+  - id: 23
+    name: addInterceptor
     since: 2.0
-    id: 22
-  - name: addInterceptor
     doc: |
       Adds an interceptor for this map. Added interceptor will intercept operations
       and execute user defined methods and will cancel operations if user defined method throw exception.
@@ -808,9 +810,9 @@ methods:
           since: 2.0
           doc: |
             id of registered interceptor.
+  - id: 24
+    name: removeInterceptor
     since: 2.0
-    id: 23
-  - name: removeInterceptor
     doc: |
       Removes the given interceptor for this map so it will not intercept operations anymore.
     request:
@@ -838,9 +840,9 @@ methods:
           since: 2.0
           doc: |
             Returns true if successful, otherwise returns false
+  - id: 25
+    name: addEntryListenerToKeyWithPredicate
     since: 2.0
-    id: 24
-  - name: addEntryListenerToKeyWithPredicate
     doc: |
       Adds a MapListener for this map. To receive an event, you should implement a corresponding MapListener
       sub-interface for that event.
@@ -939,9 +941,9 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
+  - id: 26
+    name: addEntryListenerWithPredicate
     since: 2.0
-    id: 25
-  - name: addEntryListenerWithPredicate
     doc: |
       Adds an continuous entry listener for this map. Listener will get notified for map add/remove/update/evict events
       filtered by the given predicate.
@@ -1034,9 +1036,9 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
+  - id: 27
+    name: addEntryListenerToKey
     since: 2.0
-    id: 26
-  - name: addEntryListenerToKey
     doc: |
       Adds a MapListener for this map. To receive an event, you should implement a corresponding MapListener
       sub-interface for that event.
@@ -1128,9 +1130,9 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
+  - id: 28
+    name: addEntryListener
     since: 2.0
-    id: 27
-  - name: addEntryListener
     doc: |
       Adds a MapListener for this map. To receive an event, you should implement a corresponding MapListener
       sub-interface for that event.
@@ -1216,9 +1218,9 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
+  - id: 29
+    name: addNearCacheEntryListener
     since: 2.0
-    id: 28
-  - name: addNearCacheEntryListener
     doc: |
       Adds an entry listener for this map. Listener will get notified for all map add/remove/update/evict events.
     request:
@@ -1305,9 +1307,9 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
+  - id: 30
+    name: removeEntryListener
     since: 2.0
-    id: 29
-  - name: removeEntryListener
     doc: |
       Removes the specified entry listener. Returns silently if there is no such listener added before.
     request:
@@ -1335,9 +1337,9 @@ methods:
           since: 2.0
           doc: |
             true if registration is removed, false otherwise.
+  - id: 31
+    name: addPartitionLostListener
     since: 2.0
-    id: 30
-  - name: addPartitionLostListener
     doc: |
       Adds a MapPartitionLostListener. The addPartitionLostListener returns a register-id. This id is needed to remove
       the MapPartitionLostListener using the removePartitionLostListener(String) method.
@@ -1385,9 +1387,9 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
+  - id: 32
+    name: removePartitionLostListener
     since: 2.0
-    id: 31
-  - name: removePartitionLostListener
     doc: |
       Removes the specified map partition lost listener. Returns silently if there is no such listener added before.
     request:
@@ -1415,9 +1417,9 @@ methods:
           since: 2.0
           doc: |
             true if registration is removed, false otherwise.
+  - id: 33
+    name: getEntryView
     since: 2.0
-    id: 32
-  - name: getEntryView
     doc: |
       Returns the EntryView for the specified key.
       This method returns a clone of original mapping, modifying the returned value does not change the actual value
@@ -1459,9 +1461,9 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
+  - id: 34
+    name: evict
     since: 2.0
-    id: 33
-  - name: evict
     doc: |
       Evicts the specified key from this map. If a MapStore is defined for this map, then the entry is not deleted
       from the underlying MapStore, evict only removes the entry from the memory.
@@ -1496,9 +1498,9 @@ methods:
           since: 2.0
           doc: |
             true if the key is evicted, false otherwise.
+  - id: 35
+    name: evictAll
     since: 2.0
-    id: 34
-  - name: evictAll
     doc: |
       Evicts all keys from this map except the locked ones. If a MapStore is defined for this map, deleteAll is not
       called by this method. If you do want to deleteAll to be called use the clear method. The EVICT_ALL event is
@@ -1515,9 +1517,9 @@ methods:
           doc: |
             name of map
     response: {}
+  - id: 36
+    name: loadAll
     since: 2.0
-    id: 35
-  - name: loadAll
     doc: |
       Loads all keys into the store. This is a batch load operation so that an implementation can optimize the multiple loads.
     request:
@@ -1539,9 +1541,9 @@ methods:
             when <code>true</code>, existing values in the Map will
             be replaced by those loaded from the MapLoader
     response: {}
+  - id: 37
+    name: loadGivenKeys
     since: 2.0
-    id: 36
-  - name: loadGivenKeys
     doc: |
       Loads the given keys. This is a batch load operation so that an implementation can optimize the multiple loads.
     request:
@@ -1568,9 +1570,9 @@ methods:
           doc: |
             when <code>true</code>, existing values in the Map will be replaced by those loaded from the MapLoader
     response: {}
+  - id: 38
+    name: keySet
     since: 2.0
-    id: 37
-  - name: keySet
     doc: |
       Returns a set clone of the keys contained in this map. The set is NOT backed by the map, so changes to the map
       are NOT reflected in the set, and vice-versa. This method is always executed by a distributed query, so it may
@@ -1594,9 +1596,9 @@ methods:
           since: 2.0
           doc: |
             a set clone of the keys contained in this map.
+  - id: 39
+    name: getAll
     since: 2.0
-    id: 38
-  - name: getAll
     doc: |
       Returns the entries for the given keys. If any keys are not present in the Map, it will call loadAll The returned
       map is NOT backed by the original map, so changes to the original map are NOT reflected in the returned map, and vice-versa.
@@ -1628,9 +1630,9 @@ methods:
           since: 2.0
           doc: |
             values for the provided keys.
+  - id: 40
+    name: values
     since: 2.0
-    id: 39
-  - name: values
     doc: |
       Returns a collection clone of the values contained in this map.
       The collection is NOT backed by the map, so changes to the map are NOT reflected in the collection, and vice-versa.
@@ -1655,9 +1657,9 @@ methods:
           since: 2.0
           doc: |
             All values in the map
+  - id: 41
+    name: entrySet
     since: 2.0
-    id: 40
-  - name: entrySet
     doc: |
       Returns a Set clone of the mappings contained in this map.
       The collection is NOT backed by the map, so changes to the map are NOT reflected in the collection, and vice-versa.
@@ -1682,9 +1684,9 @@ methods:
           since: 2.0
           doc: |
             a set clone of the keys mappings in this map
+  - id: 42
+    name: keySetWithPredicate
     since: 2.0
-    id: 41
-  - name: keySetWithPredicate
     doc: |
       Queries the map based on the specified predicate and returns the keys of matching entries. Specified predicate
       runs on all members in parallel.The set is NOT backed by the map, so changes to the map are NOT reflected in the
@@ -1715,9 +1717,9 @@ methods:
           since: 2.0
           doc: |
             result key set for the query.
+  - id: 43
+    name: valuesWithPredicate
     since: 2.0
-    id: 42
-  - name: valuesWithPredicate
     doc: |
       Queries the map based on the specified predicate and returns the values of matching entries.Specified predicate
       runs on all members in parallel. The collection is NOT backed by the map, so changes to the map are NOT reflected
@@ -1748,9 +1750,9 @@ methods:
           since: 2.0
           doc: |
             result value collection of the query.
+  - id: 44
+    name: entriesWithPredicate
     since: 2.0
-    id: 43
-  - name: entriesWithPredicate
     doc: |
       Queries the map based on the specified predicate and returns the matching entries.Specified predicate
       runs on all members in parallel. The collection is NOT backed by the map, so changes to the map are NOT reflected
@@ -1781,9 +1783,9 @@ methods:
           since: 2.0
           doc: |
             result key-value entry collection of the query.
+  - id: 45
+    name: addIndex
     since: 2.0
-    id: 44
-  - name: addIndex
     doc: |
       Adds an index to this map for the specified entries so that queries can run faster.If you are querying your values
       mostly based on age and active then you should consider indexing these fields.
@@ -1817,9 +1819,9 @@ methods:
           doc: |
             true if index should be ordered, false otherwise.
     response: {}
+  - id: 46
+    name: size
     since: 2.0
-    id: 45
-  - name: size
     doc: |
       Returns the number of key-value mappings in this map.  If the map contains more than Integer.MAX_VALUE elements,
       returns Integer.MAX_VALUE
@@ -1842,9 +1844,9 @@ methods:
           since: 2.0
           doc: |
             the number of key-value mappings in this map
+  - id: 47
+    name: isEmpty
     since: 2.0
-    id: 46
-  - name: isEmpty
     doc: |
       Returns true if this map contains no key-value mappings.
     request:
@@ -1866,9 +1868,9 @@ methods:
           since: 2.0
           doc: |
             true if this map contains no key-value mappings
+  - id: 48
+    name: putAll
     since: 2.0
-    id: 47
-  - name: putAll
     doc: |
       Copies all of the mappings from the specified map to this map (optional operation).The effect of this call is
       equivalent to that of calling put(Object,Object) put(k, v) on this map once for each mapping from key k to value
@@ -1895,9 +1897,9 @@ methods:
           doc: |
             mappings to be stored in this map
     response: {}
+  - id: 49
+    name: clear
     since: 2.0
-    id: 48
-  - name: clear
     doc: |
       This method clears the map and invokes MapStore#deleteAll deleteAll on MapStore which, if connected to a database,
       will delete the records from that database. The MAP_CLEARED event is fired for any registered listeners.
@@ -1914,9 +1916,9 @@ methods:
           doc: |
             of map
     response: {}
+  - id: 50
+    name: executeOnKey
     since: 2.0
-    id: 49
-  - name: executeOnKey
     doc: |
       Applies the user defined EntryProcessor to the entry mapped by the key. Returns the the object which is result of
       the process() method of EntryProcessor.
@@ -1957,9 +1959,9 @@ methods:
           since: 2.0
           doc: |
             result of entry process.
+  - id: 51
+    name: submitToKey
     since: 2.0
-    id: 50
-  - name: submitToKey
     doc: |
       Applies the user defined EntryProcessor to the entry mapped by the key. Returns immediately with a Future
       representing that task.EntryProcessor is not cancellable, so calling Future.cancel() method won't cancel the
@@ -2001,9 +2003,9 @@ methods:
           since: 2.0
           doc: |
             result of entry process.
+  - id: 52
+    name: executeOnAllKeys
     since: 2.0
-    id: 51
-  - name: executeOnAllKeys
     doc: |
       Applies the user defined EntryProcessor to the all entries in the map.Returns the results mapped by each key in the map.
     request:
@@ -2031,9 +2033,9 @@ methods:
           since: 2.0
           doc: |
             results of entry process on the entries
+  - id: 53
+    name: executeWithPredicate
     since: 2.0
-    id: 52
-  - name: executeWithPredicate
     doc: |
       Applies the user defined EntryProcessor to the entries in the map which satisfies provided predicate.
       Returns the results mapped by each key in the map.
@@ -2068,9 +2070,9 @@ methods:
           since: 2.0
           doc: |
             results of entry process on the entries matching the query criteria
+  - id: 54
+    name: executeOnKeys
     since: 2.0
-    id: 53
-  - name: executeOnKeys
     doc: |
       Applies the user defined EntryProcessor to the entries mapped by the collection of keys.The results mapped by
       each key in the collection.
@@ -2105,9 +2107,9 @@ methods:
           since: 2.0
           doc: |
             results of entry process on the entries with the provided keys
+  - id: 55
+    name: forceUnlock
     since: 2.0
-    id: 54
-  - name: forceUnlock
     doc: |
       Releases the lock for the specified key regardless of the lock owner.It always successfully unlocks the key,
       never blocks,and returns immediately.
@@ -2135,9 +2137,9 @@ methods:
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
     response: {}
+  - id: 56
+    name: keySetWithPagingPredicate
     since: 2.0
-    id: 55
-  - name: keySetWithPagingPredicate
     doc: |
       TODO DOC
     request:
@@ -2165,9 +2167,9 @@ methods:
           since: 2.0
           doc: |
             result keys for the query.
+  - id: 57
+    name: valuesWithPagingPredicate
     since: 2.0
-    id: 56
-  - name: valuesWithPagingPredicate
     doc: |
       Queries the map based on the specified predicate and returns the values of matching entries. Specified predicate
       runs on all members in parallel. The collection is NOT backed by the map, so changes to the map are NOT reflected
@@ -2198,9 +2200,9 @@ methods:
           since: 2.0
           doc: |
             values for the query.
+  - id: 58
+    name: entriesWithPagingPredicate
     since: 2.0
-    id: 57
-  - name: entriesWithPagingPredicate
     doc: |
       TODO DOC
     request:
@@ -2228,9 +2230,9 @@ methods:
           since: 2.0
           doc: |
             key-value pairs for the query.
+  - id: 59
+    name: clearNearCache
     since: 2.0
-    id: 58
-  - name: clearNearCache
     doc: |
       TODO DOC
     request:
@@ -2251,9 +2253,9 @@ methods:
           doc: |
             TODO DOC
     response: {}
+  - id: 60
+    name: fetchKeys
     since: 2.0
-    id: 59
-  - name: fetchKeys
     doc: |
       Fetches specified number of keys from the specified partition starting from specified table index.
     request:
@@ -2293,9 +2295,9 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
+  - id: 61
+    name: fetchEntries
     since: 2.0
-    id: 60
-  - name: fetchEntries
     doc: |
       Fetches specified number of entries from the specified partition starting from specified table index.
     request:
@@ -2335,9 +2337,9 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
+  - id: 62
+    name: aggregate
     since: 2.0
-    id: 61
-  - name: aggregate
     doc: |
       Applies the aggregation logic on all map entries and returns the result
     request:
@@ -2365,9 +2367,9 @@ methods:
           since: 2.0
           doc: |
             the aggregation result
+  - id: 63
+    name: aggregateWithPredicate
     since: 2.0
-    id: 62
-  - name: aggregateWithPredicate
     doc: |
       Applies the aggregation logic on map entries filtered with the Predicate and returns the result
     request:
@@ -2401,9 +2403,9 @@ methods:
           since: 2.0
           doc: |
             the aggregation result
+  - id: 64
+    name: project
     since: 2.0
-    id: 63
-  - name: project
     doc: |
       Applies the projection logic on all map entries and returns the result
     request:
@@ -2431,9 +2433,9 @@ methods:
           since: 2.0
           doc: |
             the resulted collection upon transformation to the type of the projection
+  - id: 65
+    name: projectWithPredicate
     since: 2.0
-    id: 64
-  - name: projectWithPredicate
     doc: |
       Applies the projection logic on map entries filtered with the Predicate and returns the result
     request:
@@ -2467,9 +2469,9 @@ methods:
           since: 2.0
           doc: |
             the resulted collection upon transformation to the type of the projection
+  - id: 66
+    name: fetchNearCacheInvalidationMetadata
     since: 2.0
-    id: 65
-  - name: fetchNearCacheInvalidationMetadata
     doc: |
       Fetches invalidation metadata from partitions of map.
     request:
@@ -2503,9 +2505,9 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
+  - id: 67
+    name: assignAndGetUuids
     since: 2.0
-    id: 66
-  - name: assignAndGetUuids
     doc: |
       TODO DOC
     request:
@@ -2520,9 +2522,9 @@ methods:
           since: 2.0
           doc: |
             partitionId to assigned uuid entry list
+  - id: 68
+    name: removeAll
     since: 2.0
-    id: 67
-  - name: removeAll
     doc: |
       Removes all entries which match with the supplied predicate
     request:
@@ -2543,9 +2545,9 @@ methods:
           doc: |
             used to select entries to be removed from map.
     response: {}
+  - id: 69
+    name: addNearCacheInvalidationListener
     since: 2.0
-    id: 68
-  - name: addNearCacheInvalidationListener
     doc: |
       Adds listener to map. This listener will be used to listen near cache invalidation events.
       Eventually consistent client near caches should use this method to add invalidation listeners
@@ -2634,9 +2636,9 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
+  - id: 70
+    name: fetchWithQuery
     since: 2.0
-    id: 69
-  - name: fetchWithQuery
     doc: |
       Fetches the specified number of entries from the specified partition starting from specified table index
       that match the predicate and applies the projection logic on them.
@@ -2689,9 +2691,9 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
+  - id: 71
+    name: eventJournalSubscribe
     since: 2.0
-    id: 70
-  - name: eventJournalSubscribe
     doc: |
       Performs the initial subscription to the map event journal.
       This includes retrieving the event journal sequences of the
@@ -2721,9 +2723,9 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
+  - id: 72
+    name: eventJournalRead
     since: 2.0
-    id: 71
-  - name: eventJournalRead
     doc: |
       Reads from the map event journal in batches. You may specify the start sequence,
       the minumum required number of items in the response, the maximum number of items
@@ -2800,9 +2802,9 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
+  - id: 73
+    name: setTtl
     since: 2.0
-    id: 72
-  - name: setTtl
     doc: |
       Updates TTL (time to live) value of the entry specified by {@code key} with a new TTL value.
       New TTL value is valid from this operation is invoked, not from the original creation of the entry.
@@ -2848,9 +2850,9 @@ methods:
           since: 2.0
           doc: |
             'true' if the entry is affected, 'false' otherwise
+  - id: 74
+    name: putWithMaxIdle
     since: 2.0
-    id: 73
-  - name: putWithMaxIdle
     doc: |
       Puts an entry into this map with a given ttl (time to live) value.Entry will expire and get evicted after the ttl
       If ttl is 0, then the entry lives forever.This method returns a clone of the previous value, not the original
@@ -2906,9 +2908,9 @@ methods:
           since: 2.0
           doc: |
             old value of the entry
+  - id: 75
+    name: putTransientWithMaxIdle
     since: 2.0
-    id: 74
-  - name: putTransientWithMaxIdle
     doc: |
       Same as put except that MapStore, if defined, will not be called to store/persist the entry.
       If ttl and maxIdle are 0, then the entry lives forever.
@@ -2962,9 +2964,9 @@ methods:
           since: 2.0
           doc: |
             old value of the entry
+  - id: 76
+    name: putIfAbsentWithMaxIdle
     since: 2.0
-    id: 75
-  - name: putIfAbsentWithMaxIdle
     doc: |
       Puts an entry into this map with a given ttl (time to live) value if the specified key is not already associated
       with a value. Entry will expire and get evicted after the ttl or maxIdle, whichever comes first.
@@ -3018,9 +3020,9 @@ methods:
           since: 2.0
           doc: |
             old value of the entry
+  - id: 77
+    name: setWithMaxIdle
     since: 2.0
-    id: 76
-  - name: setWithMaxIdle
     doc: |
       Puts an entry into this map with a given ttl (time to live) value and maxIdle.
       Entry will expire and get evicted after the ttl or maxIdle, whichever comes first.
@@ -3077,5 +3079,3 @@ methods:
           since: 2.0
           doc: |
             old value of the entry
-    since: 2.0
-    id: 77

--- a/protocol-definitions/Map.yaml
+++ b/protocol-definitions/Map.yaml
@@ -1,6 +1,5 @@
 id: 1
 name: Map
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: put

--- a/protocol-definitions/Map.yaml
+++ b/protocol-definitions/Map.yaml
@@ -9,7 +9,6 @@ methods:
       (identically equal) value previously put into the map.Time resolution for TTL is seconds. The given TTL value is
       rounded to the next closest second value.
     request:
-      id: 0x0101
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -45,7 +44,6 @@ methods:
           doc: |
             The duration in milliseconds after which this entry shall be deleted. O means infinite.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -54,12 +52,12 @@ methods:
           doc: |
             old value of the entry
     since: 2.0
+    id: 1
   - name: get
     doc: |
       This method returns a clone of the original value, so modifying the returned value does not change the actual
       value in the map. You should put the modified value back to make changes visible to all nodes.
     request:
-      id: 0x0102
       retryable: true
       acquiresResource: false
       partitionIdentifier: key
@@ -83,7 +81,6 @@ methods:
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -92,6 +89,7 @@ methods:
           doc: |
             The value for the key if exists
     since: 2.0
+    id: 2
   - name: remove
     doc: |
       Removes the mapping for a key from this map if it is present (optional operation).
@@ -100,7 +98,6 @@ methods:
       possible that the map explicitly mapped the key to null. The map will not contain a mapping for the specified key once the
       call returns.
     request:
-      id: 0x0103
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -124,7 +121,6 @@ methods:
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -133,11 +129,11 @@ methods:
           doc: |
             Clone of the removed value, not the original (identically equal) value previously put into the map.
     since: 2.0
+    id: 3
   - name: replace
     doc: |
       Replaces the entry for a key only if currently mapped to a given value.
     request:
-      id: 0x0104
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -167,7 +163,6 @@ methods:
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -176,11 +171,11 @@ methods:
           doc: |
             Clone of the previous value, not the original (identically equal) value previously put into the map.
     since: 2.0
+    id: 4
   - name: replaceIfSame
     doc: |
       Replaces the the entry for a key only if existing values equal to the testValue
     request:
-      id: 0x0105
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -216,7 +211,6 @@ methods:
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -225,11 +219,11 @@ methods:
           doc: |
             true if value is replaced with new one, false otherwise
     since: 2.0
+    id: 5
   - name: containsKey
     doc: |
       Returns true if this map contains a mapping for the specified key.
     request:
-      id: 0x0109
       retryable: true
       acquiresResource: false
       partitionIdentifier: key
@@ -253,7 +247,6 @@ methods:
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -262,12 +255,12 @@ methods:
           doc: |
             Returns true if the key exists, otherwise returns false.
     since: 2.0
+    id: 9
   - name: containsValue
     doc: |
       Returns true if this map maps one or more keys to the specified value.This operation will probably require time
       linear in the map size for most implementations of the Map interface.
     request:
-      id: 0x010a
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -285,7 +278,6 @@ methods:
           doc: |
             Value to check if exists in the map.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -294,11 +286,11 @@ methods:
           doc: |
             Returns true if the value exists, otherwise returns false.
     since: 2.0
+    id: 10
   - name: removeIfSame
     doc: |
       Removes the mapping for a key from this map if existing value equal to the this value
     request:
-      id: 0x010b
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -328,7 +320,6 @@ methods:
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -337,6 +328,7 @@ methods:
           doc: |
             Returns true if the key exists and removed, otherwise returns false.
     since: 2.0
+    id: 11
   - name: delete
     doc: |
       Removes the mapping for a key from this map if it is present.Unlike remove(Object), this operation does not return
@@ -346,7 +338,6 @@ methods:
       This method breaks the contract of EntryListener. When an entry is removed by delete(), it fires an EntryEvent
       with a null oldValue. Also, a listener with predicates will have null values, so only keys can be queried via predicates
     request:
-      id: 0x010c
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -369,15 +360,14 @@ methods:
           since: 2.0
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 12
   - name: flush
     doc: |
       If this map has a MapStore, this method flushes all the local dirty entries by calling MapStore.storeAll()
       and/or MapStore.deleteAll().
     request:
-      id: 0x010d
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -388,16 +378,15 @@ methods:
           since: 2.0
           doc: |
             Name of the map.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 13
   - name: tryRemove
     doc: |
       Tries to remove the entry with the given key from this map within the specified timeout value.
       If the key is already locked by another thread and/or member, then this operation will wait the timeout
       amount for acquiring the lock.
     request:
-      id: 0x010e
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -427,7 +416,6 @@ methods:
           doc: |
             maximum time in milliseconds to wait for acquiring the lock for the key.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -436,13 +424,13 @@ methods:
           doc: |
             Returns true if successful, otherwise returns false
     since: 2.0
+    id: 14
   - name: tryPut
     doc: |
       Tries to put the given key and value into this map within a specified timeout value. If this method returns false,
       it means that the caller thread could not acquire the lock for the key within the timeout duration,
       thus the put operation is not successful.
     request:
-      id: 0x010f
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -478,7 +466,6 @@ methods:
           doc: |
             maximum time in milliseconds to wait for acquiring the lock for the key.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -487,12 +474,12 @@ methods:
           doc: |
             Returns true if successful, otherwise returns false
     since: 2.0
+    id: 15
   - name: putTransient
     doc: |
       Same as put except that MapStore, if defined, will not be called to store/persist the entry.
       If ttl is 0, then the entry lives forever.
     request:
-      id: 0x0110
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -527,15 +514,14 @@ methods:
           since: 2.0
           doc: |
             The duration in milliseconds after which this entry shall be deleted. O means infinite.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 16
   - name: putIfAbsent
     doc: |
       Puts an entry into this map with a given ttl (time to live) value if the specified key is not already associated
       with a value. Entry will expire and get evicted after the ttl.
     request:
-      id: 0x0111
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -571,7 +557,6 @@ methods:
           doc: |
             The duration in milliseconds after which this entry shall be deleted. O means infinite.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -580,13 +565,13 @@ methods:
           doc: |
             returns a clone of the previous value, not the original (identically equal) value previously put into the map.
     since: 2.0
+    id: 17
   - name: set
     doc: |
       Puts an entry into this map with a given ttl (time to live) value.Entry will expire and get evicted after the ttl
       If ttl is 0, then the entry lives forever. Similar to the put operation except that set doesn't
       return the old value, which is more efficient.
     request:
-      id: 0x0112
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -621,9 +606,9 @@ methods:
           since: 2.0
           doc: |
             The duration in milliseconds after which this entry shall be deleted. O means infinite.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 18
   - name: lock
     doc: |
       Acquires the lock for the specified lease time.After lease time, lock will be released.If the lock is not
@@ -632,7 +617,6 @@ methods:
       Scope of the lock is this map only. Acquired lock is only for the key in this map. Locks are re-entrant,
       so if the key is locked N times then it should be unlocked N times before another thread can acquire it.
     request:
-      id: 0x0113
       retryable: true
       acquiresResource: true
       partitionIdentifier: key
@@ -667,9 +651,9 @@ methods:
           since: 2.0
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 19
   - name: tryLock
     doc: |
       Tries to acquire the lock for the specified key for the specified lease time.After lease time, the lock will be
@@ -677,7 +661,6 @@ methods:
       purposes and lies dormant until one of two things happens the lock is acquired by the current thread, or
       the specified waiting time elapses.
     request:
-      id: 0x0114
       retryable: true
       acquiresResource: true
       partitionIdentifier: key
@@ -719,7 +702,6 @@ methods:
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -728,11 +710,11 @@ methods:
           doc: |
             Returns true if successful, otherwise returns false
     since: 2.0
+    id: 20
   - name: isLocked
     doc: |
       Checks the lock for the specified key.If the lock is acquired then returns true, else returns false.
     request:
-      id: 0x0115
       retryable: true
       acquiresResource: false
       partitionIdentifier: key
@@ -750,7 +732,6 @@ methods:
           doc: |
             Key for the map entry to check if it is locked.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -759,6 +740,7 @@ methods:
           doc: |
             Returns true if the entry is locked, otherwise returns false
     since: 2.0
+    id: 21
   - name: unlock
     doc: |
       Releases the lock for the specified key. It never blocks and returns immediately.
@@ -766,7 +748,6 @@ methods:
       then the lock is released.  If the current thread is not the holder of this lock,
       then ILLEGAL_MONITOR_STATE is thrown.
     request:
-      id: 0x0116
       retryable: true
       acquiresResource: false
       partitionIdentifier: key
@@ -795,15 +776,14 @@ methods:
           since: 2.0
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 22
   - name: addInterceptor
     doc: |
       Adds an interceptor for this map. Added interceptor will intercept operations
       and execute user defined methods and will cancel operations if user defined method throw exception.
     request:
-      id: 0x0117
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -821,7 +801,6 @@ methods:
           doc: |
             interceptor to add
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -830,11 +809,11 @@ methods:
           doc: |
             id of registered interceptor.
     since: 2.0
+    id: 23
   - name: removeInterceptor
     doc: |
       Removes the given interceptor for this map so it will not intercept operations anymore.
     request:
-      id: 0x0118
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -852,7 +831,6 @@ methods:
           doc: |
             of interceptor
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -861,12 +839,12 @@ methods:
           doc: |
             Returns true if successful, otherwise returns false
     since: 2.0
+    id: 24
   - name: addEntryListenerToKeyWithPredicate
     doc: |
       Adds a MapListener for this map. To receive an event, you should implement a corresponding MapListener
       sub-interface for that event.
     request:
-      id: 0x0119
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -909,7 +887,6 @@ methods:
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -918,8 +895,7 @@ methods:
           doc: |
             A unique string which is used as a key to remove the listener.
     events:
-      - id: 0x00cb
-        name: Entry
+      - name: Entry
         params:
           - name: key
             type: Data
@@ -964,12 +940,12 @@ methods:
             doc: |
               TODO DOC
     since: 2.0
+    id: 25
   - name: addEntryListenerWithPredicate
     doc: |
       Adds an continuous entry listener for this map. Listener will get notified for map add/remove/update/evict events
       filtered by the given predicate.
     request:
-      id: 0x011a
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -1006,7 +982,6 @@ methods:
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -1015,8 +990,7 @@ methods:
           doc: |
             A unique string which is used as a key to remove the listener.
     events:
-      - id: 0x00cb
-        name: Entry
+      - name: Entry
         params:
           - name: key
             type: Data
@@ -1061,12 +1035,12 @@ methods:
             doc: |
               TODO DOC
     since: 2.0
+    id: 26
   - name: addEntryListenerToKey
     doc: |
       Adds a MapListener for this map. To receive an event, you should implement a corresponding MapListener
       sub-interface for that event.
     request:
-      id: 0x011b
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -1102,7 +1076,6 @@ methods:
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -1111,8 +1084,7 @@ methods:
           doc: |
             A unique string which is used as a key to remove the listener.
     events:
-      - id: 0x00cb
-        name: Entry
+      - name: Entry
         params:
           - name: key
             type: Data
@@ -1157,12 +1129,12 @@ methods:
             doc: |
               TODO DOC
     since: 2.0
+    id: 27
   - name: addEntryListener
     doc: |
       Adds a MapListener for this map. To receive an event, you should implement a corresponding MapListener
       sub-interface for that event.
     request:
-      id: 0x011c
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -1192,7 +1164,6 @@ methods:
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -1201,8 +1172,7 @@ methods:
           doc: |
             A unique string which is used as a key to remove the listener.
     events:
-      - id: 0x00cb
-        name: Entry
+      - name: Entry
         params:
           - name: key
             type: Data
@@ -1247,11 +1217,11 @@ methods:
             doc: |
               TODO DOC
     since: 2.0
+    id: 28
   - name: addNearCacheEntryListener
     doc: |
       Adds an entry listener for this map. Listener will get notified for all map add/remove/update/evict events.
     request:
-      id: 0x011d
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -1275,7 +1245,6 @@ methods:
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -1284,8 +1253,7 @@ methods:
           doc: |
             A unique string which is used as a key to remove the listener.
     events:
-      - id: 0x00d7
-        name: IMapInvalidation
+      - name: IMapInvalidation
         params:
           - name: key
             type: Data
@@ -1311,8 +1279,7 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
-      - id: 0x00d8
-        name: IMapBatchInvalidation
+      - name: IMapBatchInvalidation
         params:
           - name: keys
             type: List_Data
@@ -1339,11 +1306,11 @@ methods:
             doc: |
               TODO DOC
     since: 2.0
+    id: 29
   - name: removeEntryListener
     doc: |
       Removes the specified entry listener. Returns silently if there is no such listener added before.
     request:
-      id: 0x011e
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -1361,7 +1328,6 @@ methods:
           doc: |
             id of registered listener.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -1370,6 +1336,7 @@ methods:
           doc: |
             true if registration is removed, false otherwise.
     since: 2.0
+    id: 30
   - name: addPartitionLostListener
     doc: |
       Adds a MapPartitionLostListener. The addPartitionLostListener returns a register-id. This id is needed to remove
@@ -1379,7 +1346,6 @@ methods:
       IMPORTANT: Listeners registered from HazelcastClient may miss some of the map partition lost events due
       to design limitations.
     request:
-      id: 0x011f
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -1397,7 +1363,6 @@ methods:
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -1406,8 +1371,7 @@ methods:
           doc: |
             returns the registration id for the MapPartitionLostListener.
     events:
-      - id: 0x00d1
-        name: MapPartitionLost
+      - name: MapPartitionLost
         params:
           - name: partitionId
             type: int
@@ -1422,11 +1386,11 @@ methods:
             doc: |
               TODO DOC
     since: 2.0
+    id: 31
   - name: removePartitionLostListener
     doc: |
       Removes the specified map partition lost listener. Returns silently if there is no such listener added before.
     request:
-      id: 0x0120
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -1444,7 +1408,6 @@ methods:
           doc: |
             id of register
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -1453,13 +1416,13 @@ methods:
           doc: |
             true if registration is removed, false otherwise.
     since: 2.0
+    id: 32
   - name: getEntryView
     doc: |
       Returns the EntryView for the specified key.
       This method returns a clone of original mapping, modifying the returned value does not change the actual value
       in the map. One should put modified value back to make changes visible to all nodes.
     request:
-      id: 0x0121
       retryable: true
       acquiresResource: false
       partitionIdentifier: key
@@ -1483,7 +1446,6 @@ methods:
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
-      id: 0x006f
       params:
         - name: response
           type: SimpleEntryView
@@ -1498,12 +1460,12 @@ methods:
           doc: |
             TODO DOC
     since: 2.0
+    id: 33
   - name: evict
     doc: |
       Evicts the specified key from this map. If a MapStore is defined for this map, then the entry is not deleted
       from the underlying MapStore, evict only removes the entry from the memory.
     request:
-      id: 0x0122
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -1527,7 +1489,6 @@ methods:
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -1536,13 +1497,13 @@ methods:
           doc: |
             true if the key is evicted, false otherwise.
     since: 2.0
+    id: 34
   - name: evictAll
     doc: |
       Evicts all keys from this map except the locked ones. If a MapStore is defined for this map, deleteAll is not
       called by this method. If you do want to deleteAll to be called use the clear method. The EVICT_ALL event is
       fired for any registered listeners.
     request:
-      id: 0x0123
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -1553,14 +1514,13 @@ methods:
           since: 2.0
           doc: |
             name of map
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 35
   - name: loadAll
     doc: |
       Loads all keys into the store. This is a batch load operation so that an implementation can optimize the multiple loads.
     request:
-      id: 0x0124
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -1578,14 +1538,13 @@ methods:
           doc: |
             when <code>true</code>, existing values in the Map will
             be replaced by those loaded from the MapLoader
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 36
   - name: loadGivenKeys
     doc: |
       Loads the given keys. This is a batch load operation so that an implementation can optimize the multiple loads.
     request:
-      id: 0x0125
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -1608,16 +1567,15 @@ methods:
           since: 2.0
           doc: |
             when <code>true</code>, existing values in the Map will be replaced by those loaded from the MapLoader
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 37
   - name: keySet
     doc: |
       Returns a set clone of the keys contained in this map. The set is NOT backed by the map, so changes to the map
       are NOT reflected in the set, and vice-versa. This method is always executed by a distributed query, so it may
       throw a QueryResultSizeExceededException if query result size limit is configured.
     request:
-      id: 0x0126
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -1629,7 +1587,6 @@ methods:
           doc: |
             name of the map
     response:
-      id: 0x006a
       params:
         - name: response
           type: List_Data
@@ -1638,6 +1595,7 @@ methods:
           doc: |
             a set clone of the keys contained in this map.
     since: 2.0
+    id: 38
   - name: getAll
     doc: |
       Returns the entries for the given keys. If any keys are not present in the Map, it will call loadAll The returned
@@ -1646,7 +1604,6 @@ methods:
       matching to a different partition id shall be ignored. The API implementation using this request may need to send multiple
       of these request messages for filling a request for a key set if the keys belong to different partitions.
     request:
-      id: 0x0127
       retryable: false
       acquiresResource: false
       partitionIdentifier: any key belongs to target partition
@@ -1664,7 +1621,6 @@ methods:
           doc: |
             keys to get
     response:
-      id: 0x0075
       params:
         - name: response
           type: Map_Data_Data
@@ -1673,6 +1629,7 @@ methods:
           doc: |
             values for the provided keys.
     since: 2.0
+    id: 39
   - name: values
     doc: |
       Returns a collection clone of the values contained in this map.
@@ -1680,7 +1637,6 @@ methods:
       This method is always executed by a distributed query, so it may throw a QueryResultSizeExceededException
       if query result size limit is configured.
     request:
-      id: 0x0128
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -1692,7 +1648,6 @@ methods:
           doc: |
             name of map
     response:
-      id: 0x006a
       params:
         - name: response
           type: List_Data
@@ -1701,6 +1656,7 @@ methods:
           doc: |
             All values in the map
     since: 2.0
+    id: 40
   - name: entrySet
     doc: |
       Returns a Set clone of the mappings contained in this map.
@@ -1708,7 +1664,6 @@ methods:
       This method is always executed by a distributed query, so it may throw a QueryResultSizeExceededException
       if query result size limit is configured.
     request:
-      id: 0x0129
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -1720,7 +1675,6 @@ methods:
           doc: |
             name of map
     response:
-      id: 0x0075
       params:
         - name: response
           type: Map_Data_Data
@@ -1729,6 +1683,7 @@ methods:
           doc: |
             a set clone of the keys mappings in this map
     since: 2.0
+    id: 41
   - name: keySetWithPredicate
     doc: |
       Queries the map based on the specified predicate and returns the keys of matching entries. Specified predicate
@@ -1736,7 +1691,6 @@ methods:
       set, and vice-versa. This method is always executed by a distributed query, so it may throw a
       QueryResultSizeExceededException if query result size limit is configured.
     request:
-      id: 0x012a
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -1754,7 +1708,6 @@ methods:
           doc: |
             specified query criteria.
     response:
-      id: 0x006a
       params:
         - name: response
           type: List_Data
@@ -1763,6 +1716,7 @@ methods:
           doc: |
             result key set for the query.
     since: 2.0
+    id: 42
   - name: valuesWithPredicate
     doc: |
       Queries the map based on the specified predicate and returns the values of matching entries.Specified predicate
@@ -1770,7 +1724,6 @@ methods:
       in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw a
       QueryResultSizeExceededException if query result size limit is configured.
     request:
-      id: 0x012b
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -1788,7 +1741,6 @@ methods:
           doc: |
             specified query criteria.
     response:
-      id: 0x006a
       params:
         - name: response
           type: List_Data
@@ -1797,6 +1749,7 @@ methods:
           doc: |
             result value collection of the query.
     since: 2.0
+    id: 43
   - name: entriesWithPredicate
     doc: |
       Queries the map based on the specified predicate and returns the matching entries.Specified predicate
@@ -1804,7 +1757,6 @@ methods:
       in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw a
       QueryResultSizeExceededException if query result size limit is configured.
     request:
-      id: 0x012c
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -1822,7 +1774,6 @@ methods:
           doc: |
             specified query criteria.
     response:
-      id: 0x0075
       params:
         - name: response
           type: Map_Data_Data
@@ -1831,6 +1782,7 @@ methods:
           doc: |
             result key-value entry collection of the query.
     since: 2.0
+    id: 44
   - name: addIndex
     doc: |
       Adds an index to this map for the specified entries so that queries can run faster.If you are querying your values
@@ -1842,7 +1794,6 @@ methods:
       Until the index finishes being created, any searches for the attribute will use a full Map scan, thus avoiding
       using a partially built index and returning incorrect results.
     request:
-      id: 0x012d
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -1865,15 +1816,14 @@ methods:
           since: 2.0
           doc: |
             true if index should be ordered, false otherwise.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 45
   - name: size
     doc: |
       Returns the number of key-value mappings in this map.  If the map contains more than Integer.MAX_VALUE elements,
       returns Integer.MAX_VALUE
     request:
-      id: 0x012e
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -1885,7 +1835,6 @@ methods:
           doc: |
             of map
     response:
-      id: 0x0066
       params:
         - name: response
           type: int
@@ -1894,11 +1843,11 @@ methods:
           doc: |
             the number of key-value mappings in this map
     since: 2.0
+    id: 46
   - name: isEmpty
     doc: |
       Returns true if this map contains no key-value mappings.
     request:
-      id: 0x012f
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -1910,7 +1859,6 @@ methods:
           doc: |
             name of map
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -1919,6 +1867,7 @@ methods:
           doc: |
             true if this map contains no key-value mappings
     since: 2.0
+    id: 47
   - name: putAll
     doc: |
       Copies all of the mappings from the specified map to this map (optional operation).The effect of this call is
@@ -1929,7 +1878,6 @@ methods:
       matching to a different partition id shall be ignored. The API implementation using this request may need to send multiple
       of these request messages for filling a request for a key set if the keys belong to different partitions.
     request:
-      id: 0x0130
       retryable: false
       acquiresResource: false
       partitionIdentifier: any key belongs to target partition
@@ -1946,16 +1894,15 @@ methods:
           since: 2.0
           doc: |
             mappings to be stored in this map
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 48
   - name: clear
     doc: |
       This method clears the map and invokes MapStore#deleteAll deleteAll on MapStore which, if connected to a database,
       will delete the records from that database. The MAP_CLEARED event is fired for any registered listeners.
       To clear a map without calling MapStore#deleteAll, use #evictAll.
     request:
-      id: 0x0131
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -1966,15 +1913,14 @@ methods:
           since: 2.0
           doc: |
             of map
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 49
   - name: executeOnKey
     doc: |
       Applies the user defined EntryProcessor to the entry mapped by the key. Returns the the object which is result of
       the process() method of EntryProcessor.
     request:
-      id: 0x0132
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -2004,7 +1950,6 @@ methods:
           doc: |
             TODO DOC
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -2013,13 +1958,13 @@ methods:
           doc: |
             result of entry process.
     since: 2.0
+    id: 50
   - name: submitToKey
     doc: |
       Applies the user defined EntryProcessor to the entry mapped by the key. Returns immediately with a Future
       representing that task.EntryProcessor is not cancellable, so calling Future.cancel() method won't cancel the
       operation of EntryProcessor.
     request:
-      id: 0x0133
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -2049,7 +1994,6 @@ methods:
           doc: |
             TODO DOC
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -2058,11 +2002,11 @@ methods:
           doc: |
             result of entry process.
     since: 2.0
+    id: 51
   - name: executeOnAllKeys
     doc: |
       Applies the user defined EntryProcessor to the all entries in the map.Returns the results mapped by each key in the map.
     request:
-      id: 0x0134
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -2080,7 +2024,6 @@ methods:
           doc: |
             entry processor to be executed.
     response:
-      id: 0x0075
       params:
         - name: response
           type: Map_Data_Data
@@ -2089,12 +2032,12 @@ methods:
           doc: |
             results of entry process on the entries
     since: 2.0
+    id: 52
   - name: executeWithPredicate
     doc: |
       Applies the user defined EntryProcessor to the entries in the map which satisfies provided predicate.
       Returns the results mapped by each key in the map.
     request:
-      id: 0x0135
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -2118,7 +2061,6 @@ methods:
           doc: |
             specified query criteria.
     response:
-      id: 0x0075
       params:
         - name: response
           type: Map_Data_Data
@@ -2127,12 +2069,12 @@ methods:
           doc: |
             results of entry process on the entries matching the query criteria
     since: 2.0
+    id: 53
   - name: executeOnKeys
     doc: |
       Applies the user defined EntryProcessor to the entries mapped by the collection of keys.The results mapped by
       each key in the collection.
     request:
-      id: 0x0136
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -2156,7 +2098,6 @@ methods:
           doc: |
             The keys for the entries for which the entry processor shall be executed on.
     response:
-      id: 0x0075
       params:
         - name: response
           type: Map_Data_Data
@@ -2165,12 +2106,12 @@ methods:
           doc: |
             results of entry process on the entries with the provided keys
     since: 2.0
+    id: 54
   - name: forceUnlock
     doc: |
       Releases the lock for the specified key regardless of the lock owner.It always successfully unlocks the key,
       never blocks,and returns immediately.
     request:
-      id: 0x0137
       retryable: true
       acquiresResource: false
       partitionIdentifier: key
@@ -2193,14 +2134,13 @@ methods:
           since: 2.0
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 55
   - name: keySetWithPagingPredicate
     doc: |
       TODO DOC
     request:
-      id: 0x0138
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -2218,7 +2158,6 @@ methods:
           doc: |
             specified query criteria.
     response:
-      id: 0x006a
       params:
         - name: response
           type: List_Data
@@ -2227,6 +2166,7 @@ methods:
           doc: |
             result keys for the query.
     since: 2.0
+    id: 56
   - name: valuesWithPagingPredicate
     doc: |
       Queries the map based on the specified predicate and returns the values of matching entries. Specified predicate
@@ -2234,7 +2174,6 @@ methods:
       in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw a
       QueryResultSizeExceededException if query result size limit is configured.
     request:
-      id: 0x0139
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -2252,7 +2191,6 @@ methods:
           doc: |
             specified query criteria.
     response:
-      id: 0x0075
       params:
         - name: response
           type: Map_Data_Data
@@ -2261,11 +2199,11 @@ methods:
           doc: |
             values for the query.
     since: 2.0
+    id: 57
   - name: entriesWithPagingPredicate
     doc: |
       TODO DOC
     request:
-      id: 0x013a
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -2283,7 +2221,6 @@ methods:
           doc: |
             specified query criteria.
     response:
-      id: 0x0075
       params:
         - name: response
           type: Map_Data_Data
@@ -2292,11 +2229,11 @@ methods:
           doc: |
             key-value pairs for the query.
     since: 2.0
+    id: 58
   - name: clearNearCache
     doc: |
       TODO DOC
     request:
-      id: 0x013b
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -2313,14 +2250,13 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 59
   - name: fetchKeys
     doc: |
       Fetches specified number of keys from the specified partition starting from specified table index.
     request:
-      id: 0x013c
       retryable: true
       acquiresResource: false
       partitionIdentifier: partitionId
@@ -2344,7 +2280,6 @@ methods:
           doc: |
             The number of items to be batched
     response:
-      id: 0x0074
       params:
         - name: tableIndex
           type: int
@@ -2359,11 +2294,11 @@ methods:
           doc: |
             TODO DOC
     since: 2.0
+    id: 60
   - name: fetchEntries
     doc: |
       Fetches specified number of entries from the specified partition starting from specified table index.
     request:
-      id: 0x013d
       retryable: true
       acquiresResource: false
       partitionIdentifier: partitionId
@@ -2387,7 +2322,6 @@ methods:
           doc: |
             The number of items to be batched
     response:
-      id: 0x0076
       params:
         - name: tableIndex
           type: int
@@ -2402,11 +2336,11 @@ methods:
           doc: |
             TODO DOC
     since: 2.0
+    id: 61
   - name: aggregate
     doc: |
       Applies the aggregation logic on all map entries and returns the result
     request:
-      id: 0x013e
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -2424,7 +2358,6 @@ methods:
           doc: |
             aggregator to aggregate the entries with
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -2433,11 +2366,11 @@ methods:
           doc: |
             the aggregation result
     since: 2.0
+    id: 62
   - name: aggregateWithPredicate
     doc: |
       Applies the aggregation logic on map entries filtered with the Predicate and returns the result
     request:
-      id: 0x013f
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -2461,7 +2394,6 @@ methods:
           doc: |
             predicate to filter the entries with
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -2470,11 +2402,11 @@ methods:
           doc: |
             the aggregation result
     since: 2.0
+    id: 63
   - name: project
     doc: |
       Applies the projection logic on all map entries and returns the result
     request:
-      id: 0x0140
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -2492,7 +2424,6 @@ methods:
           doc: |
             projection to transform the entries with. May return null.
     response:
-      id: 0x0077
       params:
         - name: response
           type: ListCN_Data
@@ -2501,11 +2432,11 @@ methods:
           doc: |
             the resulted collection upon transformation to the type of the projection
     since: 2.0
+    id: 64
   - name: projectWithPredicate
     doc: |
       Applies the projection logic on map entries filtered with the Predicate and returns the result
     request:
-      id: 0x0141
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -2529,7 +2460,6 @@ methods:
           doc: |
             predicate to filter the entries with
     response:
-      id: 0x0077
       params:
         - name: response
           type: ListCN_Data
@@ -2538,11 +2468,11 @@ methods:
           doc: |
             the resulted collection upon transformation to the type of the projection
     since: 2.0
+    id: 65
   - name: fetchNearCacheInvalidationMetadata
     doc: |
       Fetches invalidation metadata from partitions of map.
     request:
-      id: 0x0142
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -2560,7 +2490,6 @@ methods:
           doc: |
             TODO DOC
     response:
-      id: 0x007a
       params:
         - name: namePartitionSequenceList
           type: Map_String_Map_Integer_Long
@@ -2575,16 +2504,15 @@ methods:
           doc: |
             TODO DOC
     since: 2.0
+    id: 66
   - name: assignAndGetUuids
     doc: |
       TODO DOC
     request:
-      id: 0x0143
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
     response:
-      id: 0x007b
       params:
         - name: partitionUuidList
           type: Map_Integer_UUID
@@ -2593,11 +2521,11 @@ methods:
           doc: |
             partitionId to assigned uuid entry list
     since: 2.0
+    id: 67
   - name: removeAll
     doc: |
       Removes all entries which match with the supplied predicate
     request:
-      id: 0x0144
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -2614,16 +2542,15 @@ methods:
           since: 2.0
           doc: |
             used to select entries to be removed from map.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 68
   - name: addNearCacheInvalidationListener
     doc: |
       Adds listener to map. This listener will be used to listen near cache invalidation events.
       Eventually consistent client near caches should use this method to add invalidation listeners
       instead of {@link #addNearCacheEntryListener(String, int, boolean)}
     request:
-      id: 0x0145
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -2647,7 +2574,6 @@ methods:
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -2656,8 +2582,7 @@ methods:
           doc: |
             A unique string which is used as a key to remove the listener.
     events:
-      - id: 0x00d7
-        name: IMapInvalidation
+      - name: IMapInvalidation
         params:
           - name: key
             type: Data
@@ -2683,8 +2608,7 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
-      - id: 0x00d8
-        name: IMapBatchInvalidation
+      - name: IMapBatchInvalidation
         params:
           - name: keys
             type: List_Data
@@ -2711,12 +2635,12 @@ methods:
             doc: |
               TODO DOC
     since: 2.0
+    id: 69
   - name: fetchWithQuery
     doc: |
       Fetches the specified number of entries from the specified partition starting from specified table index
       that match the predicate and applies the projection logic on them.
     request:
-      id: 0x0146
       retryable: true
       acquiresResource: false
       partitionIdentifier: partitionId
@@ -2752,7 +2676,6 @@ methods:
           doc: |
             predicate to filter the entries with
     response:
-      id: 0x007c
       params:
         - name: results
           type: ListCN_Data
@@ -2767,13 +2690,13 @@ methods:
           doc: |
             TODO DOC
     since: 2.0
+    id: 70
   - name: eventJournalSubscribe
     doc: |
       Performs the initial subscription to the map event journal.
       This includes retrieving the event journal sequences of the
       oldest and newest event in the journal.
     request:
-      id: 0x0147
       retryable: true
       acquiresResource: false
       partitionIdentifier: partitionId
@@ -2785,7 +2708,6 @@ methods:
           doc: |
             name of the map
     response:
-      id: 0x007d
       params:
         - name: oldestSequence
           type: long
@@ -2800,6 +2722,7 @@ methods:
           doc: |
             TODO DOC
     since: 2.0
+    id: 71
   - name: eventJournalRead
     doc: |
       Reads from the map event journal in batches. You may specify the start sequence,
@@ -2811,7 +2734,6 @@ methods:
       The predicate, filter and projection may be {@code null} in which case all elements are returned
       and no projection is applied.
     request:
-      id: 0x0148
       retryable: true
       acquiresResource: false
       partitionIdentifier: partitionId
@@ -2853,7 +2775,6 @@ methods:
           doc: |
             the projection to apply to journal events
     response:
-      id: 0x0073
       params:
         - name: readCount
           type: int
@@ -2880,6 +2801,7 @@ methods:
           doc: |
             TODO DOC
     since: 2.0
+    id: 72
   - name: setTtl
     doc: |
       Updates TTL (time to live) value of the entry specified by {@code key} with a new TTL value.
@@ -2896,7 +2818,6 @@ methods:
       <p>
       Time resolution for TTL is seconds. The given TTL value is rounded to the next closest second value.
     request:
-      id: 0x0149
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -2920,7 +2841,6 @@ methods:
           doc: |
             The duration in milliseconds after which this entry shall be deleted. O means infinite.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -2929,6 +2849,7 @@ methods:
           doc: |
             'true' if the entry is affected, 'false' otherwise
     since: 2.0
+    id: 73
   - name: putWithMaxIdle
     doc: |
       Puts an entry into this map with a given ttl (time to live) value.Entry will expire and get evicted after the ttl
@@ -2936,7 +2857,6 @@ methods:
       (identically equal) value previously put into the map.Time resolution for TTL is seconds. The given TTL value is
       rounded to the next closest second value.
     request:
-      id: 0x014a
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -2979,7 +2899,6 @@ methods:
             The duration of maximum idle for this entry.
             Milliseconds of idle, after which this entry shall be deleted. O means infinite.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -2988,12 +2907,12 @@ methods:
           doc: |
             old value of the entry
     since: 2.0
+    id: 74
   - name: putTransientWithMaxIdle
     doc: |
       Same as put except that MapStore, if defined, will not be called to store/persist the entry.
       If ttl and maxIdle are 0, then the entry lives forever.
     request:
-      id: 0x014b
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -3036,7 +2955,6 @@ methods:
             The duration of maximum idle for this entry.
             Milliseconds of idle, after which this entry shall be deleted. O means infinite.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -3045,12 +2963,12 @@ methods:
           doc: |
             old value of the entry
     since: 2.0
+    id: 75
   - name: putIfAbsentWithMaxIdle
     doc: |
       Puts an entry into this map with a given ttl (time to live) value if the specified key is not already associated
       with a value. Entry will expire and get evicted after the ttl or maxIdle, whichever comes first.
     request:
-      id: 0x014c
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -3093,7 +3011,6 @@ methods:
             The duration of maximum idle for this entry.
             Milliseconds of idle, after which this entry shall be deleted. O means infinite.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -3102,6 +3019,7 @@ methods:
           doc: |
             old value of the entry
     since: 2.0
+    id: 76
   - name: setWithMaxIdle
     doc: |
       Puts an entry into this map with a given ttl (time to live) value and maxIdle.
@@ -3110,7 +3028,6 @@ methods:
 
       Similar to the put operation except that set doesn't return the old value, which is more efficient.
     request:
-      id: 0x014d
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -3153,7 +3070,6 @@ methods:
             The duration of maximum idle for this entry.
             Milliseconds of idle, after which this entry shall be deleted. O means infinite.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -3162,3 +3078,4 @@ methods:
           doc: |
             old value of the entry
     since: 2.0
+    id: 77

--- a/protocol-definitions/MultiMap.yaml
+++ b/protocol-definitions/MultiMap.yaml
@@ -2,7 +2,9 @@ id: 2
 name: MultiMap
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: put
+  - id: 1
+    name: put
+    since: 2.0
     doc: |
       Stores a key-value pair in the multimap.
     request:
@@ -42,9 +44,9 @@ methods:
           since: 2.0
           doc: |
             True if size of the multimap is increased, false if the multimap already contains the key-value pair.
+  - id: 2
+    name: get
     since: 2.0
-    id: 1
-  - name: get
     doc: |
       Returns the collection of values associated with the key. The collection is NOT backed by the map, so changes to
       the map are NOT reflected in the collection, and vice-versa.
@@ -79,9 +81,9 @@ methods:
           since: 2.0
           doc: |
             The collection of the values associated with the key.
+  - id: 3
+    name: remove
     since: 2.0
-    id: 2
-  - name: remove
     doc: |
       Removes the given key value pair from the multimap.
     request:
@@ -115,9 +117,9 @@ methods:
           since: 2.0
           doc: |
             True if the size of the multimap changed after the remove operation, false otherwise.
+  - id: 4
+    name: keySet
     since: 2.0
-    id: 3
-  - name: keySet
     doc: |
       Returns the set of keys in the multimap.The collection is NOT backed by the map, so changes to the map are NOT
       reflected in the collection, and vice-versa.
@@ -140,9 +142,9 @@ methods:
           since: 2.0
           doc: |
             The set of keys in the multimap. The returned set might be modifiable but it has no effect on the multimap.
+  - id: 5
+    name: values
     since: 2.0
-    id: 4
-  - name: values
     doc: |
       Returns the collection of values in the multimap.The collection is NOT backed by the map, so changes to the map
       are NOT reflected in the collection, and vice-versa.
@@ -165,9 +167,9 @@ methods:
           since: 2.0
           doc: |
             The collection of values in the multimap. the returned collection might be modifiable but it has no effect on the multimap.
+  - id: 6
+    name: entrySet
     since: 2.0
-    id: 5
-  - name: entrySet
     doc: |
       Returns the set of key-value pairs in the multimap.The collection is NOT backed by the map, so changes to the map
       are NOT reflected in the collection, and vice-versa
@@ -190,9 +192,9 @@ methods:
           since: 2.0
           doc: |
             The set of key-value pairs in the multimap. The returned set might be modifiable but it has no effect on the multimap.
+  - id: 7
+    name: containsKey
     since: 2.0
-    id: 6
-  - name: containsKey
     doc: |
       Returns whether the multimap contains an entry with the key.
     request:
@@ -226,9 +228,9 @@ methods:
           since: 2.0
           doc: |
             True if the multimap contains an entry with the key, false otherwise.
+  - id: 8
+    name: containsValue
     since: 2.0
-    id: 7
-  - name: containsValue
     doc: |
       Returns whether the multimap contains an entry with the value.
     request:
@@ -256,9 +258,9 @@ methods:
           since: 2.0
           doc: |
             True if the multimap contains an entry with the value, false otherwise.
+  - id: 9
+    name: containsEntry
     since: 2.0
-    id: 8
-  - name: containsEntry
     doc: |
       Returns whether the multimap contains the given key-value pair.
     request:
@@ -298,9 +300,9 @@ methods:
           since: 2.0
           doc: |
             True if the multimap contains the key-value pair, false otherwise.
+  - id: 10
+    name: size
     since: 2.0
-    id: 9
-  - name: size
     doc: |
       Returns the number of key-value pairs in the multimap.
     request:
@@ -322,9 +324,9 @@ methods:
           since: 2.0
           doc: |
             The number of key-value pairs in the multimap.
+  - id: 11
+    name: clear
     since: 2.0
-    id: 10
-  - name: clear
     doc: |
       Clears the multimap. Removes all key-value pairs.
     request:
@@ -339,9 +341,9 @@ methods:
           doc: |
             Name of the MultiMap
     response: {}
+  - id: 12
+    name: valueCount
     since: 2.0
-    id: 11
-  - name: valueCount
     doc: |
       Returns the number of values that match the given key in the multimap.
     request:
@@ -375,9 +377,9 @@ methods:
           since: 2.0
           doc: |
             The number of values that match the given key in the multimap
+  - id: 13
+    name: addEntryListenerToKey
     since: 2.0
-    id: 12
-  - name: addEntryListenerToKey
     doc: |
       Adds the specified entry listener for the specified key.The listener will be notified for all
       add/remove/update/evict events for the specified key only.
@@ -463,9 +465,9 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
+  - id: 14
+    name: addEntryListener
     since: 2.0
-    id: 13
-  - name: addEntryListener
     doc: |
       Adds an entry listener for this multimap. The listener will be notified for all multimap add/remove/update/evict events.
     request:
@@ -544,9 +546,9 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
+  - id: 15
+    name: removeEntryListener
     since: 2.0
-    id: 14
-  - name: removeEntryListener
     doc: |
       Removes the specified entry listener. Returns silently if no such listener was added before.
     request:
@@ -574,9 +576,9 @@ methods:
           since: 2.0
           doc: |
             True if registration is removed, false otherwise
+  - id: 16
+    name: lock
     since: 2.0
-    id: 15
-  - name: lock
     doc: |
       Acquires the lock for the specified key for the specified lease time. After the lease time, the lock will be
       released. If the lock is not available, then the current thread becomes disabled for thread scheduling
@@ -619,9 +621,9 @@ methods:
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
     response: {}
+  - id: 17
+    name: tryLock
     since: 2.0
-    id: 16
-  - name: tryLock
     doc: |
       Tries to acquire the lock for the specified key for the specified lease time. After lease time, the lock will be
       released. If the lock is not available, then the current thread becomes disabled for thread scheduling purposes
@@ -676,9 +678,9 @@ methods:
           since: 2.0
           doc: |
             True if the lock was acquired and false if the waiting time elapsed before the lock acquired
+  - id: 18
+    name: isLocked
     since: 2.0
-    id: 17
-  - name: isLocked
     doc: |
       Checks the lock for the specified key. If the lock is acquired, this method returns true, else it returns false.
     request:
@@ -706,9 +708,9 @@ methods:
           since: 2.0
           doc: |
             True if the lock acquired,false otherwise
+  - id: 19
+    name: unlock
     since: 2.0
-    id: 18
-  - name: unlock
     doc: |
       Releases the lock for the specified key regardless of the lock owner. It always successfully unlocks the key,
       never blocks and returns immediately.
@@ -742,9 +744,9 @@ methods:
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
     response: {}
+  - id: 20
+    name: forceUnlock
     since: 2.0
-    id: 19
-  - name: forceUnlock
     doc: |
       Releases the lock for the specified key regardless of the lock owner. It always successfully unlocks the key,
       never blocks and returns immediately.
@@ -772,9 +774,9 @@ methods:
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
     response: {}
+  - id: 21
+    name: removeEntry
     since: 2.0
-    id: 20
-  - name: removeEntry
     doc: |
       Removes all the entries with the given key. The collection is NOT backed by the map, so changes to the map are
       NOT reflected in the collection, and vice-versa.
@@ -815,9 +817,9 @@ methods:
           since: 2.0
           doc: |
             True if the size of the multimap changed after the remove operation, false otherwise.
+  - id: 22
+    name: delete
     since: 2.0
-    id: 21
-  - name: delete
     doc: |
       Removes all the entries with the given key.
     request:
@@ -844,5 +846,3 @@ methods:
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation
     response: {}
-    since: 2.0
-    id: 22

--- a/protocol-definitions/MultiMap.yaml
+++ b/protocol-definitions/MultiMap.yaml
@@ -6,7 +6,6 @@ methods:
     doc: |
       Stores a key-value pair in the multimap.
     request:
-      id: 0x0201
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -36,7 +35,6 @@ methods:
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -45,12 +43,12 @@ methods:
           doc: |
             True if size of the multimap is increased, false if the multimap already contains the key-value pair.
     since: 2.0
+    id: 1
   - name: get
     doc: |
       Returns the collection of values associated with the key. The collection is NOT backed by the map, so changes to
       the map are NOT reflected in the collection, and vice-versa.
     request:
-      id: 0x0202
       retryable: true
       acquiresResource: false
       partitionIdentifier: key
@@ -74,7 +72,6 @@ methods:
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
-      id: 0x006a
       params:
         - name: response
           type: List_Data
@@ -83,11 +80,11 @@ methods:
           doc: |
             The collection of the values associated with the key.
     since: 2.0
+    id: 2
   - name: remove
     doc: |
       Removes the given key value pair from the multimap.
     request:
-      id: 0x0203
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -111,7 +108,6 @@ methods:
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
-      id: 0x006a
       params:
         - name: response
           type: List_Data
@@ -120,12 +116,12 @@ methods:
           doc: |
             True if the size of the multimap changed after the remove operation, false otherwise.
     since: 2.0
+    id: 3
   - name: keySet
     doc: |
       Returns the set of keys in the multimap.The collection is NOT backed by the map, so changes to the map are NOT
       reflected in the collection, and vice-versa.
     request:
-      id: 0x0204
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -137,7 +133,6 @@ methods:
           doc: |
             Name of the MultiMap
     response:
-      id: 0x006a
       params:
         - name: response
           type: List_Data
@@ -146,12 +141,12 @@ methods:
           doc: |
             The set of keys in the multimap. The returned set might be modifiable but it has no effect on the multimap.
     since: 2.0
+    id: 4
   - name: values
     doc: |
       Returns the collection of values in the multimap.The collection is NOT backed by the map, so changes to the map
       are NOT reflected in the collection, and vice-versa.
     request:
-      id: 0x0205
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -163,7 +158,6 @@ methods:
           doc: |
             Name of the MultiMap
     response:
-      id: 0x006a
       params:
         - name: response
           type: List_Data
@@ -172,12 +166,12 @@ methods:
           doc: |
             The collection of values in the multimap. the returned collection might be modifiable but it has no effect on the multimap.
     since: 2.0
+    id: 5
   - name: entrySet
     doc: |
       Returns the set of key-value pairs in the multimap.The collection is NOT backed by the map, so changes to the map
       are NOT reflected in the collection, and vice-versa
     request:
-      id: 0x0206
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -189,7 +183,6 @@ methods:
           doc: |
             Name of the MultiMap
     response:
-      id: 0x0075
       params:
         - name: response
           type: Map_Data_Data
@@ -198,11 +191,11 @@ methods:
           doc: |
             The set of key-value pairs in the multimap. The returned set might be modifiable but it has no effect on the multimap.
     since: 2.0
+    id: 6
   - name: containsKey
     doc: |
       Returns whether the multimap contains an entry with the key.
     request:
-      id: 0x0207
       retryable: true
       acquiresResource: false
       partitionIdentifier: key
@@ -226,7 +219,6 @@ methods:
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -235,11 +227,11 @@ methods:
           doc: |
             True if the multimap contains an entry with the key, false otherwise.
     since: 2.0
+    id: 7
   - name: containsValue
     doc: |
       Returns whether the multimap contains an entry with the value.
     request:
-      id: 0x0208
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -257,7 +249,6 @@ methods:
           doc: |
             The value whose existence is checked.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -266,11 +257,11 @@ methods:
           doc: |
             True if the multimap contains an entry with the value, false otherwise.
     since: 2.0
+    id: 8
   - name: containsEntry
     doc: |
       Returns whether the multimap contains the given key-value pair.
     request:
-      id: 0x0209
       retryable: true
       acquiresResource: false
       partitionIdentifier: key
@@ -300,7 +291,6 @@ methods:
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -309,11 +299,11 @@ methods:
           doc: |
             True if the multimap contains the key-value pair, false otherwise.
     since: 2.0
+    id: 9
   - name: size
     doc: |
       Returns the number of key-value pairs in the multimap.
     request:
-      id: 0x020a
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -325,7 +315,6 @@ methods:
           doc: |
             Name of the MultiMap
     response:
-      id: 0x0066
       params:
         - name: response
           type: int
@@ -334,11 +323,11 @@ methods:
           doc: |
             The number of key-value pairs in the multimap.
     since: 2.0
+    id: 10
   - name: clear
     doc: |
       Clears the multimap. Removes all key-value pairs.
     request:
-      id: 0x020b
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -349,14 +338,13 @@ methods:
           since: 2.0
           doc: |
             Name of the MultiMap
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 11
   - name: valueCount
     doc: |
       Returns the number of values that match the given key in the multimap.
     request:
-      id: 0x020c
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -380,7 +368,6 @@ methods:
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation
     response:
-      id: 0x0066
       params:
         - name: response
           type: int
@@ -389,12 +376,12 @@ methods:
           doc: |
             The number of values that match the given key in the multimap
     since: 2.0
+    id: 12
   - name: addEntryListenerToKey
     doc: |
       Adds the specified entry listener for the specified key.The listener will be notified for all
       add/remove/update/evict events for the specified key only.
     request:
-      id: 0x020d
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -424,7 +411,6 @@ methods:
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -433,8 +419,7 @@ methods:
           doc: |
             Returns registration id for the entry listener
     events:
-      - id: 0x00cb
-        name: Entry
+      - name: Entry
         params:
           - name: key
             type: Data
@@ -479,11 +464,11 @@ methods:
             doc: |
               TODO DOC
     since: 2.0
+    id: 13
   - name: addEntryListener
     doc: |
       Adds an entry listener for this multimap. The listener will be notified for all multimap add/remove/update/evict events.
     request:
-      id: 0x020e
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -507,7 +492,6 @@ methods:
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -516,8 +500,7 @@ methods:
           doc: |
             Returns registration id for the entry listener
     events:
-      - id: 0x00cb
-        name: Entry
+      - name: Entry
         params:
           - name: key
             type: Data
@@ -562,11 +545,11 @@ methods:
             doc: |
               TODO DOC
     since: 2.0
+    id: 14
   - name: removeEntryListener
     doc: |
       Removes the specified entry listener. Returns silently if no such listener was added before.
     request:
-      id: 0x020f
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -584,7 +567,6 @@ methods:
           doc: |
             Registration id of listener
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -593,6 +575,7 @@ methods:
           doc: |
             True if registration is removed, false otherwise
     since: 2.0
+    id: 15
   - name: lock
     doc: |
       Acquires the lock for the specified key for the specified lease time. After the lease time, the lock will be
@@ -601,7 +584,6 @@ methods:
       lock is only for the key in this map.Locks are re-entrant, so if the key is locked N times, then it should be
       unlocked N times before another thread can acquire it.
     request:
-      id: 0x0210
       retryable: true
       acquiresResource: true
       partitionIdentifier: key
@@ -636,9 +618,9 @@ methods:
           since: 2.0
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 16
   - name: tryLock
     doc: |
       Tries to acquire the lock for the specified key for the specified lease time. After lease time, the lock will be
@@ -646,7 +628,6 @@ methods:
       and lies dormant until one of two things happens:the lock is acquired by the current thread, or the specified
       waiting time elapses.
     request:
-      id: 0x0211
       retryable: true
       acquiresResource: true
       partitionIdentifier: key
@@ -688,7 +669,6 @@ methods:
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -697,11 +677,11 @@ methods:
           doc: |
             True if the lock was acquired and false if the waiting time elapsed before the lock acquired
     since: 2.0
+    id: 17
   - name: isLocked
     doc: |
       Checks the lock for the specified key. If the lock is acquired, this method returns true, else it returns false.
     request:
-      id: 0x0212
       retryable: true
       acquiresResource: false
       partitionIdentifier: key
@@ -719,7 +699,6 @@ methods:
           doc: |
             Key to lock to be checked.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -728,12 +707,12 @@ methods:
           doc: |
             True if the lock acquired,false otherwise
     since: 2.0
+    id: 18
   - name: unlock
     doc: |
       Releases the lock for the specified key regardless of the lock owner. It always successfully unlocks the key,
       never blocks and returns immediately.
     request:
-      id: 0x0213
       retryable: true
       acquiresResource: false
       partitionIdentifier: key
@@ -762,15 +741,14 @@ methods:
           since: 2.0
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 19
   - name: forceUnlock
     doc: |
       Releases the lock for the specified key regardless of the lock owner. It always successfully unlocks the key,
       never blocks and returns immediately.
     request:
-      id: 0x0214
       retryable: true
       acquiresResource: false
       partitionIdentifier: key
@@ -793,15 +771,14 @@ methods:
           since: 2.0
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 20
   - name: removeEntry
     doc: |
       Removes all the entries with the given key. The collection is NOT backed by the map, so changes to the map are
       NOT reflected in the collection, and vice-versa.
     request:
-      id: 0x0215
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -831,7 +808,6 @@ methods:
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -840,11 +816,11 @@ methods:
           doc: |
             True if the size of the multimap changed after the remove operation, false otherwise.
     since: 2.0
+    id: 21
   - name: delete
     doc: |
       Removes all the entries with the given key.
     request:
-      id: 0x0216
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -867,6 +843,6 @@ methods:
           since: 2.0
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 22

--- a/protocol-definitions/MultiMap.yaml
+++ b/protocol-definitions/MultiMap.yaml
@@ -1,6 +1,5 @@
 id: 2
 name: MultiMap
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: put

--- a/protocol-definitions/PNCounter.yaml
+++ b/protocol-definitions/PNCounter.yaml
@@ -2,7 +2,9 @@ id: 32
 name: PNCounter
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: get
+  - id: 1
+    name: get
+    since: 2.0
     doc: |
       Query operation to retrieve the current value of the PNCounter.
       <p>
@@ -55,9 +57,9 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
+  - id: 2
+    name: add
     since: 2.0
-    id: 1
-  - name: add
     doc: |
       Adds a delta to the PNCounter value. The delta may be negative for a
       subtraction.
@@ -125,9 +127,9 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
+  - id: 3
+    name: getConfiguredReplicaCount
     since: 2.0
-    id: 2
-  - name: getConfiguredReplicaCount
     doc: |
       Returns the configured number of CRDT replicas for the PN counter with
       the given {@code name}.
@@ -152,5 +154,3 @@ methods:
           since: 2.0
           doc: |
             the configured replica count
-    since: 2.0
-    id: 3

--- a/protocol-definitions/PNCounter.yaml
+++ b/protocol-definitions/PNCounter.yaml
@@ -1,6 +1,5 @@
 id: 32
 name: PNCounter
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: get

--- a/protocol-definitions/PNCounter.yaml
+++ b/protocol-definitions/PNCounter.yaml
@@ -13,7 +13,6 @@ methods:
       If smart routing is disabled, the actual member processing the client
       message may act as a proxy.
     request:
-      id: 0x2001
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -37,7 +36,6 @@ methods:
           doc: |
             the target replica
     response:
-      id: 0x007f
       params:
         - name: value
           type: long
@@ -58,6 +56,7 @@ methods:
           doc: |
             TODO DOC
     since: 2.0
+    id: 1
   - name: add
     doc: |
       Adds a delta to the PNCounter value. The delta may be negative for a
@@ -70,7 +69,6 @@ methods:
       If smart routing is disabled, the actual member processing the client
       message may act as a proxy.
     request:
-      id: 0x2002
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -108,7 +106,6 @@ methods:
           doc: |
             the target replica
     response:
-      id: 0x007f
       params:
         - name: value
           type: long
@@ -129,6 +126,7 @@ methods:
           doc: |
             TODO DOC
     since: 2.0
+    id: 2
   - name: getConfiguredReplicaCount
     doc: |
       Returns the configured number of CRDT replicas for the PN counter with
@@ -136,7 +134,6 @@ methods:
       The actual replica count may be less, depending on the number of data
       members in the cluster (members that own data).
     request:
-      id: 0x2003
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -148,7 +145,6 @@ methods:
           doc: |
             the name of the PNCounter
     response:
-      id: 0x0066
       params:
         - name: response
           type: int
@@ -157,3 +153,4 @@ methods:
           doc: |
             the configured replica count
     since: 2.0
+    id: 3

--- a/protocol-definitions/Queue.yaml
+++ b/protocol-definitions/Queue.yaml
@@ -1,6 +1,5 @@
 id: 3
 name: Queue
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: offer

--- a/protocol-definitions/Queue.yaml
+++ b/protocol-definitions/Queue.yaml
@@ -7,7 +7,6 @@ methods:
       Inserts the specified element into this queue, waiting up to the specified wait time if necessary for space to
       become available.
     request:
-      id: 0x0301
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -31,7 +30,6 @@ methods:
           doc: |
             Maximum time in milliseconds to wait for acquiring the lock for the key.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -40,11 +38,11 @@ methods:
           doc: |
             <tt>True</tt> if the element was added to this queue, else <tt>false</tt>
     since: 2.0
+    id: 1
   - name: put
     doc: |
       Inserts the specified element into this queue, waiting if necessary for space to become available.
     request:
-      id: 0x0302
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -61,15 +59,14 @@ methods:
           since: 2.0
           doc: |
             The element to add
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 2
   - name: size
     doc: |
       Returns the number of elements in this collection.  If this collection contains more than Integer.MAX_VALUE
       elements, returns Integer.MAX_VALUE
     request:
-      id: 0x0303
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -81,7 +78,6 @@ methods:
           doc: |
             Name of the Queue
     response:
-      id: 0x0066
       params:
         - name: response
           type: int
@@ -90,12 +86,12 @@ methods:
           doc: |
             The number of elements in this collection
     since: 2.0
+    id: 3
   - name: remove
     doc: |
       Retrieves and removes the head of this queue.  This method differs from poll only in that it throws an exception
       if this queue is empty.
     request:
-      id: 0x0304
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -113,7 +109,6 @@ methods:
           doc: |
             Element to be removed from this queue, if present
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -122,12 +117,12 @@ methods:
           doc: |
             <tt>true</tt> if this queue changed as a result of the call
     since: 2.0
+    id: 4
   - name: poll
     doc: |
       Retrieves and removes the head of this queue, waiting up to the specified wait time if necessary for an element
       to become available.
     request:
-      id: 0x0305
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -145,7 +140,6 @@ methods:
           doc: |
             Maximum time in milliseconds to wait for acquiring the lock for the key.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -154,11 +148,11 @@ methods:
           doc: |
             The head of this queue, or <tt>null</tt> if this queue is empty
     since: 2.0
+    id: 5
   - name: take
     doc: |
       Retrieves and removes the head of this queue, waiting if necessary until an element becomes available.
     request:
-      id: 0x0306
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -170,7 +164,6 @@ methods:
           doc: |
             Name of the Queue
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -179,11 +172,11 @@ methods:
           doc: |
             The head of this queue
     since: 2.0
+    id: 6
   - name: peek
     doc: |
       Retrieves, but does not remove, the head of this queue, or returns null if this queue is empty.
     request:
-      id: 0x0307
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -195,7 +188,6 @@ methods:
           doc: |
             Name of the Queue
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -204,12 +196,12 @@ methods:
           doc: |
             The head of this queue, or <tt>null</tt> if this queue is empty
     since: 2.0
+    id: 7
   - name: iterator
     doc: |
       Returns an iterator over the elements in this collection.  There are no guarantees concerning the order in which
       the elements are returned (unless this collection is an instance of some class that provides a guarantee).
     request:
-      id: 0x0308
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -221,7 +213,6 @@ methods:
           doc: |
             Name of the Queue
     response:
-      id: 0x006a
       params:
         - name: response
           type: List_Data
@@ -230,6 +221,7 @@ methods:
           doc: |
             list of all data in queue
     since: 2.0
+    id: 8
   - name: drainTo
     doc: |
       Removes all available elements from this queue and adds them to the given collection.  This operation may be more
@@ -238,7 +230,6 @@ methods:
       thrown. Attempts to drain a queue to itself result in ILLEGAL_ARGUMENT. Further, the behavior of
       this operation is undefined if the specified collection is modified while the operation is in progress.
     request:
-      id: 0x0309
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -250,7 +241,6 @@ methods:
           doc: |
             Name of the Queue
     response:
-      id: 0x006a
       params:
         - name: response
           type: List_Data
@@ -259,6 +249,7 @@ methods:
           doc: |
             list of all removed data in queue
     since: 2.0
+    id: 9
   - name: drainToMaxSize
     doc: |
       Removes at most the given number of available elements from this queue and adds them to the given collection.
@@ -267,7 +258,6 @@ methods:
       ILLEGAL_ARGUMENT. Further, the behavior of this operation is undefined if the specified collection is
       modified while the operation is in progress.
     request:
-      id: 0x030a
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -285,7 +275,6 @@ methods:
           doc: |
             The maximum number of elements to transfer
     response:
-      id: 0x006a
       params:
         - name: response
           type: List_Data
@@ -294,12 +283,12 @@ methods:
           doc: |
             list of all removed data in result of this method
     since: 2.0
+    id: 10
   - name: contains
     doc: |
       Returns true if this queue contains the specified element. More formally, returns true if and only if this queue
       contains at least one element e such that value.equals(e)
     request:
-      id: 0x030b
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -317,7 +306,6 @@ methods:
           doc: |
             Element whose presence in this collection is to be tested
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -326,11 +314,11 @@ methods:
           doc: |
             <tt>true</tt> if this collection contains the specified element
     since: 2.0
+    id: 11
   - name: containsAll
     doc: |
       Return true if this collection contains all of the elements in the specified collection.
     request:
-      id: 0x030c
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -348,7 +336,6 @@ methods:
           doc: |
             Collection to be checked for containment in this collection
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -357,12 +344,12 @@ methods:
           doc: |
             <tt>true</tt> if this collection contains all of the elements in the specified collection
     since: 2.0
+    id: 12
   - name: compareAndRemoveAll
     doc: |
       Removes all of this collection's elements that are also contained in the specified collection (optional operation).
       After this call returns, this collection will contain no elements in common with the specified collection.
     request:
-      id: 0x030d
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -380,7 +367,6 @@ methods:
           doc: |
             Collection containing elements to be removed from this collection
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -389,12 +375,12 @@ methods:
           doc: |
             <tt>true</tt> if this collection changed as a result of the call
     since: 2.0
+    id: 13
   - name: compareAndRetainAll
     doc: |
       Retains only the elements in this collection that are contained in the specified collection (optional operation).
       In other words, removes from this collection all of its elements that are not contained in the specified collection.
     request:
-      id: 0x030e
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -412,7 +398,6 @@ methods:
           doc: |
             collection containing elements to be retained in this collection
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -421,12 +406,12 @@ methods:
           doc: |
             <tt>true</tt> if this collection changed as a result of the call
     since: 2.0
+    id: 14
   - name: clear
     doc: |
       Removes all of the elements from this collection (optional operation). The collection will be empty after this
       method returns.
     request:
-      id: 0x030f
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -437,9 +422,9 @@ methods:
           since: 2.0
           doc: |
             Name of the Queue
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 15
   - name: addAll
     doc: |
       Adds all of the elements in the specified collection to this collection (optional operation).The behavior of this
@@ -447,7 +432,6 @@ methods:
       (This implies that the behavior of this call is undefined if the specified collection is this collection,
       and this collection is nonempty.)
     request:
-      id: 0x0310
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -465,7 +449,6 @@ methods:
           doc: |
             Collection containing elements to be added to this collection
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -474,11 +457,11 @@ methods:
           doc: |
             <tt>true</tt> if this collection changed as a result of the call
     since: 2.0
+    id: 16
   - name: addListener
     doc: |
       Adds an listener for this collection. Listener will be notified or all collection add/remove events.
     request:
-      id: 0x0311
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -502,7 +485,6 @@ methods:
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -511,8 +493,7 @@ methods:
           doc: |
             The registration id
     events:
-      - id: 0x00cc
-        name: Item
+      - name: Item
         params:
           - name: item
             type: Data
@@ -533,11 +514,11 @@ methods:
             doc: |
               TODO DOC
     since: 2.0
+    id: 17
   - name: removeListener
     doc: |
       Removes the specified item listener.Returns silently if the specified listener was not added before.
     request:
-      id: 0x0312
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -555,7 +536,6 @@ methods:
           doc: |
             Id of the listener registration.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -564,6 +544,7 @@ methods:
           doc: |
             True if the item listener is removed, false otherwise
     since: 2.0
+    id: 18
   - name: remainingCapacity
     doc: |
       Returns the number of additional elements that this queue can ideally (in the absence of memory or resource
@@ -571,7 +552,6 @@ methods:
       always tell if an attempt to insert an element will succeed by inspecting remainingCapacity because it may be
       the case that another thread is about to insert or remove an element.
     request:
-      id: 0x0313
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -583,7 +563,6 @@ methods:
           doc: |
             Name of the Queue
     response:
-      id: 0x0066
       params:
         - name: response
           type: int
@@ -592,11 +571,11 @@ methods:
           doc: |
             The remaining capacity
     since: 2.0
+    id: 19
   - name: isEmpty
     doc: |
       Returns true if this collection contains no elements.
     request:
-      id: 0x0314
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -608,7 +587,6 @@ methods:
           doc: |
             Name of the Queue
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -617,3 +595,4 @@ methods:
           doc: |
             <tt>True</tt> if this collection contains no elements
     since: 2.0
+    id: 20

--- a/protocol-definitions/Queue.yaml
+++ b/protocol-definitions/Queue.yaml
@@ -2,7 +2,9 @@ id: 3
 name: Queue
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: offer
+  - id: 1
+    name: offer
+    since: 2.0
     doc: |
       Inserts the specified element into this queue, waiting up to the specified wait time if necessary for space to
       become available.
@@ -37,9 +39,9 @@ methods:
           since: 2.0
           doc: |
             <tt>True</tt> if the element was added to this queue, else <tt>false</tt>
+  - id: 2
+    name: put
     since: 2.0
-    id: 1
-  - name: put
     doc: |
       Inserts the specified element into this queue, waiting if necessary for space to become available.
     request:
@@ -60,9 +62,9 @@ methods:
           doc: |
             The element to add
     response: {}
+  - id: 3
+    name: size
     since: 2.0
-    id: 2
-  - name: size
     doc: |
       Returns the number of elements in this collection.  If this collection contains more than Integer.MAX_VALUE
       elements, returns Integer.MAX_VALUE
@@ -85,9 +87,9 @@ methods:
           since: 2.0
           doc: |
             The number of elements in this collection
+  - id: 4
+    name: remove
     since: 2.0
-    id: 3
-  - name: remove
     doc: |
       Retrieves and removes the head of this queue.  This method differs from poll only in that it throws an exception
       if this queue is empty.
@@ -116,9 +118,9 @@ methods:
           since: 2.0
           doc: |
             <tt>true</tt> if this queue changed as a result of the call
+  - id: 5
+    name: poll
     since: 2.0
-    id: 4
-  - name: poll
     doc: |
       Retrieves and removes the head of this queue, waiting up to the specified wait time if necessary for an element
       to become available.
@@ -147,9 +149,9 @@ methods:
           since: 2.0
           doc: |
             The head of this queue, or <tt>null</tt> if this queue is empty
+  - id: 6
+    name: take
     since: 2.0
-    id: 5
-  - name: take
     doc: |
       Retrieves and removes the head of this queue, waiting if necessary until an element becomes available.
     request:
@@ -171,9 +173,9 @@ methods:
           since: 2.0
           doc: |
             The head of this queue
+  - id: 7
+    name: peek
     since: 2.0
-    id: 6
-  - name: peek
     doc: |
       Retrieves, but does not remove, the head of this queue, or returns null if this queue is empty.
     request:
@@ -195,9 +197,9 @@ methods:
           since: 2.0
           doc: |
             The head of this queue, or <tt>null</tt> if this queue is empty
+  - id: 8
+    name: iterator
     since: 2.0
-    id: 7
-  - name: iterator
     doc: |
       Returns an iterator over the elements in this collection.  There are no guarantees concerning the order in which
       the elements are returned (unless this collection is an instance of some class that provides a guarantee).
@@ -220,9 +222,9 @@ methods:
           since: 2.0
           doc: |
             list of all data in queue
+  - id: 9
+    name: drainTo
     since: 2.0
-    id: 8
-  - name: drainTo
     doc: |
       Removes all available elements from this queue and adds them to the given collection.  This operation may be more
       efficient than repeatedly polling this queue.  A failure encountered while attempting to add elements to
@@ -248,9 +250,9 @@ methods:
           since: 2.0
           doc: |
             list of all removed data in queue
+  - id: 10
+    name: drainToMaxSize
     since: 2.0
-    id: 9
-  - name: drainToMaxSize
     doc: |
       Removes at most the given number of available elements from this queue and adds them to the given collection.
       A failure encountered while attempting to add elements to collection may result in elements being in neither,
@@ -282,9 +284,9 @@ methods:
           since: 2.0
           doc: |
             list of all removed data in result of this method
+  - id: 11
+    name: contains
     since: 2.0
-    id: 10
-  - name: contains
     doc: |
       Returns true if this queue contains the specified element. More formally, returns true if and only if this queue
       contains at least one element e such that value.equals(e)
@@ -313,9 +315,9 @@ methods:
           since: 2.0
           doc: |
             <tt>true</tt> if this collection contains the specified element
+  - id: 12
+    name: containsAll
     since: 2.0
-    id: 11
-  - name: containsAll
     doc: |
       Return true if this collection contains all of the elements in the specified collection.
     request:
@@ -343,9 +345,9 @@ methods:
           since: 2.0
           doc: |
             <tt>true</tt> if this collection contains all of the elements in the specified collection
+  - id: 13
+    name: compareAndRemoveAll
     since: 2.0
-    id: 12
-  - name: compareAndRemoveAll
     doc: |
       Removes all of this collection's elements that are also contained in the specified collection (optional operation).
       After this call returns, this collection will contain no elements in common with the specified collection.
@@ -374,9 +376,9 @@ methods:
           since: 2.0
           doc: |
             <tt>true</tt> if this collection changed as a result of the call
+  - id: 14
+    name: compareAndRetainAll
     since: 2.0
-    id: 13
-  - name: compareAndRetainAll
     doc: |
       Retains only the elements in this collection that are contained in the specified collection (optional operation).
       In other words, removes from this collection all of its elements that are not contained in the specified collection.
@@ -405,9 +407,9 @@ methods:
           since: 2.0
           doc: |
             <tt>true</tt> if this collection changed as a result of the call
+  - id: 15
+    name: clear
     since: 2.0
-    id: 14
-  - name: clear
     doc: |
       Removes all of the elements from this collection (optional operation). The collection will be empty after this
       method returns.
@@ -423,9 +425,9 @@ methods:
           doc: |
             Name of the Queue
     response: {}
+  - id: 16
+    name: addAll
     since: 2.0
-    id: 15
-  - name: addAll
     doc: |
       Adds all of the elements in the specified collection to this collection (optional operation).The behavior of this
       operation is undefined if the specified collection is modified while the operation is in progress.
@@ -456,9 +458,9 @@ methods:
           since: 2.0
           doc: |
             <tt>true</tt> if this collection changed as a result of the call
+  - id: 17
+    name: addListener
     since: 2.0
-    id: 16
-  - name: addListener
     doc: |
       Adds an listener for this collection. Listener will be notified or all collection add/remove events.
     request:
@@ -513,9 +515,9 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
+  - id: 18
+    name: removeListener
     since: 2.0
-    id: 17
-  - name: removeListener
     doc: |
       Removes the specified item listener.Returns silently if the specified listener was not added before.
     request:
@@ -543,9 +545,9 @@ methods:
           since: 2.0
           doc: |
             True if the item listener is removed, false otherwise
+  - id: 19
+    name: remainingCapacity
     since: 2.0
-    id: 18
-  - name: remainingCapacity
     doc: |
       Returns the number of additional elements that this queue can ideally (in the absence of memory or resource
       constraints) accept without blocking, or Integer.MAX_VALUE if there is no intrinsic limit. Note that you cannot
@@ -570,9 +572,9 @@ methods:
           since: 2.0
           doc: |
             The remaining capacity
+  - id: 20
+    name: isEmpty
     since: 2.0
-    id: 19
-  - name: isEmpty
     doc: |
       Returns true if this collection contains no elements.
     request:
@@ -594,5 +596,3 @@ methods:
           since: 2.0
           doc: |
             <tt>True</tt> if this collection contains no elements
-    since: 2.0
-    id: 20

--- a/protocol-definitions/ReplicatedMap.yaml
+++ b/protocol-definitions/ReplicatedMap.yaml
@@ -8,7 +8,6 @@ methods:
       be replaced by the specified one and returned from the call. In addition, you have to specify a ttl and its TimeUnit
       to define when the value is outdated and thus should be removed from the replicated map.
     request:
-      id: 0x0e01
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -38,7 +37,6 @@ methods:
           doc: |
             ttl in milliseconds to be associated with the specified key-value pair
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -47,12 +45,12 @@ methods:
           doc: |
             The old value if existed for the key.
     since: 2.0
+    id: 1
   - name: size
     doc: |
       Returns the number of key-value mappings in this map. If the map contains more than Integer.MAX_VALUE elements,
       returns Integer.MAX_VALUE.
     request:
-      id: 0x0e02
       retryable: true
       acquiresResource: false
       partitionIdentifier: random
@@ -64,7 +62,6 @@ methods:
           doc: |
             Name of the ReplicatedMap
     response:
-      id: 0x0066
       params:
         - name: response
           type: int
@@ -73,11 +70,11 @@ methods:
           doc: |
             the number of key-value mappings in this map.
     since: 2.0
+    id: 2
   - name: isEmpty
     doc: |
       Return true if this map contains no key-value mappings
     request:
-      id: 0x0e03
       retryable: true
       acquiresResource: false
       partitionIdentifier: random
@@ -89,7 +86,6 @@ methods:
           doc: |
             Name of the ReplicatedMap
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -98,11 +94,11 @@ methods:
           doc: |
             <tt>True</tt> if this map contains no key-value mappings
     since: 2.0
+    id: 3
   - name: containsKey
     doc: |
       Returns true if this map contains a mapping for the specified key.
     request:
-      id: 0x0e04
       retryable: true
       acquiresResource: false
       partitionIdentifier: key
@@ -120,7 +116,6 @@ methods:
           doc: |
             The key whose associated value is to be returned.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -129,12 +124,12 @@ methods:
           doc: |
             <tt>True</tt> if this map contains a mapping for the specified key
     since: 2.0
+    id: 4
   - name: containsValue
     doc: |
       Returns true if this map maps one or more keys to the specified value.
       This operation will probably require time linear in the map size for most implementations of the Map interface.
     request:
-      id: 0x0e05
       retryable: true
       acquiresResource: false
       partitionIdentifier: random
@@ -152,7 +147,6 @@ methods:
           doc: |
             value whose presence in this map is to be tested
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -161,6 +155,7 @@ methods:
           doc: |
             <tt>true</tt> if this map maps one or more keys to the specified value
     since: 2.0
+    id: 5
   - name: get
     doc: |
       Returns the value to which the specified key is mapped, or null if this map contains no mapping for the key.
@@ -168,7 +163,6 @@ methods:
       necessarily indicate that the map contains no mapping for the key; it's also possible that the map
       explicitly maps the key to null.  The #containsKey operation may be used to distinguish these two cases.
     request:
-      id: 0x0e06
       retryable: true
       acquiresResource: false
       partitionIdentifier: key
@@ -186,7 +180,6 @@ methods:
           doc: |
             The key whose associated value is to be returned
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -195,6 +188,7 @@ methods:
           doc: |
             The value to which the specified key is mapped, or null if this map contains no mapping for the key
     since: 2.0
+    id: 6
   - name: remove
     doc: |
       Removes the mapping for a key from this map if it is present (optional operation). Returns the value to which this map previously associated the key,
@@ -202,7 +196,6 @@ methods:
       null does not necessarily indicate that the map contained no mapping for the key; it's also possible that the map
       explicitly mapped the key to null. The map will not contain a mapping for the specified key once the call returns.
     request:
-      id: 0x0e07
       retryable: false
       acquiresResource: false
       partitionIdentifier: key
@@ -220,7 +213,6 @@ methods:
           doc: |
             Key with which the specified value is to be associated.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -229,6 +221,7 @@ methods:
           doc: |
             the previous value associated with <tt>key</tt>, or <tt>null</tt> if there was no mapping for <tt>key</tt>.
     since: 2.0
+    id: 7
   - name: putAll
     doc: |
       Copies all of the mappings from the specified map to this map (optional operation). The effect of this call is
@@ -236,7 +229,6 @@ methods:
       v in the specified map. The behavior of this operation is undefined if the specified map is modified while the
       operation is in progress.
     request:
-      id: 0x0e08
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -253,9 +245,9 @@ methods:
           since: 2.0
           doc: |
             entries to be stored in this map
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 8
   - name: clear
     doc: |
       The clear operation wipes data out of the replicated maps.It is the only synchronous remote operation in this
@@ -263,7 +255,6 @@ methods:
       it is retried for at most 3 times (on the failing nodes only). If it does not work after the third time, this
       method throws a OPERATION_TIMEOUT back to the caller.
     request:
-      id: 0x0e09
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -274,15 +265,14 @@ methods:
           since: 2.0
           doc: |
             Name of the Replicated Map
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 9
   - name: addEntryListenerToKeyWithPredicate
     doc: |
       Adds an continuous entry listener for this map. The listener will be notified for map add/remove/update/evict
       events filtered by the given predicate.
     request:
-      id: 0x0e0a
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -312,7 +302,6 @@ methods:
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -321,8 +310,7 @@ methods:
           doc: |
             A unique string  which is used as a key to remove the listener.
     events:
-      - id: 0x00cb
-        name: Entry
+      - name: Entry
         params:
           - name: key
             type: Data
@@ -367,12 +355,12 @@ methods:
             doc: |
               TODO DOC
     since: 2.0
+    id: 10
   - name: addEntryListenerWithPredicate
     doc: |
       Adds an continuous entry listener for this map. The listener will be notified for map add/remove/update/evict
       events filtered by the given predicate.
     request:
-      id: 0x0e0b
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -396,7 +384,6 @@ methods:
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -405,8 +392,7 @@ methods:
           doc: |
             A unique string  which is used as a key to remove the listener.
     events:
-      - id: 0x00cb
-        name: Entry
+      - name: Entry
         params:
           - name: key
             type: Data
@@ -451,12 +437,12 @@ methods:
             doc: |
               TODO DOC
     since: 2.0
+    id: 11
   - name: addEntryListenerToKey
     doc: |
       Adds the specified entry listener for the specified key. The listener will be notified for all
       add/remove/update/evict events of the specified key only.
     request:
-      id: 0x0e0c
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -480,7 +466,6 @@ methods:
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -489,8 +474,7 @@ methods:
           doc: |
             A unique string  which is used as a key to remove the listener.
     events:
-      - id: 0x00cb
-        name: Entry
+      - name: Entry
         params:
           - name: key
             type: Data
@@ -535,11 +519,11 @@ methods:
             doc: |
               TODO DOC
     since: 2.0
+    id: 12
   - name: addEntryListener
     doc: |
       Adds an entry listener for this map. The listener will be notified for all map add/remove/update/evict events.
     request:
-      id: 0x0e0d
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -557,7 +541,6 @@ methods:
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -566,8 +549,7 @@ methods:
           doc: |
             A unique string  which is used as a key to remove the listener.
     events:
-      - id: 0x00cb
-        name: Entry
+      - name: Entry
         params:
           - name: key
             type: Data
@@ -612,11 +594,11 @@ methods:
             doc: |
               TODO DOC
     since: 2.0
+    id: 13
   - name: removeEntryListener
     doc: |
       Removes the specified entry listener. Returns silently if there was no such listener added before.
     request:
-      id: 0x0e0e
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -634,7 +616,6 @@ methods:
           doc: |
             ID of the registered entry listener.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -643,6 +624,7 @@ methods:
           doc: |
             True if registration is removed, false otherwise.
     since: 2.0
+    id: 14
   - name: keySet
     doc: |
       Returns a lazy Set view of the key contained in this map. A LazySet is optimized for querying speed
@@ -652,7 +634,6 @@ methods:
       very poor performance if called repeatedly (for example, in a loop). If the use case is different from querying
       the data, please copy the resulting set into a new java.util.HashSet.
     request:
-      id: 0x0e0f
       retryable: true
       acquiresResource: false
       partitionIdentifier: random
@@ -664,7 +645,6 @@ methods:
           doc: |
             Name of the ReplicatedMap
     response:
-      id: 0x006a
       params:
         - name: response
           type: List_Data
@@ -673,11 +653,11 @@ methods:
           doc: |
             A lazy set view of the keys contained in this map.
     since: 2.0
+    id: 15
   - name: values
     doc: |
       TODO DOC
     request:
-      id: 0x0e10
       retryable: true
       acquiresResource: false
       partitionIdentifier: random
@@ -689,7 +669,6 @@ methods:
           doc: |
             Name of the ReplicatedMap
     response:
-      id: 0x006a
       params:
         - name: response
           type: List_Data
@@ -698,11 +677,11 @@ methods:
           doc: |
             A collection view of the values contained in this map.
     since: 2.0
+    id: 16
   - name: entrySet
     doc: |
       TODO DOC
     request:
-      id: 0x0e11
       retryable: true
       acquiresResource: false
       partitionIdentifier: random
@@ -714,7 +693,6 @@ methods:
           doc: |
             Name of the ReplicatedMap
     response:
-      id: 0x0075
       params:
         - name: response
           type: Map_Data_Data
@@ -723,11 +701,11 @@ methods:
           doc: |
             A lazy set view of the mappings contained in this map.
     since: 2.0
+    id: 17
   - name: addNearCacheEntryListener
     doc: |
       TODO DOC
     request:
-      id: 0x0e12
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -751,7 +729,6 @@ methods:
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -760,8 +737,7 @@ methods:
           doc: |
             A unique string  which is used as a key to remove the listener.
     events:
-      - id: 0x00cb
-        name: Entry
+      - name: Entry
         params:
           - name: key
             type: Data
@@ -806,3 +782,4 @@ methods:
             doc: |
               TODO DOC
     since: 2.0
+    id: 18

--- a/protocol-definitions/ReplicatedMap.yaml
+++ b/protocol-definitions/ReplicatedMap.yaml
@@ -2,7 +2,9 @@ id: 14
 name: ReplicatedMap
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: put
+  - id: 1
+    name: put
+    since: 2.0
     doc: |
       Associates a given value to the specified key and replicates it to the cluster. If there is an old value, it will
       be replaced by the specified one and returned from the call. In addition, you have to specify a ttl and its TimeUnit
@@ -44,9 +46,9 @@ methods:
           since: 2.0
           doc: |
             The old value if existed for the key.
+  - id: 2
+    name: size
     since: 2.0
-    id: 1
-  - name: size
     doc: |
       Returns the number of key-value mappings in this map. If the map contains more than Integer.MAX_VALUE elements,
       returns Integer.MAX_VALUE.
@@ -69,9 +71,9 @@ methods:
           since: 2.0
           doc: |
             the number of key-value mappings in this map.
+  - id: 3
+    name: isEmpty
     since: 2.0
-    id: 2
-  - name: isEmpty
     doc: |
       Return true if this map contains no key-value mappings
     request:
@@ -93,9 +95,9 @@ methods:
           since: 2.0
           doc: |
             <tt>True</tt> if this map contains no key-value mappings
+  - id: 4
+    name: containsKey
     since: 2.0
-    id: 3
-  - name: containsKey
     doc: |
       Returns true if this map contains a mapping for the specified key.
     request:
@@ -123,9 +125,9 @@ methods:
           since: 2.0
           doc: |
             <tt>True</tt> if this map contains a mapping for the specified key
+  - id: 5
+    name: containsValue
     since: 2.0
-    id: 4
-  - name: containsValue
     doc: |
       Returns true if this map maps one or more keys to the specified value.
       This operation will probably require time linear in the map size for most implementations of the Map interface.
@@ -154,9 +156,9 @@ methods:
           since: 2.0
           doc: |
             <tt>true</tt> if this map maps one or more keys to the specified value
+  - id: 6
+    name: get
     since: 2.0
-    id: 5
-  - name: get
     doc: |
       Returns the value to which the specified key is mapped, or null if this map contains no mapping for the key.
       If this map permits null values, then a return value of null does not
@@ -187,9 +189,9 @@ methods:
           since: 2.0
           doc: |
             The value to which the specified key is mapped, or null if this map contains no mapping for the key
+  - id: 7
+    name: remove
     since: 2.0
-    id: 6
-  - name: remove
     doc: |
       Removes the mapping for a key from this map if it is present (optional operation). Returns the value to which this map previously associated the key,
       or null if the map contained no mapping for the key. If this map permits null values, then a return value of
@@ -220,9 +222,9 @@ methods:
           since: 2.0
           doc: |
             the previous value associated with <tt>key</tt>, or <tt>null</tt> if there was no mapping for <tt>key</tt>.
+  - id: 8
+    name: putAll
     since: 2.0
-    id: 7
-  - name: putAll
     doc: |
       Copies all of the mappings from the specified map to this map (optional operation). The effect of this call is
       equivalent to that of calling put(Object,Object) put(k, v) on this map once for each mapping from key k to value
@@ -246,9 +248,9 @@ methods:
           doc: |
             entries to be stored in this map
     response: {}
+  - id: 9
+    name: clear
     since: 2.0
-    id: 8
-  - name: clear
     doc: |
       The clear operation wipes data out of the replicated maps.It is the only synchronous remote operation in this
       implementation, so be aware that this might be a slow operation. If some node fails on executing the operation,
@@ -266,9 +268,9 @@ methods:
           doc: |
             Name of the Replicated Map
     response: {}
+  - id: 10
+    name: addEntryListenerToKeyWithPredicate
     since: 2.0
-    id: 9
-  - name: addEntryListenerToKeyWithPredicate
     doc: |
       Adds an continuous entry listener for this map. The listener will be notified for map add/remove/update/evict
       events filtered by the given predicate.
@@ -354,9 +356,9 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
+  - id: 11
+    name: addEntryListenerWithPredicate
     since: 2.0
-    id: 10
-  - name: addEntryListenerWithPredicate
     doc: |
       Adds an continuous entry listener for this map. The listener will be notified for map add/remove/update/evict
       events filtered by the given predicate.
@@ -436,9 +438,9 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
+  - id: 12
+    name: addEntryListenerToKey
     since: 2.0
-    id: 11
-  - name: addEntryListenerToKey
     doc: |
       Adds the specified entry listener for the specified key. The listener will be notified for all
       add/remove/update/evict events of the specified key only.
@@ -518,9 +520,9 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
+  - id: 13
+    name: addEntryListener
     since: 2.0
-    id: 12
-  - name: addEntryListener
     doc: |
       Adds an entry listener for this map. The listener will be notified for all map add/remove/update/evict events.
     request:
@@ -593,9 +595,9 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
+  - id: 14
+    name: removeEntryListener
     since: 2.0
-    id: 13
-  - name: removeEntryListener
     doc: |
       Removes the specified entry listener. Returns silently if there was no such listener added before.
     request:
@@ -623,9 +625,9 @@ methods:
           since: 2.0
           doc: |
             True if registration is removed, false otherwise.
+  - id: 15
+    name: keySet
     since: 2.0
-    id: 14
-  - name: keySet
     doc: |
       Returns a lazy Set view of the key contained in this map. A LazySet is optimized for querying speed
       (preventing eager deserialization and hashing on HashSet insertion) and does NOT provide all operations.
@@ -652,9 +654,9 @@ methods:
           since: 2.0
           doc: |
             A lazy set view of the keys contained in this map.
+  - id: 16
+    name: values
     since: 2.0
-    id: 15
-  - name: values
     doc: |
       TODO DOC
     request:
@@ -676,9 +678,9 @@ methods:
           since: 2.0
           doc: |
             A collection view of the values contained in this map.
+  - id: 17
+    name: entrySet
     since: 2.0
-    id: 16
-  - name: entrySet
     doc: |
       TODO DOC
     request:
@@ -700,9 +702,9 @@ methods:
           since: 2.0
           doc: |
             A lazy set view of the mappings contained in this map.
+  - id: 18
+    name: addNearCacheEntryListener
     since: 2.0
-    id: 17
-  - name: addNearCacheEntryListener
     doc: |
       TODO DOC
     request:
@@ -781,5 +783,3 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
-    since: 2.0
-    id: 18

--- a/protocol-definitions/ReplicatedMap.yaml
+++ b/protocol-definitions/ReplicatedMap.yaml
@@ -1,6 +1,5 @@
 id: 14
 name: ReplicatedMap
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: put

--- a/protocol-definitions/Ringbuffer.yaml
+++ b/protocol-definitions/Ringbuffer.yaml
@@ -7,7 +7,6 @@ methods:
       Returns number of items in the ringbuffer. If no ttl is set, the size will always be equal to capacity after the
       head completed the first looparound the ring. This is because no items are getting retired.
     request:
-      id: 0x1901
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -19,7 +18,6 @@ methods:
           doc: |
             Name of the Ringbuffer
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -28,12 +26,12 @@ methods:
           doc: |
             the size
     since: 2.0
+    id: 1
   - name: tailSequence
     doc: |
       Returns the sequence of the tail. The tail is the side of the ringbuffer where the items are added to.
       The initial value of the tail is -1.
     request:
-      id: 0x1902
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -45,7 +43,6 @@ methods:
           doc: |
             Name of the Ringbuffer
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -54,13 +51,13 @@ methods:
           doc: |
             the sequence of the tail
     since: 2.0
+    id: 2
   - name: headSequence
     doc: |
       Returns the sequence of the head. The head is the side of the ringbuffer where the oldest items in the ringbuffer
       are found. If the RingBuffer is empty, the head will be one more than the tail.
       The initial value of the head is 0 (1 more than tail).
     request:
-      id: 0x1903
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -72,7 +69,6 @@ methods:
           doc: |
             Name of the Ringbuffer
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -81,11 +77,11 @@ methods:
           doc: |
             the sequence of the head
     since: 2.0
+    id: 3
   - name: capacity
     doc: |
       Returns the capacity of this Ringbuffer.
     request:
-      id: 0x1904
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -97,7 +93,6 @@ methods:
           doc: |
             Name of the Ringbuffer
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -106,12 +101,12 @@ methods:
           doc: |
             the capacity
     since: 2.0
+    id: 4
   - name: remainingCapacity
     doc: |
       Returns the remaining capacity of the ringbuffer. The returned value could be stale as soon as it is returned.
       If ttl is not set, the remaining capacity will always be the capacity.
     request:
-      id: 0x1905
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -123,7 +118,6 @@ methods:
           doc: |
             Name of the Ringbuffer
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -132,6 +126,7 @@ methods:
           doc: |
             the remaining capacity
     since: 2.0
+    id: 5
   - name: add
     doc: |
       Adds an item to the tail of the Ringbuffer. If there is space in the ringbuffer, the call
@@ -146,7 +141,6 @@ methods:
       this id is not the sequence of the item you are about to publish but from a previously published item. So it can't be used
       to find that item.
     request:
-      id: 0x1906
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -170,7 +164,6 @@ methods:
           doc: |
             to item to add
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -179,6 +172,7 @@ methods:
           doc: |
             the sequence of the added item, or -1 if the add failed.
     since: 2.0
+    id: 6
   - name: readOne
     doc: |
       Reads one item from the Ringbuffer. If the sequence is one beyond the current tail, this call blocks until an
@@ -186,7 +180,6 @@ methods:
       readers or it can be read multiple times by the same reader. Currently it isn't possible to control how long this
       call is going to block. In the future we could add e.g. tryReadOne(long sequence, long timeout, TimeUnit unit).
     request:
-      id: 0x1908
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -204,7 +197,6 @@ methods:
           doc: |
             the sequence of the item to read.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -213,6 +205,7 @@ methods:
           doc: |
             the read item
     since: 2.0
+    id: 8
   - name: addAll
     doc: |
       Adds all the items of a collection to the tail of the Ringbuffer. A addAll is likely to outperform multiple calls
@@ -224,7 +217,6 @@ methods:
       If an addAll is executed concurrently with an add or addAll, no guarantee is given that items are contiguous.
       The result of the future contains the sequenceId of the last written item
     request:
-      id: 0x1909
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -248,7 +240,6 @@ methods:
           doc: |
             the overflowPolicy to use
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -257,6 +248,7 @@ methods:
           doc: |
             the ICompletableFuture to synchronize on completion.
     since: 2.0
+    id: 9
   - name: readMany
     doc: |
       Reads a batch of items from the Ringbuffer. If the number of available items after the first read item is smaller
@@ -267,7 +259,6 @@ methods:
       true are returned. Using filters is a good way to prevent getting items that are of no value to the receiver.
       This reduces the amount of IO and the number of operations being executed, and can result in a significant performance improvement.
     request:
-      id: 0x190a
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -303,7 +294,6 @@ methods:
           doc: |
             Filter is allowed to be null, indicating there is no filter.
     response:
-      id: 0x0073
       params:
         - name: readCount
           type: int
@@ -330,3 +320,4 @@ methods:
           doc: |
             TODO DOC
     since: 2.0
+    id: 10

--- a/protocol-definitions/Ringbuffer.yaml
+++ b/protocol-definitions/Ringbuffer.yaml
@@ -1,6 +1,5 @@
 id: 25
 name: Ringbuffer
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: size

--- a/protocol-definitions/Ringbuffer.yaml
+++ b/protocol-definitions/Ringbuffer.yaml
@@ -2,7 +2,9 @@ id: 25
 name: Ringbuffer
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: size
+  - id: 1
+    name: size
+    since: 2.0
     doc: |
       Returns number of items in the ringbuffer. If no ttl is set, the size will always be equal to capacity after the
       head completed the first looparound the ring. This is because no items are getting retired.
@@ -25,9 +27,9 @@ methods:
           since: 2.0
           doc: |
             the size
+  - id: 2
+    name: tailSequence
     since: 2.0
-    id: 1
-  - name: tailSequence
     doc: |
       Returns the sequence of the tail. The tail is the side of the ringbuffer where the items are added to.
       The initial value of the tail is -1.
@@ -50,9 +52,9 @@ methods:
           since: 2.0
           doc: |
             the sequence of the tail
+  - id: 3
+    name: headSequence
     since: 2.0
-    id: 2
-  - name: headSequence
     doc: |
       Returns the sequence of the head. The head is the side of the ringbuffer where the oldest items in the ringbuffer
       are found. If the RingBuffer is empty, the head will be one more than the tail.
@@ -76,9 +78,9 @@ methods:
           since: 2.0
           doc: |
             the sequence of the head
+  - id: 4
+    name: capacity
     since: 2.0
-    id: 3
-  - name: capacity
     doc: |
       Returns the capacity of this Ringbuffer.
     request:
@@ -100,9 +102,9 @@ methods:
           since: 2.0
           doc: |
             the capacity
+  - id: 5
+    name: remainingCapacity
     since: 2.0
-    id: 4
-  - name: remainingCapacity
     doc: |
       Returns the remaining capacity of the ringbuffer. The returned value could be stale as soon as it is returned.
       If ttl is not set, the remaining capacity will always be the capacity.
@@ -125,9 +127,9 @@ methods:
           since: 2.0
           doc: |
             the remaining capacity
+  - id: 6
+    name: add
     since: 2.0
-    id: 5
-  - name: add
     doc: |
       Adds an item to the tail of the Ringbuffer. If there is space in the ringbuffer, the call
       will return the sequence of the written item. If there is no space, it depends on the overflow policy what happens:
@@ -171,9 +173,9 @@ methods:
           since: 2.0
           doc: |
             the sequence of the added item, or -1 if the add failed.
+  - id: 8
+    name: readOne
     since: 2.0
-    id: 6
-  - name: readOne
     doc: |
       Reads one item from the Ringbuffer. If the sequence is one beyond the current tail, this call blocks until an
       item is added. This method is not destructive unlike e.g. a queue.take. So the same item can be read by multiple
@@ -204,9 +206,9 @@ methods:
           since: 2.0
           doc: |
             the read item
+  - id: 9
+    name: addAll
     since: 2.0
-    id: 8
-  - name: addAll
     doc: |
       Adds all the items of a collection to the tail of the Ringbuffer. A addAll is likely to outperform multiple calls
       to add(Object) due to better io utilization and a reduced number of executed operations. If the batch is empty,
@@ -247,9 +249,9 @@ methods:
           since: 2.0
           doc: |
             the ICompletableFuture to synchronize on completion.
+  - id: 10
+    name: readMany
     since: 2.0
-    id: 9
-  - name: readMany
     doc: |
       Reads a batch of items from the Ringbuffer. If the number of available items after the first read item is smaller
       than the maxCount, these items are returned. So it could be the number of items read is smaller than the maxCount.
@@ -319,5 +321,3 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
-    since: 2.0
-    id: 10

--- a/protocol-definitions/ScheduledExecutor.yaml
+++ b/protocol-definitions/ScheduledExecutor.yaml
@@ -2,7 +2,9 @@ id: 29
 name: ScheduledExecutor
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: shutdown
+  - id: 1
+    name: shutdown
+    since: 2.0
     doc: |
       Initiates an orderly shutdown in which previously submitted tasks are executed, but no new tasks will be accepted.
       Invocation has no additional effect if already shut down.
@@ -24,9 +26,9 @@ methods:
           doc: |
             The cluster member where the shutdown for this scheduler will be sent.
     response: {}
+  - id: 2
+    name: submitToPartition
     since: 2.0
-    id: 1
-  - name: submitToPartition
     doc: |
       Submits the task to partition for execution, partition is chosen based on multiple criteria of the given task.
     request:
@@ -71,9 +73,9 @@ methods:
           doc: |
             period between each run in milliseconds
     response: {}
+  - id: 3
+    name: submitToAddress
     since: 2.0
-    id: 2
-  - name: submitToAddress
     doc: |
       Submits the task to a member for execution, member is provided in the form of an address.
     request:
@@ -124,9 +126,9 @@ methods:
           doc: |
             period between each run in milliseconds
     response: {}
+  - id: 4
+    name: getAllScheduledFutures
     since: 2.0
-    id: 3
-  - name: getAllScheduledFutures
     doc: |
       Returns all scheduled tasks in for a given scheduler in the given member.
     request:
@@ -148,9 +150,9 @@ methods:
           since: 2.0
           doc: |
             A list of scheduled task handlers used to construct the future proxies.
+  - id: 5
+    name: getStatsFromPartition
     since: 2.0
-    id: 4
-  - name: getStatsFromPartition
     doc: |
       Returns statistics of the task
     request:
@@ -202,9 +204,9 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
+  - id: 6
+    name: getStatsFromAddress
     since: 2.0
-    id: 5
-  - name: getStatsFromAddress
     doc: |
       Returns statistics of the task
     request:
@@ -262,9 +264,9 @@ methods:
           since: 2.0
           doc: |
             TODO DOC
+  - id: 7
+    name: getDelayFromPartition
     since: 2.0
-    id: 6
-  - name: getDelayFromPartition
     doc: |
       Returns the ScheduledFuture's delay in nanoseconds for the task in the scheduler.
     request:
@@ -292,9 +294,9 @@ methods:
           since: 2.0
           doc: |
             The remaining delay of the task formatted in nanoseconds.
+  - id: 8
+    name: getDelayFromAddress
     since: 2.0
-    id: 7
-  - name: getDelayFromAddress
     doc: |
       Returns the ScheduledFuture's delay in nanoseconds for the task in the scheduler.
     request:
@@ -328,9 +330,9 @@ methods:
           since: 2.0
           doc: |
             The remaining delay of the task formatted in nanoseconds.
+  - id: 9
+    name: cancelFromPartition
     since: 2.0
-    id: 8
-  - name: cancelFromPartition
     doc: |
       Cancels further execution and scheduling of the task
     request:
@@ -364,9 +366,9 @@ methods:
           since: 2.0
           doc: |
             True if the task was cancelled
+  - id: 10
+    name: cancelFromAddress
     since: 2.0
-    id: 9
-  - name: cancelFromAddress
     doc: |
       Cancels further execution and scheduling of the task
     request:
@@ -406,9 +408,9 @@ methods:
           since: 2.0
           doc: |
             True if the task was cancelled
+  - id: 11
+    name: isCancelledFromPartition
     since: 2.0
-    id: 10
-  - name: isCancelledFromPartition
     doc: |
       Checks whether a task as identified from the given handler is already cancelled.
     request:
@@ -436,9 +438,9 @@ methods:
           since: 2.0
           doc: |
             True if the task is cancelled
+  - id: 12
+    name: isCancelledFromAddress
     since: 2.0
-    id: 11
-  - name: isCancelledFromAddress
     doc: |
       Checks whether a task as identified from the given handler is already cancelled.
     request:
@@ -472,9 +474,9 @@ methods:
           since: 2.0
           doc: |
             True if the task is cancelled
+  - id: 13
+    name: isDoneFromPartition
     since: 2.0
-    id: 12
-  - name: isDoneFromPartition
     doc: |
       Checks whether a task is done.
       @see {@link java.util.concurrent.Future#cancel(boolean)}
@@ -503,9 +505,9 @@ methods:
           since: 2.0
           doc: |
             True if the task is done
+  - id: 14
+    name: isDoneFromAddress
     since: 2.0
-    id: 13
-  - name: isDoneFromAddress
     doc: |
       Checks whether a task is done.
       @see {@link java.util.concurrent.Future#cancel(boolean)}
@@ -540,9 +542,9 @@ methods:
           since: 2.0
           doc: |
             True if the task is done
+  - id: 15
+    name: getResultFromPartition
     since: 2.0
-    id: 14
-  - name: getResultFromPartition
     doc: |
       Fetches the result of the task ({@link java.util.concurrent.Callable})
       The call will blocking until the result is ready.
@@ -571,9 +573,9 @@ methods:
           since: 2.0
           doc: |
             The result of the completed task, in serialized form ({
+  - id: 16
+    name: getResultFromAddress
     since: 2.0
-    id: 15
-  - name: getResultFromAddress
     doc: |
       Fetches the result of the task ({@link java.util.concurrent.Callable})
       The call will blocking until the result is ready.
@@ -608,9 +610,9 @@ methods:
           since: 2.0
           doc: |
             The result of the completed task, in serialized form ({
+  - id: 17
+    name: disposeFromPartition
     since: 2.0
-    id: 16
-  - name: disposeFromPartition
     doc: |
       Dispose the task from the scheduler
     request:
@@ -631,9 +633,9 @@ methods:
           doc: |
             The name of the task
     response: {}
+  - id: 18
+    name: disposeFromAddress
     since: 2.0
-    id: 17
-  - name: disposeFromAddress
     doc: |
       Dispose the task from the scheduler
     request:
@@ -660,5 +662,3 @@ methods:
           doc: |
             The address of the member where the task will get scheduled.
     response: {}
-    since: 2.0
-    id: 18

--- a/protocol-definitions/ScheduledExecutor.yaml
+++ b/protocol-definitions/ScheduledExecutor.yaml
@@ -7,7 +7,6 @@ methods:
       Initiates an orderly shutdown in which previously submitted tasks are executed, but no new tasks will be accepted.
       Invocation has no additional effect if already shut down.
     request:
-      id: 0x1d01
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -24,14 +23,13 @@ methods:
           since: 2.0
           doc: |
             The cluster member where the shutdown for this scheduler will be sent.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 1
   - name: submitToPartition
     doc: |
       Submits the task to partition for execution, partition is chosen based on multiple criteria of the given task.
     request:
-      id: 0x1d02
       retryable: true
       acquiresResource: false
       partitionIdentifier: taskName
@@ -72,14 +70,13 @@ methods:
           since: 2.0
           doc: |
             period between each run in milliseconds
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 2
   - name: submitToAddress
     doc: |
       Submits the task to a member for execution, member is provided in the form of an address.
     request:
-      id: 0x1d03
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -126,14 +123,13 @@ methods:
           since: 2.0
           doc: |
             period between each run in milliseconds
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 3
   - name: getAllScheduledFutures
     doc: |
       Returns all scheduled tasks in for a given scheduler in the given member.
     request:
-      id: 0x1d04
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -145,7 +141,6 @@ methods:
           doc: |
             The name of the scheduler.
     response:
-      id: 0x0079
       params:
         - name: handlers
           type: Map_Member_List_ScheduledTaskHandler
@@ -154,11 +149,11 @@ methods:
           doc: |
             A list of scheduled task handlers used to construct the future proxies.
     since: 2.0
+    id: 4
   - name: getStatsFromPartition
     doc: |
       Returns statistics of the task
     request:
-      id: 0x1d05
       retryable: true
       acquiresResource: false
       partitionIdentifier: taskName
@@ -176,7 +171,6 @@ methods:
           doc: |
             The name of the task
     response:
-      id: 0x0078
       params:
         - name: lastIdleTimeNanos
           type: long
@@ -209,11 +203,11 @@ methods:
           doc: |
             TODO DOC
     since: 2.0
+    id: 5
   - name: getStatsFromAddress
     doc: |
       Returns statistics of the task
     request:
-      id: 0x1d06
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -237,7 +231,6 @@ methods:
           doc: |
             The address of the member where the task will get scheduled.
     response:
-      id: 0x0078
       params:
         - name: lastIdleTimeNanos
           type: long
@@ -270,11 +263,11 @@ methods:
           doc: |
             TODO DOC
     since: 2.0
+    id: 6
   - name: getDelayFromPartition
     doc: |
       Returns the ScheduledFuture's delay in nanoseconds for the task in the scheduler.
     request:
-      id: 0x1d07
       retryable: true
       acquiresResource: false
       partitionIdentifier: taskName
@@ -292,7 +285,6 @@ methods:
           doc: |
             The name of the task
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -301,11 +293,11 @@ methods:
           doc: |
             The remaining delay of the task formatted in nanoseconds.
     since: 2.0
+    id: 7
   - name: getDelayFromAddress
     doc: |
       Returns the ScheduledFuture's delay in nanoseconds for the task in the scheduler.
     request:
-      id: 0x1d08
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -329,7 +321,6 @@ methods:
           doc: |
             The address of the member where the task will get scheduled.
     response:
-      id: 0x0067
       params:
         - name: response
           type: long
@@ -338,11 +329,11 @@ methods:
           doc: |
             The remaining delay of the task formatted in nanoseconds.
     since: 2.0
+    id: 8
   - name: cancelFromPartition
     doc: |
       Cancels further execution and scheduling of the task
     request:
-      id: 0x1d09
       retryable: true
       acquiresResource: false
       partitionIdentifier: taskName
@@ -366,7 +357,6 @@ methods:
           doc: |
             A boolean flag to indicate whether the task should be interrupted.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -375,11 +365,11 @@ methods:
           doc: |
             True if the task was cancelled
     since: 2.0
+    id: 9
   - name: cancelFromAddress
     doc: |
       Cancels further execution and scheduling of the task
     request:
-      id: 0x1d0a
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -409,7 +399,6 @@ methods:
           doc: |
             A boolean flag to indicate whether the task should be interrupted.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -418,11 +407,11 @@ methods:
           doc: |
             True if the task was cancelled
     since: 2.0
+    id: 10
   - name: isCancelledFromPartition
     doc: |
       Checks whether a task as identified from the given handler is already cancelled.
     request:
-      id: 0x1d0b
       retryable: true
       acquiresResource: false
       partitionIdentifier: taskName
@@ -440,7 +429,6 @@ methods:
           doc: |
             The name of the task
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -449,11 +437,11 @@ methods:
           doc: |
             True if the task is cancelled
     since: 2.0
+    id: 11
   - name: isCancelledFromAddress
     doc: |
       Checks whether a task as identified from the given handler is already cancelled.
     request:
-      id: 0x1d0c
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -477,7 +465,6 @@ methods:
           doc: |
             The address of the member where the task will get scheduled.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -486,12 +473,12 @@ methods:
           doc: |
             True if the task is cancelled
     since: 2.0
+    id: 12
   - name: isDoneFromPartition
     doc: |
       Checks whether a task is done.
       @see {@link java.util.concurrent.Future#cancel(boolean)}
     request:
-      id: 0x1d0d
       retryable: true
       acquiresResource: false
       partitionIdentifier: taskName
@@ -509,7 +496,6 @@ methods:
           doc: |
             The name of the task
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -518,12 +504,12 @@ methods:
           doc: |
             True if the task is done
     since: 2.0
+    id: 13
   - name: isDoneFromAddress
     doc: |
       Checks whether a task is done.
       @see {@link java.util.concurrent.Future#cancel(boolean)}
     request:
-      id: 0x1d0e
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -547,7 +533,6 @@ methods:
           doc: |
             The address of the member where the task will get scheduled.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -556,12 +541,12 @@ methods:
           doc: |
             True if the task is done
     since: 2.0
+    id: 14
   - name: getResultFromPartition
     doc: |
       Fetches the result of the task ({@link java.util.concurrent.Callable})
       The call will blocking until the result is ready.
     request:
-      id: 0x1d0f
       retryable: true
       acquiresResource: false
       partitionIdentifier: taskName
@@ -579,7 +564,6 @@ methods:
           doc: |
             The name of the task
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -588,12 +572,12 @@ methods:
           doc: |
             The result of the completed task, in serialized form ({
     since: 2.0
+    id: 15
   - name: getResultFromAddress
     doc: |
       Fetches the result of the task ({@link java.util.concurrent.Callable})
       The call will blocking until the result is ready.
     request:
-      id: 0x1d10
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -617,7 +601,6 @@ methods:
           doc: |
             The address of the member where the task will get scheduled.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -626,11 +609,11 @@ methods:
           doc: |
             The result of the completed task, in serialized form ({
     since: 2.0
+    id: 16
   - name: disposeFromPartition
     doc: |
       Dispose the task from the scheduler
     request:
-      id: 0x1d11
       retryable: true
       acquiresResource: false
       partitionIdentifier: taskName
@@ -647,14 +630,13 @@ methods:
           since: 2.0
           doc: |
             The name of the task
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 17
   - name: disposeFromAddress
     doc: |
       Dispose the task from the scheduler
     request:
-      id: 0x1d12
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -677,6 +659,6 @@ methods:
           since: 2.0
           doc: |
             The address of the member where the task will get scheduled.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 18

--- a/protocol-definitions/ScheduledExecutor.yaml
+++ b/protocol-definitions/ScheduledExecutor.yaml
@@ -1,6 +1,5 @@
 id: 29
 name: ScheduledExecutor
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: shutdown

--- a/protocol-definitions/Semaphore.yaml
+++ b/protocol-definitions/Semaphore.yaml
@@ -6,7 +6,6 @@ methods:
     doc: |
       Try to initialize this ISemaphore instance with the given permit count
     request:
-      id: 0x0d01
       retryable: false
       acquiresResource: true
       partitionIdentifier: name
@@ -24,7 +23,6 @@ methods:
           doc: |
             The given permit count
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -33,6 +31,7 @@ methods:
           doc: |
             True if initialization succeeds, false otherwise.
     since: 2.0
+    id: 1
   - name: acquire
     doc: |
       Acquires the given number of permits if they are available, and returns immediately, reducing the number of
@@ -43,7 +42,6 @@ methods:
       the current thread. If the current thread has its interrupted status set on entry to this method, or is  while
       waiting for a permit, then  is thrown and the current thread's interrupted status is cleared.
     request:
-      id: 0x0d02
       retryable: false
       acquiresResource: true
       partitionIdentifier: name
@@ -60,15 +58,14 @@ methods:
           since: 2.0
           doc: |
             The given permit count
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 2
   - name: availablePermits
     doc: |
       Returns the current number of permits currently available in this semaphore. This method is typically used for
       debugging and testing purposes.
     request:
-      id: 0x0d03
       retryable: true
       acquiresResource: false
       partitionIdentifier: name
@@ -80,7 +77,6 @@ methods:
           doc: |
             Name of the Semaphore
     response:
-      id: 0x0066
       params:
         - name: response
           type: int
@@ -89,11 +85,11 @@ methods:
           doc: |
             The number of permits available in this semaphore.
     since: 2.0
+    id: 3
   - name: drainPermits
     doc: |
       Acquires and returns all permits that are immediately available.
     request:
-      id: 0x0d04
       retryable: false
       acquiresResource: true
       partitionIdentifier: name
@@ -105,7 +101,6 @@ methods:
           doc: |
             Name of the Semaphore
     response:
-      id: 0x0066
       params:
         - name: response
           type: int
@@ -114,12 +109,12 @@ methods:
           doc: |
             The number of permits drained
     since: 2.0
+    id: 4
   - name: reducePermits
     doc: |
       Shrinks the number of available permits by the indicated reduction. This method differs from  acquire in that it
       does not block waiting for permits to become available.
     request:
-      id: 0x0d05
       retryable: false
       acquiresResource: true
       partitionIdentifier: name
@@ -136,16 +131,15 @@ methods:
           since: 2.0
           doc: |
             The number of permits to remove
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 5
   - name: release
     doc: |
       Releases the given number of permits, increasing the number of available permits by that amount. There is no
       requirement that a thread that releases a permit must have acquired that permit by calling one of the
       acquire()acquire methods. Correct usage of a semaphore is established by programming convention in the application.
     request:
-      id: 0x0d06
       retryable: false
       acquiresResource: true
       partitionIdentifier: name
@@ -162,16 +156,15 @@ methods:
           since: 2.0
           doc: |
             The number of permits to remove
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 6
   - name: tryAcquire
     doc: |
       Acquires the given number of permits, if they are available, and returns immediately, with the value true,
       reducing the number of available permits by the given amount. If insufficient permits are available then this
       method will return immediately with the value false and the number of available permits is unchanged.
     request:
-      id: 0x0d07
       retryable: false
       acquiresResource: true
       partitionIdentifier: name
@@ -195,7 +188,6 @@ methods:
           doc: |
             The maximum time to wait for a permit
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -204,12 +196,12 @@ methods:
           doc: |
             true if all permits were acquired,  false if the waiting time elapsed before all permits could be acquired
     since: 2.0
+    id: 7
   - name: increasePermits
     doc: |
       Increases the number of available permits by the indicated amount. This method differs from {@code release}
       in that it does not effect the amount of permits this caller has attached.
     request:
-      id: 0x0d08
       retryable: false
       acquiresResource: true
       partitionIdentifier: name
@@ -227,6 +219,6 @@ methods:
           doc: |
             The number of permits to add
             @throws IllegalArgumentException if {@code increase} is negative
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 8

--- a/protocol-definitions/Semaphore.yaml
+++ b/protocol-definitions/Semaphore.yaml
@@ -2,7 +2,9 @@ id: 13
 name: Semaphore
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: init
+  - id: 1
+    name: init
+    since: 2.0
     doc: |
       Try to initialize this ISemaphore instance with the given permit count
     request:
@@ -30,9 +32,9 @@ methods:
           since: 2.0
           doc: |
             True if initialization succeeds, false otherwise.
+  - id: 2
+    name: acquire
     since: 2.0
-    id: 1
-  - name: acquire
     doc: |
       Acquires the given number of permits if they are available, and returns immediately, reducing the number of
       available permits by the given amount. If insufficient permits are available then the current thread becomes
@@ -59,9 +61,9 @@ methods:
           doc: |
             The given permit count
     response: {}
+  - id: 3
+    name: availablePermits
     since: 2.0
-    id: 2
-  - name: availablePermits
     doc: |
       Returns the current number of permits currently available in this semaphore. This method is typically used for
       debugging and testing purposes.
@@ -84,9 +86,9 @@ methods:
           since: 2.0
           doc: |
             The number of permits available in this semaphore.
+  - id: 4
+    name: drainPermits
     since: 2.0
-    id: 3
-  - name: drainPermits
     doc: |
       Acquires and returns all permits that are immediately available.
     request:
@@ -108,9 +110,9 @@ methods:
           since: 2.0
           doc: |
             The number of permits drained
+  - id: 5
+    name: reducePermits
     since: 2.0
-    id: 4
-  - name: reducePermits
     doc: |
       Shrinks the number of available permits by the indicated reduction. This method differs from  acquire in that it
       does not block waiting for permits to become available.
@@ -132,9 +134,9 @@ methods:
           doc: |
             The number of permits to remove
     response: {}
+  - id: 6
+    name: release
     since: 2.0
-    id: 5
-  - name: release
     doc: |
       Releases the given number of permits, increasing the number of available permits by that amount. There is no
       requirement that a thread that releases a permit must have acquired that permit by calling one of the
@@ -157,9 +159,9 @@ methods:
           doc: |
             The number of permits to remove
     response: {}
+  - id: 7
+    name: tryAcquire
     since: 2.0
-    id: 6
-  - name: tryAcquire
     doc: |
       Acquires the given number of permits, if they are available, and returns immediately, with the value true,
       reducing the number of available permits by the given amount. If insufficient permits are available then this
@@ -195,9 +197,9 @@ methods:
           since: 2.0
           doc: |
             true if all permits were acquired,  false if the waiting time elapsed before all permits could be acquired
+  - id: 8
+    name: increasePermits
     since: 2.0
-    id: 7
-  - name: increasePermits
     doc: |
       Increases the number of available permits by the indicated amount. This method differs from {@code release}
       in that it does not effect the amount of permits this caller has attached.
@@ -220,5 +222,3 @@ methods:
             The number of permits to add
             @throws IllegalArgumentException if {@code increase} is negative
     response: {}
-    since: 2.0
-    id: 8

--- a/protocol-definitions/Semaphore.yaml
+++ b/protocol-definitions/Semaphore.yaml
@@ -1,6 +1,5 @@
 id: 13
 name: Semaphore
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: init

--- a/protocol-definitions/Set.yaml
+++ b/protocol-definitions/Set.yaml
@@ -1,6 +1,5 @@
 id: 6
 name: Set
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: size

--- a/protocol-definitions/Set.yaml
+++ b/protocol-definitions/Set.yaml
@@ -7,7 +7,6 @@ methods:
       Returns the number of elements in this set (its cardinality). If this set contains more than Integer.MAX_VALUE
       elements, returns Integer.MAX_VALUE.
     request:
-      id: 0x0601
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -19,7 +18,6 @@ methods:
           doc: |
             Name of the Set
     response:
-      id: 0x0066
       params:
         - name: response
           type: int
@@ -28,11 +26,11 @@ methods:
           doc: |
             The number of elements in this set (its cardinality)
     since: 2.0
+    id: 1
   - name: contains
     doc: |
       Returns true if this set contains the specified element.
     request:
-      id: 0x0602
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -50,7 +48,6 @@ methods:
           doc: |
             Element whose presence in this set is to be tested
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -59,12 +56,12 @@ methods:
           doc: |
             True if this set contains the specified element, false otherwise
     since: 2.0
+    id: 2
   - name: containsAll
     doc: |
       Returns true if this set contains all of the elements of the specified collection. If the specified collection is
       also a set, this method returns true if it is a subset of this set.
     request:
-      id: 0x0603
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -82,7 +79,6 @@ methods:
           doc: |
             Collection to be checked for containment in this list
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -92,6 +88,7 @@ methods:
             true if this set contains all of the elements of the
             specified collection
     since: 2.0
+    id: 3
   - name: add
     doc: |
       Adds the specified element to this set if it is not already present (optional operation).
@@ -101,7 +98,6 @@ methods:
       element, including null, and throw an exception, as described in the specification for Collection
       Individual set implementations should clearly document any restrictions on the elements that they may contain.
     request:
-      id: 0x0604
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -119,7 +115,6 @@ methods:
           doc: |
             Element to be added to this set
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -129,13 +124,13 @@ methods:
             True if this set did not already contain the specified
             element and the element is added, returns false otherwise.
     since: 2.0
+    id: 4
   - name: remove
     doc: |
       Removes the specified element from this set if it is present (optional operation).
       Returns true if this set contained the element (or equivalently, if this set changed as a result of the call).
       (This set will not contain the element once the call returns.)
     request:
-      id: 0x0605
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -153,7 +148,6 @@ methods:
           doc: |
             Object to be removed from this set, if present
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -162,6 +156,7 @@ methods:
           doc: |
             True if this set contained the specified element and it is removed successfully
     since: 2.0
+    id: 5
   - name: addAll
     doc: |
       Adds all of the elements in the specified collection to this set if they're not already present
@@ -169,7 +164,6 @@ methods:
       set so that its value is the union of the two sets. The behavior of this operation is undefined if the specified
       collection is modified while the operation is in progress.
     request:
-      id: 0x0606
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -187,7 +181,6 @@ methods:
           doc: |
             Collection containing elements to be added to this set
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -196,13 +189,13 @@ methods:
           doc: |
             True if this set changed as a result of the call
     since: 2.0
+    id: 6
   - name: compareAndRemoveAll
     doc: |
       Removes from this set all of its elements that are contained in the specified collection (optional operation).
       If the specified collection is also a set, this operation effectively modifies this set so that its value is the
       asymmetric set difference of the two sets.
     request:
-      id: 0x0607
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -220,7 +213,6 @@ methods:
           doc: |
             The list of values to test for matching the item to remove.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -229,6 +221,7 @@ methods:
           doc: |
             true if at least one item in values existed and removed, false otherwise.
     since: 2.0
+    id: 7
   - name: compareAndRetainAll
     doc: |
       Retains only the elements in this set that are contained in the specified collection (optional operation).
@@ -236,7 +229,6 @@ methods:
       If the specified collection is also a set, this operation effectively modifies this set so that its value is the
       intersection of the two sets.
     request:
-      id: 0x0608
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -254,7 +246,6 @@ methods:
           doc: |
             The list of values to test for matching the item to retain.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -264,11 +255,11 @@ methods:
             true if at least one item in values existed and it is retained, false otherwise. All items not in valueSet but
             in the Set are removed.
     since: 2.0
+    id: 8
   - name: clear
     doc: |
       Removes all of the elements from this set (optional operation). The set will be empty after this call returns.
     request:
-      id: 0x0609
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -279,14 +270,13 @@ methods:
           since: 2.0
           doc: |
             Name of the Set
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 9
   - name: getAll
     doc: |
       Return the all elements of this collection
     request:
-      id: 0x060a
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -298,7 +288,6 @@ methods:
           doc: |
             Name of the Set
     response:
-      id: 0x006a
       params:
         - name: response
           type: List_Data
@@ -307,11 +296,11 @@ methods:
           doc: |
             Array of all values in the Set
     since: 2.0
+    id: 10
   - name: addListener
     doc: |
       Adds an item listener for this collection. Listener will be notified for all collection add/remove events.
     request:
-      id: 0x060b
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -335,7 +324,6 @@ methods:
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -344,8 +332,7 @@ methods:
           doc: |
             The registration id.
     events:
-      - id: 0x00cc
-        name: Item
+      - name: Item
         params:
           - name: item
             type: Data
@@ -366,11 +353,11 @@ methods:
             doc: |
               TODO DOC
     since: 2.0
+    id: 11
   - name: removeListener
     doc: |
       Removes the specified item listener. Returns silently if the specified listener was not added before.
     request:
-      id: 0x060c
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -388,7 +375,6 @@ methods:
           doc: |
             The id retrieved during registration.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -397,11 +383,11 @@ methods:
           doc: |
             true if the listener with the provided id existed and removed, false otherwise.
     since: 2.0
+    id: 12
   - name: isEmpty
     doc: |
       Returns true if this set contains no elements.
     request:
-      id: 0x060d
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -413,7 +399,6 @@ methods:
           doc: |
             Name of the Set
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -422,3 +407,4 @@ methods:
           doc: |
             True if this set contains no elements
     since: 2.0
+    id: 13

--- a/protocol-definitions/Set.yaml
+++ b/protocol-definitions/Set.yaml
@@ -2,7 +2,9 @@ id: 6
 name: Set
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: size
+  - id: 1
+    name: size
+    since: 2.0
     doc: |
       Returns the number of elements in this set (its cardinality). If this set contains more than Integer.MAX_VALUE
       elements, returns Integer.MAX_VALUE.
@@ -25,9 +27,9 @@ methods:
           since: 2.0
           doc: |
             The number of elements in this set (its cardinality)
+  - id: 2
+    name: contains
     since: 2.0
-    id: 1
-  - name: contains
     doc: |
       Returns true if this set contains the specified element.
     request:
@@ -55,9 +57,9 @@ methods:
           since: 2.0
           doc: |
             True if this set contains the specified element, false otherwise
+  - id: 3
+    name: containsAll
     since: 2.0
-    id: 2
-  - name: containsAll
     doc: |
       Returns true if this set contains all of the elements of the specified collection. If the specified collection is
       also a set, this method returns true if it is a subset of this set.
@@ -87,9 +89,9 @@ methods:
           doc: |
             true if this set contains all of the elements of the
             specified collection
+  - id: 4
+    name: add
     since: 2.0
-    id: 3
-  - name: add
     doc: |
       Adds the specified element to this set if it is not already present (optional operation).
       If this set already contains the element, the call leaves the set unchanged and returns false.In combination with
@@ -123,9 +125,9 @@ methods:
           doc: |
             True if this set did not already contain the specified
             element and the element is added, returns false otherwise.
+  - id: 5
+    name: remove
     since: 2.0
-    id: 4
-  - name: remove
     doc: |
       Removes the specified element from this set if it is present (optional operation).
       Returns true if this set contained the element (or equivalently, if this set changed as a result of the call).
@@ -155,9 +157,9 @@ methods:
           since: 2.0
           doc: |
             True if this set contained the specified element and it is removed successfully
+  - id: 6
+    name: addAll
     since: 2.0
-    id: 5
-  - name: addAll
     doc: |
       Adds all of the elements in the specified collection to this set if they're not already present
       (optional operation). If the specified collection is also a set, the addAll operation effectively modifies this
@@ -188,9 +190,9 @@ methods:
           since: 2.0
           doc: |
             True if this set changed as a result of the call
+  - id: 7
+    name: compareAndRemoveAll
     since: 2.0
-    id: 6
-  - name: compareAndRemoveAll
     doc: |
       Removes from this set all of its elements that are contained in the specified collection (optional operation).
       If the specified collection is also a set, this operation effectively modifies this set so that its value is the
@@ -220,9 +222,9 @@ methods:
           since: 2.0
           doc: |
             true if at least one item in values existed and removed, false otherwise.
+  - id: 8
+    name: compareAndRetainAll
     since: 2.0
-    id: 7
-  - name: compareAndRetainAll
     doc: |
       Retains only the elements in this set that are contained in the specified collection (optional operation).
       In other words, removes from this set all of its elements that are not contained in the specified collection.
@@ -254,9 +256,9 @@ methods:
           doc: |
             true if at least one item in values existed and it is retained, false otherwise. All items not in valueSet but
             in the Set are removed.
+  - id: 9
+    name: clear
     since: 2.0
-    id: 8
-  - name: clear
     doc: |
       Removes all of the elements from this set (optional operation). The set will be empty after this call returns.
     request:
@@ -271,9 +273,9 @@ methods:
           doc: |
             Name of the Set
     response: {}
+  - id: 10
+    name: getAll
     since: 2.0
-    id: 9
-  - name: getAll
     doc: |
       Return the all elements of this collection
     request:
@@ -295,9 +297,9 @@ methods:
           since: 2.0
           doc: |
             Array of all values in the Set
+  - id: 11
+    name: addListener
     since: 2.0
-    id: 10
-  - name: addListener
     doc: |
       Adds an item listener for this collection. Listener will be notified for all collection add/remove events.
     request:
@@ -352,9 +354,9 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
+  - id: 12
+    name: removeListener
     since: 2.0
-    id: 11
-  - name: removeListener
     doc: |
       Removes the specified item listener. Returns silently if the specified listener was not added before.
     request:
@@ -382,9 +384,9 @@ methods:
           since: 2.0
           doc: |
             true if the listener with the provided id existed and removed, false otherwise.
+  - id: 13
+    name: isEmpty
     since: 2.0
-    id: 12
-  - name: isEmpty
     doc: |
       Returns true if this set contains no elements.
     request:
@@ -406,5 +408,3 @@ methods:
           since: 2.0
           doc: |
             True if this set contains no elements
-    since: 2.0
-    id: 13

--- a/protocol-definitions/Topic.yaml
+++ b/protocol-definitions/Topic.yaml
@@ -6,7 +6,6 @@ methods:
     doc: |
       Publishes the message to all subscribers of this topic
     request:
-      id: 0x0401
       retryable: false
       acquiresResource: false
       partitionIdentifier: name
@@ -23,15 +22,14 @@ methods:
           since: 2.0
           doc: |
             The message to publish to all subscribers of this topic
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 1
   - name: addMessageListener
     doc: |
       Subscribes to this topic. When someone publishes a message on this topic. onMessage() function of the given
       MessageListener is called. More than one message listener can be added on one instance.
     request:
-      id: 0x0402
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -49,7 +47,6 @@ methods:
           doc: |
             if true listens only local events on registered member
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -58,8 +55,7 @@ methods:
           doc: |
             returns the registration id
     events:
-      - id: 0x00cd
-        name: Topic
+      - name: Topic
         params:
           - name: item
             type: Data
@@ -80,11 +76,11 @@ methods:
             doc: |
               TODO DOC
     since: 2.0
+    id: 2
   - name: removeMessageListener
     doc: |
       Stops receiving messages for the given message listener.If the given listener already removed, this method does nothing.
     request:
-      id: 0x0403
       retryable: true
       acquiresResource: false
       partitionIdentifier: -1
@@ -102,7 +98,6 @@ methods:
           doc: |
             Id of listener registration.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -111,3 +106,4 @@ methods:
           doc: |
             True if registration is removed, false otherwise
     since: 2.0
+    id: 3

--- a/protocol-definitions/Topic.yaml
+++ b/protocol-definitions/Topic.yaml
@@ -2,7 +2,9 @@ id: 4
 name: Topic
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: publish
+  - id: 1
+    name: publish
+    since: 2.0
     doc: |
       Publishes the message to all subscribers of this topic
     request:
@@ -23,9 +25,9 @@ methods:
           doc: |
             The message to publish to all subscribers of this topic
     response: {}
+  - id: 2
+    name: addMessageListener
     since: 2.0
-    id: 1
-  - name: addMessageListener
     doc: |
       Subscribes to this topic. When someone publishes a message on this topic. onMessage() function of the given
       MessageListener is called. More than one message listener can be added on one instance.
@@ -75,9 +77,9 @@ methods:
             since: 2.0
             doc: |
               TODO DOC
+  - id: 3
+    name: removeMessageListener
     since: 2.0
-    id: 2
-  - name: removeMessageListener
     doc: |
       Stops receiving messages for the given message listener.If the given listener already removed, this method does nothing.
     request:
@@ -105,5 +107,3 @@ methods:
           since: 2.0
           doc: |
             True if registration is removed, false otherwise
-    since: 2.0
-    id: 3

--- a/protocol-definitions/Topic.yaml
+++ b/protocol-definitions/Topic.yaml
@@ -1,6 +1,5 @@
 id: 4
 name: Topic
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: publish

--- a/protocol-definitions/Transaction.yaml
+++ b/protocol-definitions/Transaction.yaml
@@ -1,6 +1,5 @@
 id: 23
 name: Transaction
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: commit

--- a/protocol-definitions/Transaction.yaml
+++ b/protocol-definitions/Transaction.yaml
@@ -6,7 +6,6 @@ methods:
     doc: |
       TODO DOC
     request:
-      id: 0x1701
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -23,14 +22,13 @@ methods:
           since: 2.0
           doc: |
             The thread id for the transaction.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 1
   - name: create
     doc: |
       TODO DOC
     request:
-      id: 0x1702
       retryable: false
       acquiresResource: true
       partitionIdentifier: -1
@@ -66,7 +64,6 @@ methods:
           doc: |
             The thread id for the transaction.
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -75,11 +72,11 @@ methods:
           doc: |
             The transaction id for the created transaction.
     since: 2.0
+    id: 2
   - name: rollback
     doc: |
       TODO DOC
     request:
-      id: 0x1703
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -96,6 +93,6 @@ methods:
           since: 2.0
           doc: |
             The thread id for the transaction.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 3

--- a/protocol-definitions/Transaction.yaml
+++ b/protocol-definitions/Transaction.yaml
@@ -2,7 +2,9 @@ id: 23
 name: Transaction
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: commit
+  - id: 1
+    name: commit
+    since: 2.0
     doc: |
       TODO DOC
     request:
@@ -23,9 +25,9 @@ methods:
           doc: |
             The thread id for the transaction.
     response: {}
+  - id: 2
+    name: create
     since: 2.0
-    id: 1
-  - name: create
     doc: |
       TODO DOC
     request:
@@ -71,9 +73,9 @@ methods:
           since: 2.0
           doc: |
             The transaction id for the created transaction.
+  - id: 3
+    name: rollback
     since: 2.0
-    id: 2
-  - name: rollback
     doc: |
       TODO DOC
     request:
@@ -94,5 +96,3 @@ methods:
           doc: |
             The thread id for the transaction.
     response: {}
-    since: 2.0
-    id: 3

--- a/protocol-definitions/TransactionalList.yaml
+++ b/protocol-definitions/TransactionalList.yaml
@@ -6,7 +6,6 @@ methods:
     doc: |
       Adds a new item to the transactional list.
     request:
-      id: 0x1301
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -36,7 +35,6 @@ methods:
           doc: |
             The new item added to the transactionalList
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -45,11 +43,11 @@ methods:
           doc: |
             True if the item is added successfully, false otherwise
     since: 2.0
+    id: 1
   - name: remove
     doc: |
       Remove item from the transactional list
     request:
-      id: 0x1302
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -79,7 +77,6 @@ methods:
           doc: |
             Item to remove to transactional List
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -88,11 +85,11 @@ methods:
           doc: |
             True if the removed successfully,false otherwise
     since: 2.0
+    id: 2
   - name: size
     doc: |
       Returns the size of the list
     request:
-      id: 0x1303
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -116,7 +113,6 @@ methods:
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
-      id: 0x0066
       params:
         - name: response
           type: int
@@ -125,3 +121,4 @@ methods:
           doc: |
             The size of the list
     since: 2.0
+    id: 3

--- a/protocol-definitions/TransactionalList.yaml
+++ b/protocol-definitions/TransactionalList.yaml
@@ -2,7 +2,9 @@ id: 19
 name: TransactionalList
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: add
+  - id: 1
+    name: add
+    since: 2.0
     doc: |
       Adds a new item to the transactional list.
     request:
@@ -42,9 +44,9 @@ methods:
           since: 2.0
           doc: |
             True if the item is added successfully, false otherwise
+  - id: 2
+    name: remove
     since: 2.0
-    id: 1
-  - name: remove
     doc: |
       Remove item from the transactional list
     request:
@@ -84,9 +86,9 @@ methods:
           since: 2.0
           doc: |
             True if the removed successfully,false otherwise
+  - id: 3
+    name: size
     since: 2.0
-    id: 2
-  - name: size
     doc: |
       Returns the size of the list
     request:
@@ -120,5 +122,3 @@ methods:
           since: 2.0
           doc: |
             The size of the list
-    since: 2.0
-    id: 3

--- a/protocol-definitions/TransactionalList.yaml
+++ b/protocol-definitions/TransactionalList.yaml
@@ -1,6 +1,5 @@
 id: 19
 name: TransactionalList
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: add

--- a/protocol-definitions/TransactionalMap.yaml
+++ b/protocol-definitions/TransactionalMap.yaml
@@ -2,7 +2,9 @@ id: 16
 name: TransactionalMap
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: containsKey
+  - id: 1
+    name: containsKey
+    since: 2.0
     doc: |
       Returns true if this map contains an entry for the specified key.
     request:
@@ -42,9 +44,9 @@ methods:
           since: 2.0
           doc: |
             True if this map contains an entry for the specified key.
+  - id: 2
+    name: get
     since: 2.0
-    id: 1
-  - name: get
     doc: |
       Returns the value for the specified key, or null if this map does not contain this key.
     request:
@@ -84,9 +86,9 @@ methods:
           since: 2.0
           doc: |
             The value for the specified key
+  - id: 3
+    name: getForUpdate
     since: 2.0
-    id: 2
-  - name: getForUpdate
     doc: |
       Locks the key and then gets and returns the value to which the specified key is mapped. Lock will be released at
       the end of the transaction (either commit or rollback).
@@ -127,9 +129,9 @@ methods:
           since: 2.0
           doc: |
             The value for the specified key
+  - id: 4
+    name: size
     since: 2.0
-    id: 3
-  - name: size
     doc: |
       Returns the number of entries in this map.
     request:
@@ -163,9 +165,9 @@ methods:
           since: 2.0
           doc: |
             The number of entries in this map.
+  - id: 5
+    name: isEmpty
     since: 2.0
-    id: 4
-  - name: isEmpty
     doc: |
       Returns true if this map contains no entries.
     request:
@@ -199,9 +201,9 @@ methods:
           since: 2.0
           doc: |
             <tt>true</tt> if this map contains no entries.
+  - id: 6
+    name: put
     since: 2.0
-    id: 5
-  - name: put
     doc: |
       Associates the specified value with the specified key in this map. If the map previously contained a mapping for
       the key, the old value is replaced by the specified value. The object to be put will be accessible only in the
@@ -255,9 +257,9 @@ methods:
           since: 2.0
           doc: |
             Previous value associated with key or  null if there was no mapping for key
+  - id: 7
+    name: set
     since: 2.0
-    id: 6
-  - name: set
     doc: |
       Associates the specified value with the specified key in this map. If the map previously contained a mapping for
       the key, the old value is replaced by the specified value. This method is preferred to #put(Object, Object)
@@ -299,9 +301,9 @@ methods:
           doc: |
             The value to associate with key
     response: {}
+  - id: 8
+    name: putIfAbsent
     since: 2.0
-    id: 7
-  - name: putIfAbsent
     doc: |
       If the specified key is not already associated with a value, associate it with the given value.
       The object to be put will be accessible only in the current transaction context until the transaction is committed.
@@ -348,9 +350,9 @@ methods:
           since: 2.0
           doc: |
             The previous value associated with key, or null if there was no mapping for key.
+  - id: 9
+    name: replace
     since: 2.0
-    id: 8
-  - name: replace
     doc: |
       Replaces the entry for a key only if it is currently mapped to some value. The object to be replaced will be
       accessible only in the current transaction context until the transaction is committed.
@@ -397,9 +399,9 @@ methods:
           since: 2.0
           doc: |
             The previous value associated with key, or null if there was no mapping for key.
+  - id: 10
+    name: replaceIfSame
     since: 2.0
-    id: 9
-  - name: replaceIfSame
     doc: |
       Replaces the entry for a key only if currently mapped to a given value. The object to be replaced will be
       accessible only in the current transaction context until the transaction is committed.
@@ -452,9 +454,9 @@ methods:
           since: 2.0
           doc: |
             true if the value was replaced.
+  - id: 11
+    name: remove
     since: 2.0
-    id: 10
-  - name: remove
     doc: |
       Removes the mapping for a key from this map if it is present. The map will not contain a mapping for the
       specified key once the call returns. The object to be removed will be accessible only in the current transaction
@@ -496,9 +498,9 @@ methods:
           since: 2.0
           doc: |
             The previous value associated with key, or null if there was no mapping for key
+  - id: 12
+    name: delete
     since: 2.0
-    id: 11
-  - name: delete
     doc: |
       Removes the mapping for a key from this map if it is present. The map will not contain a mapping for the specified
       key once the call returns. This method is preferred to #remove(Object) if the old value is not needed. The object
@@ -533,9 +535,9 @@ methods:
           doc: |
             Remove the mapping for this key.
     response: {}
+  - id: 13
+    name: removeIfSame
     since: 2.0
-    id: 12
-  - name: removeIfSame
     doc: |
       Removes the entry for a key only if currently mapped to a given value. The object to be removed will be removed
       from only the current transaction context until the transaction is committed.
@@ -582,9 +584,9 @@ methods:
           since: 2.0
           doc: |
             True if the value was removed
+  - id: 14
+    name: keySet
     since: 2.0
-    id: 13
-  - name: keySet
     doc: |
       Returns a set clone of the keys contained in this map. The set is NOT backed by the map, so changes to the map
       are NOT reflected in the set, and vice-versa. This method is always executed by a distributed query, so it may throw
@@ -620,9 +622,9 @@ methods:
           since: 2.0
           doc: |
             A set clone of the keys contained in this map.
+  - id: 15
+    name: keySetWithPredicate
     since: 2.0
-    id: 14
-  - name: keySetWithPredicate
     doc: |
       Queries the map based on the specified predicate and returns the keys of matching entries. Specified predicate
       runs on all members in parallel.The set is NOT backed by the map, so changes to the map are NOT reflected in the
@@ -665,9 +667,9 @@ methods:
           since: 2.0
           doc: |
             Result key set for the query.
+  - id: 16
+    name: values
     since: 2.0
-    id: 15
-  - name: values
     doc: |
       Returns a collection clone of the values contained in this map. The collection is NOT backed by the map,
       so changes to the map are NOT reflected in the collection, and vice-versa. This method is always executed by a
@@ -703,9 +705,9 @@ methods:
           since: 2.0
           doc: |
             All values in the map
+  - id: 17
+    name: valuesWithPredicate
     since: 2.0
-    id: 16
-  - name: valuesWithPredicate
     doc: |
       Queries the map based on the specified predicate and returns the values of matching entries.Specified predicate
       runs on all members in parallel. The collection is NOT backed by the map, so changes to the map are NOT reflected
@@ -748,9 +750,9 @@ methods:
           since: 2.0
           doc: |
             Result value collection of the query.
+  - id: 18
+    name: containsValue
     since: 2.0
-    id: 17
-  - name: containsValue
     doc: |
       Returns true if this map contains an entry for the specified value.
     request:
@@ -790,5 +792,3 @@ methods:
           since: 2.0
           doc: |
             True if this map contains an entry for the specified key.
-    since: 2.0
-    id: 18

--- a/protocol-definitions/TransactionalMap.yaml
+++ b/protocol-definitions/TransactionalMap.yaml
@@ -1,6 +1,5 @@
 id: 16
 name: TransactionalMap
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: containsKey

--- a/protocol-definitions/TransactionalMap.yaml
+++ b/protocol-definitions/TransactionalMap.yaml
@@ -6,7 +6,6 @@ methods:
     doc: |
       Returns true if this map contains an entry for the specified key.
     request:
-      id: 0x1001
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -36,7 +35,6 @@ methods:
           doc: |
             The specified key.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -45,11 +43,11 @@ methods:
           doc: |
             True if this map contains an entry for the specified key.
     since: 2.0
+    id: 1
   - name: get
     doc: |
       Returns the value for the specified key, or null if this map does not contain this key.
     request:
-      id: 0x1002
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -79,7 +77,6 @@ methods:
           doc: |
             The specified key
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -88,12 +85,12 @@ methods:
           doc: |
             The value for the specified key
     since: 2.0
+    id: 2
   - name: getForUpdate
     doc: |
       Locks the key and then gets and returns the value to which the specified key is mapped. Lock will be released at
       the end of the transaction (either commit or rollback).
     request:
-      id: 0x1003
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -123,7 +120,6 @@ methods:
           doc: |
             The value to which the specified key is mapped
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -132,11 +128,11 @@ methods:
           doc: |
             The value for the specified key
     since: 2.0
+    id: 3
   - name: size
     doc: |
       Returns the number of entries in this map.
     request:
-      id: 0x1004
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -160,7 +156,6 @@ methods:
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
-      id: 0x0066
       params:
         - name: response
           type: int
@@ -169,11 +164,11 @@ methods:
           doc: |
             The number of entries in this map.
     since: 2.0
+    id: 4
   - name: isEmpty
     doc: |
       Returns true if this map contains no entries.
     request:
-      id: 0x1005
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -197,7 +192,6 @@ methods:
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -206,13 +200,13 @@ methods:
           doc: |
             <tt>true</tt> if this map contains no entries.
     since: 2.0
+    id: 5
   - name: put
     doc: |
       Associates the specified value with the specified key in this map. If the map previously contained a mapping for
       the key, the old value is replaced by the specified value. The object to be put will be accessible only in the
       current transaction context till transaction is committed.
     request:
-      id: 0x1006
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -254,7 +248,6 @@ methods:
           doc: |
             The duration in milliseconds after which this entry shall be deleted. O means infinite.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -263,6 +256,7 @@ methods:
           doc: |
             Previous value associated with key or  null if there was no mapping for key
     since: 2.0
+    id: 6
   - name: set
     doc: |
       Associates the specified value with the specified key in this map. If the map previously contained a mapping for
@@ -270,7 +264,6 @@ methods:
       if the old value is not needed.
       The object to be set will be accessible only in the current transaction context until the transaction is committed.
     request:
-      id: 0x1007
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -305,15 +298,14 @@ methods:
           since: 2.0
           doc: |
             The value to associate with key
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 7
   - name: putIfAbsent
     doc: |
       If the specified key is not already associated with a value, associate it with the given value.
       The object to be put will be accessible only in the current transaction context until the transaction is committed.
     request:
-      id: 0x1008
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -349,7 +341,6 @@ methods:
           doc: |
             The value to associate with the key when there is no previous value.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -358,12 +349,12 @@ methods:
           doc: |
             The previous value associated with key, or null if there was no mapping for key.
     since: 2.0
+    id: 8
   - name: replace
     doc: |
       Replaces the entry for a key only if it is currently mapped to some value. The object to be replaced will be
       accessible only in the current transaction context until the transaction is committed.
     request:
-      id: 0x1009
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -399,7 +390,6 @@ methods:
           doc: |
             The value replaced the previous value
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -408,12 +398,12 @@ methods:
           doc: |
             The previous value associated with key, or null if there was no mapping for key.
     since: 2.0
+    id: 9
   - name: replaceIfSame
     doc: |
       Replaces the entry for a key only if currently mapped to a given value. The object to be replaced will be
       accessible only in the current transaction context until the transaction is committed.
     request:
-      id: 0x100a
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -455,7 +445,6 @@ methods:
           doc: |
             The new value to replace the old value.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -464,13 +453,13 @@ methods:
           doc: |
             true if the value was replaced.
     since: 2.0
+    id: 10
   - name: remove
     doc: |
       Removes the mapping for a key from this map if it is present. The map will not contain a mapping for the
       specified key once the call returns. The object to be removed will be accessible only in the current transaction
       context until the transaction is committed.
     request:
-      id: 0x100b
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -500,7 +489,6 @@ methods:
           doc: |
             Remove the mapping for this key.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -509,13 +497,13 @@ methods:
           doc: |
             The previous value associated with key, or null if there was no mapping for key
     since: 2.0
+    id: 11
   - name: delete
     doc: |
       Removes the mapping for a key from this map if it is present. The map will not contain a mapping for the specified
       key once the call returns. This method is preferred to #remove(Object) if the old value is not needed. The object
       to be deleted will be removed from only the current transaction context until the transaction is committed.
     request:
-      id: 0x100c
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -544,15 +532,14 @@ methods:
           since: 2.0
           doc: |
             Remove the mapping for this key.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 12
   - name: removeIfSame
     doc: |
       Removes the entry for a key only if currently mapped to a given value. The object to be removed will be removed
       from only the current transaction context until the transaction is committed.
     request:
-      id: 0x100d
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -588,7 +575,6 @@ methods:
           doc: |
             Remove the key if it has this value.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -597,13 +583,13 @@ methods:
           doc: |
             True if the value was removed
     since: 2.0
+    id: 13
   - name: keySet
     doc: |
       Returns a set clone of the keys contained in this map. The set is NOT backed by the map, so changes to the map
       are NOT reflected in the set, and vice-versa. This method is always executed by a distributed query, so it may throw
       a QueryResultSizeExceededException if query result size limit is configured.
     request:
-      id: 0x100e
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -627,7 +613,6 @@ methods:
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
-      id: 0x006a
       params:
         - name: response
           type: List_Data
@@ -636,6 +621,7 @@ methods:
           doc: |
             A set clone of the keys contained in this map.
     since: 2.0
+    id: 14
   - name: keySetWithPredicate
     doc: |
       Queries the map based on the specified predicate and returns the keys of matching entries. Specified predicate
@@ -643,7 +629,6 @@ methods:
       set, and vice-versa. This method is always executed by a distributed query, so it may throw a
       QueryResultSizeExceededException if query result size limit is configured.
     request:
-      id: 0x100f
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -673,7 +658,6 @@ methods:
           doc: |
             Specified query criteria.
     response:
-      id: 0x006a
       params:
         - name: response
           type: List_Data
@@ -682,13 +666,13 @@ methods:
           doc: |
             Result key set for the query.
     since: 2.0
+    id: 15
   - name: values
     doc: |
       Returns a collection clone of the values contained in this map. The collection is NOT backed by the map,
       so changes to the map are NOT reflected in the collection, and vice-versa. This method is always executed by a
       distributed query, so it may throw a QueryResultSizeExceededException if query result size limit is configured.
     request:
-      id: 0x1010
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -712,7 +696,6 @@ methods:
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
-      id: 0x006a
       params:
         - name: response
           type: List_Data
@@ -721,6 +704,7 @@ methods:
           doc: |
             All values in the map
     since: 2.0
+    id: 16
   - name: valuesWithPredicate
     doc: |
       Queries the map based on the specified predicate and returns the values of matching entries.Specified predicate
@@ -728,7 +712,6 @@ methods:
       in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw
       a QueryResultSizeExceededException if query result size limit is configured.
     request:
-      id: 0x1011
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -758,7 +741,6 @@ methods:
           doc: |
             Specified query criteria.
     response:
-      id: 0x006a
       params:
         - name: response
           type: List_Data
@@ -767,11 +749,11 @@ methods:
           doc: |
             Result value collection of the query.
     since: 2.0
+    id: 17
   - name: containsValue
     doc: |
       Returns true if this map contains an entry for the specified value.
     request:
-      id: 0x1012
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -801,7 +783,6 @@ methods:
           doc: |
             The specified value.
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -810,3 +791,4 @@ methods:
           doc: |
             True if this map contains an entry for the specified key.
     since: 2.0
+    id: 18

--- a/protocol-definitions/TransactionalMultiMap.yaml
+++ b/protocol-definitions/TransactionalMultiMap.yaml
@@ -1,6 +1,5 @@
 id: 17
 name: TransactionalMultiMap
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: put

--- a/protocol-definitions/TransactionalMultiMap.yaml
+++ b/protocol-definitions/TransactionalMultiMap.yaml
@@ -2,7 +2,9 @@ id: 17
 name: TransactionalMultiMap
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: put
+  - id: 1
+    name: put
+    since: 2.0
     doc: |
       Stores a key-value pair in the multimap.
     request:
@@ -48,9 +50,9 @@ methods:
           since: 2.0
           doc: |
             True if the size of the multimap is increased, false if the multimap already contains the key-value pair.
+  - id: 2
+    name: get
     since: 2.0
-    id: 1
-  - name: get
     doc: |
       Returns the collection of values associated with the key.
     request:
@@ -90,9 +92,9 @@ methods:
           since: 2.0
           doc: |
             The collection of the values associated with the key
+  - id: 3
+    name: remove
     since: 2.0
-    id: 2
-  - name: remove
     doc: |
       Removes the given key value pair from the multimap.
     request:
@@ -132,9 +134,9 @@ methods:
           since: 2.0
           doc: |
             True if the size of the multimap changed after the remove operation, false otherwise.
+  - id: 4
+    name: removeEntry
     since: 2.0
-    id: 3
-  - name: removeEntry
     doc: |
       Removes all the entries associated with the given key.
     request:
@@ -180,9 +182,9 @@ methods:
           since: 2.0
           doc: |
             True if the size of the multimap changed after the remove operation, false otherwise.
+  - id: 5
+    name: valueCount
     since: 2.0
-    id: 4
-  - name: valueCount
     doc: |
       Returns the number of values matching the given key in the multimap.
     request:
@@ -222,9 +224,9 @@ methods:
           since: 2.0
           doc: |
             The number of values matching the given key in the multimap
+  - id: 6
+    name: size
     since: 2.0
-    id: 5
-  - name: size
     doc: |
       Returns the number of key-value pairs in the multimap.
     request:
@@ -258,5 +260,3 @@ methods:
           since: 2.0
           doc: |
             The number of key-value pairs in the multimap
-    since: 2.0
-    id: 6

--- a/protocol-definitions/TransactionalMultiMap.yaml
+++ b/protocol-definitions/TransactionalMultiMap.yaml
@@ -6,7 +6,6 @@ methods:
     doc: |
       Stores a key-value pair in the multimap.
     request:
-      id: 0x1101
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -42,7 +41,6 @@ methods:
           doc: |
             The value to be stored
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -51,11 +49,11 @@ methods:
           doc: |
             True if the size of the multimap is increased, false if the multimap already contains the key-value pair.
     since: 2.0
+    id: 1
   - name: get
     doc: |
       Returns the collection of values associated with the key.
     request:
-      id: 0x1102
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -85,7 +83,6 @@ methods:
           doc: |
             The key whose associated values are returned
     response:
-      id: 0x006a
       params:
         - name: response
           type: List_Data
@@ -94,11 +91,11 @@ methods:
           doc: |
             The collection of the values associated with the key
     since: 2.0
+    id: 2
   - name: remove
     doc: |
       Removes the given key value pair from the multimap.
     request:
-      id: 0x1103
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -128,7 +125,6 @@ methods:
           doc: |
             The key whose associated values are returned
     response:
-      id: 0x006a
       params:
         - name: response
           type: List_Data
@@ -137,11 +133,11 @@ methods:
           doc: |
             True if the size of the multimap changed after the remove operation, false otherwise.
     since: 2.0
+    id: 3
   - name: removeEntry
     doc: |
       Removes all the entries associated with the given key.
     request:
-      id: 0x1104
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -177,7 +173,6 @@ methods:
           doc: |
             The value to be stored
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -186,11 +181,11 @@ methods:
           doc: |
             True if the size of the multimap changed after the remove operation, false otherwise.
     since: 2.0
+    id: 4
   - name: valueCount
     doc: |
       Returns the number of values matching the given key in the multimap.
     request:
-      id: 0x1105
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -220,7 +215,6 @@ methods:
           doc: |
             The key whose number of values are returned
     response:
-      id: 0x0066
       params:
         - name: response
           type: int
@@ -229,11 +223,11 @@ methods:
           doc: |
             The number of values matching the given key in the multimap
     since: 2.0
+    id: 5
   - name: size
     doc: |
       Returns the number of key-value pairs in the multimap.
     request:
-      id: 0x1106
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -257,7 +251,6 @@ methods:
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
-      id: 0x0066
       params:
         - name: response
           type: int
@@ -266,3 +259,4 @@ methods:
           doc: |
             The number of key-value pairs in the multimap
     since: 2.0
+    id: 6

--- a/protocol-definitions/TransactionalQueue.yaml
+++ b/protocol-definitions/TransactionalQueue.yaml
@@ -7,7 +7,6 @@ methods:
       Inserts the specified element into this queue, waiting up to the specified wait time if necessary for space to
       become available.
     request:
-      id: 0x1401
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -43,7 +42,6 @@ methods:
           doc: |
             How long to wait before giving up, in milliseconds
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -52,11 +50,11 @@ methods:
           doc: |
             <tt>true</tt> if successful, or <tt>false</tt> if the specified waiting time elapses before space is available
     since: 2.0
+    id: 1
   - name: take
     doc: |
       Retrieves and removes the head of this queue, waiting if necessary until an element becomes available.
     request:
-      id: 0x1402
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -80,7 +78,6 @@ methods:
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -89,12 +86,12 @@ methods:
           doc: |
             The head of this queue
     since: 2.0
+    id: 2
   - name: poll
     doc: |
       Retrieves and removes the head of this queue, waiting up to the specified wait time if necessary for an element
       to become available.
     request:
-      id: 0x1403
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -124,7 +121,6 @@ methods:
           doc: |
             How long to wait before giving up, in milliseconds
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -133,11 +129,11 @@ methods:
           doc: |
             The head of this queue, or <tt>null</tt> if the specified waiting time elapses before an element is available
     since: 2.0
+    id: 3
   - name: peek
     doc: |
       Retrieves, but does not remove, the head of this queue, or returns null if this queue is empty.
     request:
-      id: 0x1404
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -167,7 +163,6 @@ methods:
           doc: |
             How long to wait before giving up, in milliseconds
     response:
-      id: 0x0069
       params:
         - name: response
           type: Data
@@ -176,12 +171,12 @@ methods:
           doc: |
             The value at the head of the queue.
     since: 2.0
+    id: 4
   - name: size
     doc: |
       Returns the number of elements in this collection.If this collection contains more than Integer.MAX_VALUE
       elements, returns Integer.MAX_VALUE.
     request:
-      id: 0x1405
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -205,7 +200,6 @@ methods:
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
-      id: 0x0066
       params:
         - name: response
           type: int
@@ -214,3 +208,4 @@ methods:
           doc: |
             The number of elements in this collection
     since: 2.0
+    id: 5

--- a/protocol-definitions/TransactionalQueue.yaml
+++ b/protocol-definitions/TransactionalQueue.yaml
@@ -2,7 +2,9 @@ id: 20
 name: TransactionalQueue
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: offer
+  - id: 1
+    name: offer
+    since: 2.0
     doc: |
       Inserts the specified element into this queue, waiting up to the specified wait time if necessary for space to
       become available.
@@ -49,9 +51,9 @@ methods:
           since: 2.0
           doc: |
             <tt>true</tt> if successful, or <tt>false</tt> if the specified waiting time elapses before space is available
+  - id: 2
+    name: take
     since: 2.0
-    id: 1
-  - name: take
     doc: |
       Retrieves and removes the head of this queue, waiting if necessary until an element becomes available.
     request:
@@ -85,9 +87,9 @@ methods:
           since: 2.0
           doc: |
             The head of this queue
+  - id: 3
+    name: poll
     since: 2.0
-    id: 2
-  - name: poll
     doc: |
       Retrieves and removes the head of this queue, waiting up to the specified wait time if necessary for an element
       to become available.
@@ -128,9 +130,9 @@ methods:
           since: 2.0
           doc: |
             The head of this queue, or <tt>null</tt> if the specified waiting time elapses before an element is available
+  - id: 4
+    name: peek
     since: 2.0
-    id: 3
-  - name: peek
     doc: |
       Retrieves, but does not remove, the head of this queue, or returns null if this queue is empty.
     request:
@@ -170,9 +172,9 @@ methods:
           since: 2.0
           doc: |
             The value at the head of the queue.
+  - id: 5
+    name: size
     since: 2.0
-    id: 4
-  - name: size
     doc: |
       Returns the number of elements in this collection.If this collection contains more than Integer.MAX_VALUE
       elements, returns Integer.MAX_VALUE.
@@ -207,5 +209,3 @@ methods:
           since: 2.0
           doc: |
             The number of elements in this collection
-    since: 2.0
-    id: 5

--- a/protocol-definitions/TransactionalQueue.yaml
+++ b/protocol-definitions/TransactionalQueue.yaml
@@ -1,6 +1,5 @@
 id: 20
 name: TransactionalQueue
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: offer

--- a/protocol-definitions/TransactionalSet.yaml
+++ b/protocol-definitions/TransactionalSet.yaml
@@ -1,6 +1,5 @@
 id: 18
 name: TransactionalSet
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: add

--- a/protocol-definitions/TransactionalSet.yaml
+++ b/protocol-definitions/TransactionalSet.yaml
@@ -6,7 +6,6 @@ methods:
     doc: |
       Add new item to transactional set.
     request:
-      id: 0x1201
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -36,7 +35,6 @@ methods:
           doc: |
             Item added to transactional set
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -45,11 +43,11 @@ methods:
           doc: |
             True if item is added successfully
     since: 2.0
+    id: 1
   - name: remove
     doc: |
       Remove item from transactional set.
     request:
-      id: 0x1202
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -79,7 +77,6 @@ methods:
           doc: |
             Item removed from Transactional Set
     response:
-      id: 0x0065
       params:
         - name: response
           type: boolean
@@ -88,11 +85,11 @@ methods:
           doc: |
             True if item is remove successfully
     since: 2.0
+    id: 2
   - name: size
     doc: |
       Returns the size of the set.
     request:
-      id: 0x1203
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -116,7 +113,6 @@ methods:
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
-      id: 0x0066
       params:
         - name: response
           type: int
@@ -125,3 +121,4 @@ methods:
           doc: |
             The size of the set
     since: 2.0
+    id: 3

--- a/protocol-definitions/TransactionalSet.yaml
+++ b/protocol-definitions/TransactionalSet.yaml
@@ -2,7 +2,9 @@ id: 18
 name: TransactionalSet
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: add
+  - id: 1
+    name: add
+    since: 2.0
     doc: |
       Add new item to transactional set.
     request:
@@ -42,9 +44,9 @@ methods:
           since: 2.0
           doc: |
             True if item is added successfully
+  - id: 2
+    name: remove
     since: 2.0
-    id: 1
-  - name: remove
     doc: |
       Remove item from transactional set.
     request:
@@ -84,9 +86,9 @@ methods:
           since: 2.0
           doc: |
             True if item is remove successfully
+  - id: 3
+    name: size
     since: 2.0
-    id: 2
-  - name: size
     doc: |
       Returns the size of the set.
     request:
@@ -120,5 +122,3 @@ methods:
           since: 2.0
           doc: |
             The size of the set
-    since: 2.0
-    id: 3

--- a/protocol-definitions/XATransaction.yaml
+++ b/protocol-definitions/XATransaction.yaml
@@ -6,7 +6,6 @@ methods:
     doc: |
       TODO DOC
     request:
-      id: 0x1601
       retryable: false
       acquiresResource: false
       partitionIdentifier: xid
@@ -17,19 +16,17 @@ methods:
           since: 2.0
           doc: |
             Java XA transaction id as defined in interface javax.transaction.xa.Xid.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 1
   - name: collectTransactions
     doc: |
       TODO DOC
     request:
-      id: 0x1602
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
     response:
-      id: 0x0085
       params:
         - name: response
           type: List_Xid
@@ -38,11 +35,11 @@ methods:
           doc: |
             Array of Xids.
     since: 2.0
+    id: 2
   - name: finalize
     doc: |
       TODO DOC
     request:
-      id: 0x1603
       retryable: false
       acquiresResource: false
       partitionIdentifier: xid
@@ -59,14 +56,13 @@ methods:
           since: 2.0
           doc: |
             If true, the transaction is committed else transaction is rolled back.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 3
   - name: commit
     doc: |
       TODO DOC
     request:
-      id: 0x1604
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -83,14 +79,13 @@ methods:
           since: 2.0
           doc: |
             If true, the prepare is also done.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 4
   - name: create
     doc: |
       TODO DOC
     request:
-      id: 0x1605
       retryable: false
       acquiresResource: true
       partitionIdentifier: -1
@@ -108,7 +103,6 @@ methods:
           doc: |
             The timeout in seconds for XA operations such as prepare, commit, rollback.
     response:
-      id: 0x0068
       params:
         - name: response
           type: String
@@ -117,11 +111,11 @@ methods:
           doc: |
             The transaction unique identifier.
     since: 2.0
+    id: 5
   - name: prepare
     doc: |
       TODO DOC
     request:
-      id: 0x1606
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -132,14 +126,13 @@ methods:
           since: 2.0
           doc: |
             The id of the transaction to prepare.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 6
   - name: rollback
     doc: |
       TODO DOC
     request:
-      id: 0x1607
       retryable: false
       acquiresResource: false
       partitionIdentifier: -1
@@ -150,6 +143,6 @@ methods:
           since: 2.0
           doc: |
             The id of the transaction to rollback.
-    response:
-      id: 0x0064
+    response: {}
     since: 2.0
+    id: 7

--- a/protocol-definitions/XATransaction.yaml
+++ b/protocol-definitions/XATransaction.yaml
@@ -1,6 +1,5 @@
 id: 22
 name: XATransaction
-ns: Hazelcast.Client.Protocol.Codec
 methods:
   - id: 1
     name: clearRemote

--- a/protocol-definitions/XATransaction.yaml
+++ b/protocol-definitions/XATransaction.yaml
@@ -2,7 +2,9 @@ id: 22
 name: XATransaction
 ns: Hazelcast.Client.Protocol.Codec
 methods:
-  - name: clearRemote
+  - id: 1
+    name: clearRemote
+    since: 2.0
     doc: |
       TODO DOC
     request:
@@ -17,9 +19,9 @@ methods:
           doc: |
             Java XA transaction id as defined in interface javax.transaction.xa.Xid.
     response: {}
+  - id: 2
+    name: collectTransactions
     since: 2.0
-    id: 1
-  - name: collectTransactions
     doc: |
       TODO DOC
     request:
@@ -34,9 +36,9 @@ methods:
           since: 2.0
           doc: |
             Array of Xids.
+  - id: 3
+    name: finalize
     since: 2.0
-    id: 2
-  - name: finalize
     doc: |
       TODO DOC
     request:
@@ -57,9 +59,9 @@ methods:
           doc: |
             If true, the transaction is committed else transaction is rolled back.
     response: {}
+  - id: 4
+    name: commit
     since: 2.0
-    id: 3
-  - name: commit
     doc: |
       TODO DOC
     request:
@@ -80,9 +82,9 @@ methods:
           doc: |
             If true, the prepare is also done.
     response: {}
+  - id: 5
+    name: create
     since: 2.0
-    id: 4
-  - name: create
     doc: |
       TODO DOC
     request:
@@ -110,9 +112,9 @@ methods:
           since: 2.0
           doc: |
             The transaction unique identifier.
+  - id: 6
+    name: prepare
     since: 2.0
-    id: 5
-  - name: prepare
     doc: |
       TODO DOC
     request:
@@ -127,9 +129,9 @@ methods:
           doc: |
             The id of the transaction to prepare.
     response: {}
+  - id: 7
+    name: rollback
     since: 2.0
-    id: 6
-  - name: rollback
     doc: |
       TODO DOC
     request:
@@ -144,5 +146,3 @@ methods:
           doc: |
             The id of the transaction to rollback.
     response: {}
-    since: 2.0
-    id: 7

--- a/schema/protocol-schema.json
+++ b/schema/protocol-schema.json
@@ -126,13 +126,17 @@
   "properties": {
     "id": {
       "type": "integer",
-      "minimum": 1,
+      "minimum": 0,
       "maximum": 255,
       "description": "Service unique id, 0-255"
     },
     "name": {
       "type": "string",
       "description": "Service name"
+    },
+    "ns": {
+      "type": "string",
+      "description": "Namespace for the protocol definitions"
     },
     "methods": {
       "type": "array",
@@ -141,7 +145,7 @@
         "properties": {
           "id": {
             "type": "integer",
-            "minimum": 1,
+            "minimum": 0,
             "maximum": 255,
             "description": "Method unique id, 0-255"
           },
@@ -170,7 +174,7 @@
                 "description": "Does the request acquire resource or not"
               },
               "partitionIdentifier": {
-                "type": "string",
+                "type": ["integer", "string"],
                 "description": "How should the partition Id calculated for this request. Used in documentation."
               },
               "params": {

--- a/schema/protocol-schema.json
+++ b/schema/protocol-schema.json
@@ -134,10 +134,6 @@
       "type": "string",
       "description": "Service name"
     },
-    "ns": {
-      "type": "string",
-      "description": "Namespace for the protocol definitions"
-    },
     "methods": {
       "type": "array",
       "items": {
@@ -145,9 +141,9 @@
         "properties": {
           "id": {
             "type": "integer",
-            "minimum": 0,
+            "minimum": 1,
             "maximum": 255,
-            "description": "Method unique id, 0-255"
+            "description": "Method unique id, 1-255"
           },
           "name": {
             "type": "string",
@@ -217,7 +213,6 @@
   },
   "required": [
     "name",
-    "ns",
     "methods"
   ]
 }

--- a/util.py
+++ b/util.py
@@ -1,10 +1,13 @@
+import json
+import jsonschema
 import os
-import yaml
 import re
-from jinja2 import Environment, PackageLoader
-from java import java_types_encode, java_types_decode
 from enum import Enum
-import json, jsonschema
+
+import yaml
+from jinja2 import Environment, PackageLoader
+
+from java import java_types_encode, java_types_decode
 
 FixedLengthTypes = [
     "boolean",
@@ -54,14 +57,21 @@ def var_size_params(params):
 
 
 def generate_codecs(services, template, output_dir, extension):
+    id_fmt = "0x%02x%02x%02x"
     for service in services:
         if "methods" in service:
             methods = service["methods"]
             if methods is None:
                 print(type(methods))
             for method in service["methods"]:
-                method_id = "0x%02x%02x" % (service["id"], method["id"])
-                content = template.render(method_id=method_id, service_name=service["name"], method=method)
+                method["request"]["id"] = id_fmt % (service["id"], method["id"], 0)
+                method["response"]["id"] = id_fmt % (service["id"], method["id"], 1)
+                events = method.get("events", None)
+                if events is not None:
+                    for i in range(len(events)):
+                        method["events"][i]["id"] = id_fmt % (service["id"], method["id"], i + 2)
+
+                content = template.render(service_name=service["name"], method=method)
                 save_file(output_dir + capital(service["name"]) + capital(method["name"]) + 'Codec.' + extension, content)
 
 

--- a/util.py
+++ b/util.py
@@ -60,7 +60,8 @@ def generate_codecs(services, template, output_dir, extension):
             if methods is None:
                 print(type(methods))
             for method in service["methods"]:
-                content = template.render(service_name=service["name"], method=method)
+                method_id = "0x%02x%02x" % (service["id"], method["id"])
+                content = template.render(method_id=method_id, service_name=service["name"], method=method)
                 save_file(output_dir + capital(service["name"]) + capital(method["name"]) + 'Codec.' + extension, content)
 
 

--- a/util.py
+++ b/util.py
@@ -64,12 +64,12 @@ def generate_codecs(services, template, output_dir, extension):
             if methods is None:
                 print(type(methods))
             for method in service["methods"]:
-                method["request"]["id"] = id_fmt % (service["id"], method["id"], 0)
-                method["response"]["id"] = id_fmt % (service["id"], method["id"], 1)
+                method["request"]["id"] = int(id_fmt % (service["id"], method["id"], 0), 16)
+                method["response"]["id"] = int(id_fmt % (service["id"], method["id"], 1), 16)
                 events = method.get("events", None)
                 if events is not None:
                     for i in range(len(events)):
-                        method["events"][i]["id"] = id_fmt % (service["id"], method["id"], i + 2)
+                        method["events"][i]["id"] = int(id_fmt % (service["id"], method["id"], i + 2), 16)
 
                 content = template.render(service_name=service["name"], method=method)
                 save_file(output_dir + capital(service["name"]) + capital(method["name"]) + 'Codec.' + extension, content)


### PR DESCRIPTION
id field is removed from the request and response. Instead, ids are assigned to methods and request, response and event ids are generated from service and method id. 

Since the ids are hex values now, comments describing the hex value of ids are removed.