### PR TITLE
add custom codec generator

### DIFF
--- a/binary/__init__.py
+++ b/binary/__init__.py
@@ -3,7 +3,14 @@ FixedLengthTypes = [
     "byte",
     "int",
     "long",
-    "UUID"
+    "UUID",
+    'Enum_int_CacheEventType',
+]
+
+EnumTypes = [
+    "Enum_int_CacheEventType",
+    "Enum_String_TimeUnit",
+    "Enum_String_ExpiryPolicyType",
 ]
 
 VarLengthTypes = [
@@ -13,10 +20,14 @@ VarLengthTypes = [
     'Data'
 ]
 
+FixedEntryListTypes = [
+    'EntryList_Integer_UUID',
+    'EntryList_UUID_Long',
+    'EntryList_Integer_Long',
+    'EntryList_Long_byteArray',
+]
+
 FixedMapTypes = [
-    'Map_Integer_UUID',
-    'Map_UUID_Long',
-    'Map_Integer_Long'
 ]
 
 FixedListTypes = [
@@ -35,7 +46,9 @@ CustomTypes = [
     'ScheduledTaskHandler',
     'SimpleEntryView',
     'WanReplicationRef',
-    'Xid'
+    'Xid',
+    'ErrorHolder',
+    'StackTraceElement',
 ]
 
 CustomConfigTypes = [
@@ -54,17 +67,23 @@ CustomConfigTypes = [
     'QueryCacheConfigHolder',
     'QueueStoreConfigHolder',
     'RingbufferStoreConfigHolder',
-    'TimedExpiryPolicyFactoryConfig'
+    'TimedExpiryPolicyFactoryConfig',
+    'DurationConfig',
+    'MergePolicyConfig',
+    'CacheConfigHolder',
+]
+
+VarLengthEntryListTypes = [
+    'EntryList_String_String',
+    'EntryList_String_byteArray',
+    'EntryList_String_EntryList_Integer_Long',
+    'EntryList_Address_List_Integer',
+    'EntryList_Data_Data',
+    'EntryList_Member_List_ScheduledTaskHandler',
 ]
 
 VarLengthMapTypes = [
     'Map_String_String',
-    'Map_String_byteArray',
-    'Map_Long_byteArray',
-    'Map_String_Map_Integer_Long',
-    'Map_Address_List_Integer',
-    'Map_Data_Data',
-    'Map_Member_List_ScheduledTaskHandler'
 ]
 
 VarLengthListTypes = [
@@ -83,7 +102,8 @@ VarLengthListTypes = [
     'List_ScheduledTaskHandler',
     'List_String',
     'List_Xid',
+    'List_StackTraceElement',
 ]
 
-AllTypes = FixedLengthTypes + VarLengthTypes + FixedMapTypes + FixedListTypes + CustomTypes + CustomConfigTypes \
-           + VarLengthMapTypes + VarLengthListTypes
+AllTypes = FixedLengthTypes + EnumTypes + VarLengthTypes + FixedEntryListTypes + FixedMapTypes + FixedListTypes \
+           + CustomTypes + CustomConfigTypes + VarLengthEntryListTypes + VarLengthMapTypes + VarLengthListTypes

--- a/java/__init__.py
+++ b/java/__init__.py
@@ -20,17 +20,20 @@ _java_types_common = {
     "Integer": "java.lang.Integer",
     "Long": "java.lang.Long",
     "UUID": "java.util.UUID",
+    "Enum_int_CacheEventType": "int",
+    "Enum_String_TimeUnit": "String",
+    "Enum_String_ExpiryPolicyType": "String",
 
     "longArray": "long[]",
+    "byteArray": "byte[]",
     "String": "java.lang.String",
     "Data": "com.hazelcast.nio.serialization.Data",
 
-    "Xid": "javax.transaction.xa.Xid",
-    "Member": "com.hazelcast.cluster.Member",
     "Address": "com.hazelcast.nio.Address",
+    "ErrorHolder": "com.hazelcast.client.impl.protocol.exception.ErrorHolder",
+    "StackTraceElement": "java.lang.StackTraceElement",
     "SimpleEntryView": "com.hazelcast.map.impl.SimpleEntryView<com.hazelcast.nio.serialization.Data, com.hazelcast.nio.serialization.Data>",
     "RaftGroupId": "com.hazelcast.cp.internal.RaftGroupId",
-    "QueryCacheEventData": "com.hazelcast.map.impl.querycache.event.QueryCacheEventData",
     "WanReplicationRef": "com.hazelcast.config.WanReplicationRef",
     "HotRestartConfig": "com.hazelcast.config.HotRestartConfig",
     "EventJournalConfig": "com.hazelcast.config.EventJournalConfig",
@@ -41,7 +44,11 @@ _java_types_common = {
     "RingbufferStoreConfigHolder": "com.hazelcast.client.impl.protocol.task.dynamicconfig.RingbufferStoreConfigHolder",
     "NearCacheConfigHolder": "com.hazelcast.client.impl.protocol.task.dynamicconfig.NearCacheConfigHolder",
     "EvictionConfigHolder": "com.hazelcast.client.impl.protocol.task.dynamicconfig.EvictionConfigHolder",
+    "NearCachePreloaderConfig": "com.hazelcast.config.NearCachePreloaderConfig",
+    "PredicateConfigHolder": "com.hazelcast.client.impl.protocol.task.dynamicconfig.PredicateConfigHolder",
+    "DurationConfig": "com.hazelcast.config.CacheSimpleConfig.ExpiryPolicyFactoryConfig.DurationConfig",
 
+    "MergePolicyConfig": "com.hazelcast.config.MergePolicyConfig",
     "CacheConfigHolder": "com.hazelcast.client.impl.protocol.codec.holder.CacheConfigHolder",
     "CacheEventData": "com.hazelcast.cache.impl.CacheEventData",
     "QueryCacheConfigHolder": "com.hazelcast.client.impl.protocol.task.dynamicconfig.QueryCacheConfigHolder",
@@ -50,10 +57,17 @@ _java_types_common = {
     "AttributeConfig": "com.hazelcast.config.AttributeConfig",
     "ListenerConfigHolder": "com.hazelcast.client.impl.protocol.task.dynamicconfig.ListenerConfigHolder",
     "CacheSimpleEntryListenerConfig": "com.hazelcast.config.CacheSimpleEntryListenerConfig",
-    "ScheduledTaskHandler": "com.hazelcast.scheduledexecutor.ScheduledTaskHandler"
+
+    "Map_String_String": "java.util.Map<java.lang.String, java.lang.String>"
 }
 
 _java_types_encode = {
+    "CacheEventData": "com.hazelcast.cache.impl.CacheEventData",
+    "QueryCacheEventData": "com.hazelcast.map.impl.querycache.event.QueryCacheEventData",
+    "ScheduledTaskHandler": "com.hazelcast.scheduledexecutor.ScheduledTaskHandler",
+    "Xid": "javax.transaction.xa.Xid",
+    "Member": "com.hazelcast.cluster.Member",
+
     "List_Long": "java.util.Collection<java.lang.Long>",
     "List_UUID": "java.util.Collection<java.util.UUID>",
     "List_String": "java.util.Collection<java.lang.String>",
@@ -69,19 +83,26 @@ _java_types_encode = {
     "List_AttributeConfig": "java.util.Collection<com.hazelcast.config.AttributeConfig>",
     "List_ListenerConfigHolder": "java.util.Collection<com.hazelcast.client.impl.protocol.task.dynamicconfig.ListenerConfigHolder>",
     "List_CacheSimpleEntryListenerConfig": "java.util.Collection<com.hazelcast.config.CacheSimpleEntryListenerConfig>",
+    "List_StackTraceElement": "java.util.Collection<java.lang.StackTraceElement>",
 
-    "Map_String_String": "java.util.Collection<java.util.Map.Entry<java.lang.String, java.lang.String>>",
-    "Map_String_byteArray": "java.util.Collection<java.util.Map.Entry<java.lang.String, byte[]>>",
-    "Map_Long_byteArray": "java.util.Collection<java.util.Map.Entry<java.lang.Long, byte[]>>",
-    "Map_Integer_UUID": "java.util.Collection<java.util.Map.Entry<java.lang.Integer, java.util.UUID>>",
-    "Map_UUID_Long": "java.util.Collection<java.util.Map.Entry<java.util.UUID, java.lang.Long>>",
-    "Map_String_Map_Integer_Long": "java.util.Collection<java.util.Map.Entry<java.lang.String, java.util.List<java.util.Map.Entry<java.lang.Integer, java.lang.Long>>>>",
-    "Map_Address_List_Integer": "java.util.Collection<java.util.Map.Entry<com.hazelcast.nio.Address, java.util.List<java.lang.Integer>>>",
-    "Map_Data_Data": "java.util.Collection<java.util.Map.Entry<com.hazelcast.nio.serialization.Data, com.hazelcast.nio.serialization.Data>>",
-    "Map_Member_List_ScheduledTaskHandler": "java.util.Collection<java.util.Map.Entry<com.hazelcast.cluster.Member, java.util.List<com.hazelcast.scheduledexecutor.ScheduledTaskHandler>>>"
+    "EntryList_String_String": "java.util.Collection<java.util.Map.Entry<java.lang.String, java.lang.String>>",
+    "EntryList_String_byteArray": "java.util.Collection<java.util.Map.Entry<java.lang.String, byte[]>>",
+    "EntryList_Long_byteArray": "java.util.Collection<java.util.Map.Entry<java.lang.Long, byte[]>>",
+    "EntryList_Integer_UUID": "java.util.Collection<java.util.Map.Entry<java.lang.Integer, java.util.UUID>>",
+    "EntryList_UUID_Long": "java.util.Collection<java.util.Map.Entry<java.util.UUID, java.lang.Long>>",
+    "EntryList_String_EntryList_Integer_Long": "java.util.Collection<java.util.Map.Entry<java.lang.String, java.util.List<java.util.Map.Entry<java.lang.Integer, java.lang.Long>>>>",
+    "EntryList_Address_List_Integer": "java.util.Collection<java.util.Map.Entry<com.hazelcast.nio.Address, java.util.List<java.lang.Integer>>>",
+    "EntryList_Data_Data": "java.util.Collection<java.util.Map.Entry<com.hazelcast.nio.serialization.Data, com.hazelcast.nio.serialization.Data>>",
+    "EntryList_Member_List_ScheduledTaskHandler": "java.util.Collection<java.util.Map.Entry<com.hazelcast.cluster.Member, java.util.List<com.hazelcast.scheduledexecutor.ScheduledTaskHandler>>>"
 }
 
 _java_types_decode = {
+    "CacheEventData": "com.hazelcast.cache.impl.CacheEventDataImpl",
+    "QueryCacheEventData": "com.hazelcast.map.impl.querycache.event.DefaultQueryCacheEventData",
+    "ScheduledTaskHandler": "com.hazelcast.scheduledexecutor.impl.ScheduledTaskHandlerImpl",
+    "Xid": "com.hazelcast.transaction.impl.xa.SerializableXID",
+    "Member": "com.hazelcast.client.impl.MemberImpl",
+
     "List_Long": "java.util.List<java.lang.Long>",
     "List_UUID": "java.util.List<java.util.UUID>",
     "List_Xid": "java.util.List<javax.transaction.xa.Xid>",
@@ -92,19 +113,20 @@ _java_types_decode = {
     "List_CacheEventData": "java.util.List<com.hazelcast.cache.impl.CacheEventData>",
     "List_QueryCacheConfigHolder": "java.util.List<com.hazelcast.client.impl.protocol.task.dynamicconfig.QueryCacheConfigHolder>",
     "List_DistributedObjectInfo": "java.util.List<com.hazelcast.client.impl.client.DistributedObjectInfo>",
-    "List_QueryCacheEventData": "java.util.List<com.hazelcast.map.impl.querycache.event.QueryCacheEventData>",
+    "List_QueryCacheEventData": "java.util.List<com.hazelcast.map.impl.querycache.event.DefaultQueryCacheEventData>",
     "List_MapIndexConfig": "java.util.List<com.hazelcast.config.MapIndexConfig>",
     "List_AttributeConfig": "java.util.List<com.hazelcast.config.AttributeConfig>",
     "List_ListenerConfigHolder": "java.util.List<com.hazelcast.client.impl.protocol.task.dynamicconfig.ListenerConfigHolder>",
     "List_CacheSimpleEntryListenerConfig": "java.util.List<com.hazelcast.config.CacheSimpleEntryListenerConfig>",
+    "List_StackTraceElement": "java.util.List<java.lang.StackTraceElement>",
 
-    "Map_String_String": "java.util.List<java.util.Map.Entry<java.lang.String, java.lang.String>>",
-    "Map_String_byteArray": "java.util.List<java.util.Map.Entry<java.lang.String, byte[]>>",
-    "Map_Long_byteArray": "java.util.List<java.util.Map.Entry<java.lang.Long, byte[]>>",
-    "Map_Integer_UUID": "java.util.List<java.util.Map.Entry<java.lang.Integer, java.util.UUID>>",
-    "Map_UUID_Long": "java.util.List<java.util.Map.Entry<java.util.UUID, java.lang.Long>>",
-    "Map_String_Map_Integer_Long": "java.util.List<java.util.Map.Entry<java.lang.String, java.util.List<java.util.Map.Entry<java.lang.Integer, java.lang.Long>>>>",
-    "Map_Address_List_Integer": "java.util.List<java.util.Map.Entry<com.hazelcast.nio.Address, java.util.List<java.lang.Integer>>>",
-    "Map_Data_Data": "java.util.List<java.util.Map.Entry<com.hazelcast.nio.serialization.Data, com.hazelcast.nio.serialization.Data>>",
-    "Map_Member_List_ScheduledTaskHandler": "java.util.List<java.util.Map.Entry<com.hazelcast.cluster.Member, java.util.List<com.hazelcast.scheduledexecutor.ScheduledTaskHandler>>>"
+    "EntryList_String_String": "java.util.List<java.util.Map.Entry<java.lang.String, java.lang.String>>",
+    "EntryList_String_byteArray": "java.util.List<java.util.Map.Entry<java.lang.String, byte[]>>",
+    "EntryList_Long_byteArray": "java.util.List<java.util.Map.Entry<java.lang.Long, byte[]>>",
+    "EntryList_Integer_UUID": "java.util.List<java.util.Map.Entry<java.lang.Integer, java.util.UUID>>",
+    "EntryList_UUID_Long": "java.util.List<java.util.Map.Entry<java.util.UUID, java.lang.Long>>",
+    "EntryList_String_EntryList_Integer_Long": "java.util.List<java.util.Map.Entry<java.lang.String, java.util.List<java.util.Map.Entry<java.lang.Integer, java.lang.Long>>>>",
+    "EntryList_Address_List_Integer": "java.util.List<java.util.Map.Entry<com.hazelcast.nio.Address, java.util.List<java.lang.Integer>>>",
+    "EntryList_Data_Data": "java.util.List<java.util.Map.Entry<com.hazelcast.nio.serialization.Data, com.hazelcast.nio.serialization.Data>>",
+    "EntryList_Member_List_ScheduledTaskHandler": "java.util.List<java.util.Map.Entry<com.hazelcast.cluster.Member, java.util.List<com.hazelcast.scheduledexecutor.ScheduledTaskHandler>>>"
 }

--- a/java/codec-template.java.j2
+++ b/java/codec-template.java.j2
@@ -1,6 +1,8 @@
 {% macro encode_var_sized(param) -%}
     {% if is_var_sized_list(param.type) or is_var_sized_list_contains_nullable(param.type) -%}
         ListMultiFrameCodec.encode{% if is_var_sized_list_contains_nullable(param.type)%}ContainsNullable{% endif %}{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param.name }}, {{ item_type(lang_name, param.type) }}Codec::encode)
+    {%- elif is_var_sized_entry_list(param.type) -%}
+        EntryListCodec.encode{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param.name }}, {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
     {%- elif is_var_sized_map(param.type) -%}
         MapCodec.encode{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param.name }}, {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
     {%- else -%}
@@ -14,6 +16,8 @@
 {% macro decode_var_sized(param) -%}
     {%- if is_var_sized_list(param.type) or is_var_sized_list_contains_nullable(param.type) -%}
         ListMultiFrameCodec.decode{% if is_var_sized_list_contains_nullable(param.type) %}ContainsNullable{% endif %}{% if param.nullable  %}Nullable{% endif %}(iterator, {{ item_type(lang_name, param.type) }}Codec::decode)
+    {%- elif is_var_sized_entry_list(param.type) -%}
+        EntryListCodec.decode{% if param.nullable  %}Nullable{% endif %}(iterator, {{ key_type(lang_name, param.type) }}Codec::decode, {{ value_type(lang_name, param.type) }}Codec::decode)
     {%- elif is_var_sized_map(param.type) -%}
         MapCodec.decode{% if param.nullable  %}Nullable{% endif %}(iterator, {{ key_type(lang_name, param.type) }}Codec::decode, {{ value_type(lang_name, param.type) }}Codec::decode)
     {%- else -%}
@@ -46,9 +50,10 @@ package {{ namespace }};
 package com.hazelcast.client.impl.protocol.codec;
 {% endif %}
 
-import com.hazelcast.client.impl.protocol.Generated;
 import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.Generated;
 import com.hazelcast.client.impl.protocol.codec.builtin.*;
+import com.hazelcast.client.impl.protocol.codec.custom.*;
 
 import java.util.ListIterator;
 
@@ -179,11 +184,11 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[RESPONSE_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);
         encodeInt(initialFrame.content, TYPE_FIELD_OFFSET, RESPONSE_MESSAGE_TYPE);
-        clientMessage.add(initialFrame);
-
     {% for param in fixed_params(method.response.params) %}
         encode{{ param.type|capital }}(initialFrame.content, RESPONSE_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET, {{ param.name }});
     {% endfor %}
+        clientMessage.add(initialFrame);
+
     {% for param in var_size_params(method.response.params) %}
         {{ encode_var_sized(param) }};
     {% endfor %}
@@ -221,6 +226,7 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
         encode{{ param.type|capital }}(initialFrame.content, EVENT_{{ to_upper_snake_case(event.name)}}_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET, {{ param.name }});
     {% endfor %}
         clientMessage.add(initialFrame);
+
     {% for param in var_size_params(event.params) %}
         {{ encode_var_sized(param) }};
     {% endfor %}
@@ -242,10 +248,10 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
                 iterator.next();
             {% endif %}
             {% for param in fixed_params(event.params) %}
-                {{ lang_types_decode(param.type) }} {{param.name}} = decode{{ param.type|capital }}(initialFrame.content, EVENT_{{ to_upper_snake_case(event.name)}}_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET);
+                {{ lang_types_encode(param.type) }} {{param.name}} = decode{{ param.type|capital }}(initialFrame.content, EVENT_{{ to_upper_snake_case(event.name)}}_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET);
             {% endfor %}
             {% for param in var_size_params(event.params) %}
-                {{ lang_types_decode(param.type) }} {{param.name}} = {{ decode_var_sized(param) }};
+                {{ lang_types_encode(param.type) }} {{param.name}} = {{ decode_var_sized(param) }};
             {% endfor %}
                 handle{{ event.name|capital }}Event({% for param in event.params %}{{param.name}}{% if not loop.last %}, {% endif %}{% endfor %});
                 return;

--- a/java/custom-codec-template.java.j2
+++ b/java/custom-codec-template.java.j2
@@ -1,0 +1,123 @@
+{% macro encode_var_sized(param) -%}
+    {% if is_var_sized_list(param.type) or is_var_sized_list_contains_nullable(param.type) -%}
+        ListMultiFrameCodec.encode{% if is_var_sized_list_contains_nullable(param.type)%}ContainsNullable{% endif %}{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param_name(codec.name)}}.{% if param.type == 'boolean' %}is{% else %}get{% endif %}{{ param.name|capital }}(), {{ item_type(lang_name, param.type) }}Codec::encode)
+    {%- elif is_var_sized_entry_list(param.type) -%}
+        EntryList.encode{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param_name(codec.name)}}.{% if param.type == 'boolean' %}is{% else %}get{% endif %}{{ param.name|capital }}(), {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
+    {%- elif is_var_sized_map(param.type) -%}
+        MapCodec.encode{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param_name(codec.name)}}.{% if param.type == 'boolean' %}is{% else %}get{% endif %}{{ param.name|capital }}(), {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
+    {%- else -%}
+        {%- if param.nullable  -%}
+            CodecUtil.encodeNullable(clientMessage, {{ param_name(codec.name)}}.{% if param.type == 'boolean' %}is{% else %}get{% endif %}{{ param.name|capital }}(), {% if is_enum(param.type) %}{{ lang_name(enum_type(lang_name, param.type)) }}{% else %}{{ lang_name(param.type) }}{% endif %}Codec::encode)
+        {%- else -%}
+            {% if is_enum(param.type) %}{{ lang_name(enum_type(lang_name, param.type)) }}{% else %}{{ lang_name(param.type) }}{% endif %}Codec.encode(clientMessage, {{ param_name(codec.name)}}.{% if param.type == 'boolean' %}is{% else %}get{% endif %}{{ param.name|capital }}())
+        {%- endif %}
+    {% endif %}
+{%- endmacro %}
+{% macro decode_var_sized(param) -%}
+    {%- if is_var_sized_list(param.type) or is_var_sized_list_contains_nullable(param.type) -%}
+        ListMultiFrameCodec.decode{% if is_var_sized_list_contains_nullable(param.type) %}ContainsNullable{% endif %}{% if param.nullable  %}Nullable{% endif %}(iterator, {{ item_type(lang_name, param.type) }}Codec::decode)
+    {%- elif is_var_sized_entry_list(param.type) -%}
+        EntryListCodec.decode{% if param.nullable  %}Nullable{% endif %}(iterator, {{ key_type(lang_name, param.type) }}Codec::decode, {{ value_type(lang_name, param.type) }}Codec::decode)
+    {%- elif is_var_sized_map(param.type) -%}
+        MapCodec.decode{% if param.nullable  %}Nullable{% endif %}(iterator, {{ key_type(lang_name, param.type) }}Codec::decode, {{ value_type(lang_name, param.type) }}Codec::decode)
+    {%- else -%}
+        {%- if param.nullable  -%}
+            CodecUtil.decodeNullable(iterator, {% if is_enum(param.type) %}{{ lang_name(enum_type(lang_name, param.type)) }}{% else %}{{ lang_name(param.type) }}{% endif %}Codec::decode)
+        {%- else -%}
+            {% if is_enum(param.type) %}{{ lang_name(enum_type(lang_name, param.type)) }}{% else %}{{ lang_name(param.type) }}{% endif %}Codec.decode(iterator)
+        {%- endif -%}
+    {%- endif -%}
+{%- endmacro %}
+/*
+ * Copyright (c) 2008-2019, Hazelcast, Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+{% if namespace %}
+package {{ namespace }};
+{% else %}
+package com.hazelcast.client.impl.protocol.codec.custom;
+{% endif %}
+
+import com.hazelcast.client.impl.protocol.ClientMessage;
+import com.hazelcast.client.impl.protocol.Generated;
+import com.hazelcast.client.impl.protocol.codec.builtin.*;
+
+import java.util.ListIterator;
+
+import static com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil.fastForwardToEndFrame;
+import static com.hazelcast.client.impl.protocol.ClientMessage.*;
+import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.*;
+
+@Generated("!codec_hash!")
+public final class {{ codec.name|capital }}Codec {
+    {% for param in fixed_params(codec.params) %}
+    private static final int {{ to_upper_snake_case(param.name) }}_FIELD_OFFSET = {% if loop.first %}0{% else %}{{ to_upper_snake_case(loop.previtem.name)}}_FIELD_OFFSET + {% if is_enum(loop.previtem.type) %}{{ enum_type(lang_name, loop.previtem.type).upper() }}{% else %}{{ loop.previtem.type.upper() }}{% endif %}_SIZE_IN_BYTES{% endif %};
+    {% if loop.last %}
+    private static final int INITIAL_FRAME_SIZE = {{to_upper_snake_case(param.name)}}_FIELD_OFFSET + {% if is_enum(param.type) %}{{ enum_type(lang_name, param.type).upper() }}{% else %}{{ param.type.upper() }}{% endif %}_SIZE_IN_BYTES;
+    {% endif %}
+    {% endfor %}
+
+    private {{ codec.name|capital }}Codec() {
+    }
+
+    public static void encode(ClientMessage clientMessage, {{ lang_types_encode(codec.name) }} {{ param_name(codec.name) }}) {
+        clientMessage.add(BEGIN_FRAME);
+        {% for param in fixed_params(codec.params) %}
+        {% if loop.first %}
+
+        ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[INITIAL_FRAME_SIZE]);
+        {% endif %}
+        encode{% if is_enum(param.type) %}{{ enum_type(lang_name, param.type)|capital }}{% else %}{{ param.type|capital }}{% endif %}(initialFrame.content, {{to_upper_snake_case(param.name)}}_FIELD_OFFSET, {{ param_name(codec.name)}}.{% if param.type == 'boolean' %}is{% else %}get{% endif %}{{ param.name|capital }}());
+        {% if loop.last %}
+        clientMessage.add(initialFrame);
+        {% endif %}
+        {% endfor %}
+        {% for param in var_size_params(codec.params) %}
+        {% if loop.first %}
+
+        {% endif %}
+        {{ encode_var_sized(param) }};
+        {% endfor %}
+
+        clientMessage.add(END_FRAME);
+    }
+
+    public static {{ lang_types_decode(codec.name) }} decode(ListIterator<ClientMessage.Frame> iterator) {
+        // begin frame
+        iterator.next();
+        {% for param in fixed_params(codec.params) %}
+        {% if loop.first %}
+
+        ClientMessage.Frame initialFrame = iterator.next();
+        {% endif %}
+        {{ lang_types_decode(param.type) }} {{ param.name }} = decode{% if is_enum(param.type) %}{{ enum_type(lang_name, param.type)|capital }}{% else %}{{ param.type|capital }}{% endif %}(initialFrame.content, {{ to_upper_snake_case(param.name) }}_FIELD_OFFSET);
+        {% endfor %}
+        {% for param in var_size_params(codec.params) %}
+        {% if loop.first %}
+
+        {% endif %}
+        {{ lang_types_decode(param.type) }} {{ param.name }} = {{ decode_var_sized(param) }};
+        {% endfor %}
+
+        fastForwardToEndFrame(iterator);
+
+        {% if codec.returnWithFactory %}
+        return CustomTypeFactory.create{{ codec.name }}({% for param in codec.params %}{{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %});
+        {% else %}
+        return new {{ lang_types_decode(codec.name) }}({% for param in codec.params %}{{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %});
+        {% endif %}
+    }
+}
+

--- a/protocol-definitions/Cache.yaml
+++ b/protocol-definitions/Cache.yaml
@@ -386,7 +386,7 @@ methods:
     response:
       params:
         - name: response
-          type: Map_Data_Data
+          type: EntryList_Data_Data
           nullable: false
           since: 2.0
           doc: |
@@ -1087,7 +1087,7 @@ methods:
           doc: |
             name of the cache
         - name: entries
-          type: Map_Data_Data
+          type: EntryList_Data_Data
           nullable: false
           since: 2.0
           doc: |
@@ -1144,7 +1144,7 @@ methods:
           doc: |
             The slot number (or index) to start the iterator
         - name: entries
-          type: Map_Data_Data
+          type: EntryList_Data_Data
           nullable: false
           since: 2.0
           doc: |
@@ -1271,13 +1271,13 @@ methods:
     response:
       params:
         - name: namePartitionSequenceList
-          type: Map_String_Map_Integer_Long
+          type: EntryList_String_EntryList_Integer_Long
           nullable: false
           since: 2.0
           doc: |
             TODO DOC
         - name: partitionUuidList
-          type: Map_Integer_UUID
+          type: EntryList_Integer_UUID
           nullable: false
           since: 2.0
           doc: |
@@ -1294,7 +1294,7 @@ methods:
     response:
       params:
         - name: partitionUuidList
-          type: Map_Integer_UUID
+          type: EntryList_Integer_UUID
           nullable: false
           since: 2.0
           doc: |

--- a/protocol-definitions/Client.yaml
+++ b/protocol-definitions/Client.yaml
@@ -457,7 +457,7 @@ methods:
     response:
       params:
         - name: partitions
-          type: Map_Address_List_Integer
+          type: EntryList_Address_List_Integer
           nullable: false
           since: 2.0
           doc: |
@@ -823,7 +823,7 @@ methods:
       partitionIdentifier: -1
       params:
         - name: classDefinitions
-          type: Map_String_byteArray
+          type: EntryList_String_byteArray
           nullable: false
           since: 2.0
           doc: |
@@ -843,7 +843,7 @@ methods:
       - name: Partitions
         params:
           - name: partitions
-            type: Map_Address_List_Integer
+            type: EntryList_Address_List_Integer
             nullable: false
             since: 2.0
             doc: |
@@ -869,7 +869,7 @@ methods:
       partitionIdentifier: -1
       params:
         - name: proxies
-          type: Map_String_String
+          type: EntryList_String_String
           nullable: false
           since: 2.0
           doc: |

--- a/protocol-definitions/ContinuousQuery.yaml
+++ b/protocol-definitions/ContinuousQuery.yaml
@@ -63,7 +63,7 @@ methods:
     response:
       params:
         - name: response
-          type: Map_Data_Data
+          type: EntryList_Data_Data
           nullable: false
           since: 2.0
           doc: |

--- a/protocol-definitions/Map.yaml
+++ b/protocol-definitions/Map.yaml
@@ -1624,7 +1624,7 @@ methods:
     response:
       params:
         - name: response
-          type: Map_Data_Data
+          type: EntryList_Data_Data
           nullable: false
           since: 2.0
           doc: |
@@ -1678,7 +1678,7 @@ methods:
     response:
       params:
         - name: response
-          type: Map_Data_Data
+          type: EntryList_Data_Data
           nullable: false
           since: 2.0
           doc: |
@@ -1777,7 +1777,7 @@ methods:
     response:
       params:
         - name: response
-          type: Map_Data_Data
+          type: EntryList_Data_Data
           nullable: false
           since: 2.0
           doc: |
@@ -1890,7 +1890,7 @@ methods:
           doc: |
             name of map
         - name: entries
-          type: Map_Data_Data
+          type: EntryList_Data_Data
           nullable: false
           since: 2.0
           doc: |
@@ -2027,7 +2027,7 @@ methods:
     response:
       params:
         - name: response
-          type: Map_Data_Data
+          type: EntryList_Data_Data
           nullable: false
           since: 2.0
           doc: |
@@ -2064,7 +2064,7 @@ methods:
     response:
       params:
         - name: response
-          type: Map_Data_Data
+          type: EntryList_Data_Data
           nullable: false
           since: 2.0
           doc: |
@@ -2101,7 +2101,7 @@ methods:
     response:
       params:
         - name: response
-          type: Map_Data_Data
+          type: EntryList_Data_Data
           nullable: false
           since: 2.0
           doc: |
@@ -2194,7 +2194,7 @@ methods:
     response:
       params:
         - name: response
-          type: Map_Data_Data
+          type: EntryList_Data_Data
           nullable: false
           since: 2.0
           doc: |
@@ -2224,7 +2224,7 @@ methods:
     response:
       params:
         - name: response
-          type: Map_Data_Data
+          type: EntryList_Data_Data
           nullable: false
           since: 2.0
           doc: |
@@ -2331,7 +2331,7 @@ methods:
           doc: |
             The slot number (or index) to start the iterator
         - name: entries
-          type: Map_Data_Data
+          type: EntryList_Data_Data
           nullable: false
           since: 2.0
           doc: |
@@ -2493,13 +2493,13 @@ methods:
     response:
       params:
         - name: namePartitionSequenceList
-          type: Map_String_Map_Integer_Long
+          type: EntryList_String_EntryList_Integer_Long
           nullable: false
           since: 2.0
           doc: |
             TODO DOC
         - name: partitionUuidList
-          type: Map_Integer_UUID
+          type: EntryList_Integer_UUID
           nullable: false
           since: 2.0
           doc: |
@@ -2516,7 +2516,7 @@ methods:
     response:
       params:
         - name: partitionUuidList
-          type: Map_Integer_UUID
+          type: EntryList_Integer_UUID
           nullable: false
           since: 2.0
           doc: |

--- a/protocol-definitions/Metrics.yaml
+++ b/protocol-definitions/Metrics.yaml
@@ -27,7 +27,7 @@ methods:
     response:
       params:
         - name: elements
-          type: Map_Long_byteArray
+          type: EntryList_Long_byteArray
           nullable: false
           since: 2.0
           doc: |

--- a/protocol-definitions/MultiMap.yaml
+++ b/protocol-definitions/MultiMap.yaml
@@ -186,7 +186,7 @@ methods:
     response:
       params:
         - name: response
-          type: Map_Data_Data
+          type: EntryList_Data_Data
           nullable: false
           since: 2.0
           doc: |

--- a/protocol-definitions/PNCounter.yaml
+++ b/protocol-definitions/PNCounter.yaml
@@ -25,7 +25,7 @@ methods:
           doc: |
             the name of the PNCounter
         - name: replicaTimestamps
-          type: Map_UUID_Long
+          type: EntryList_UUID_Long
           nullable: false
           since: 2.0
           doc: |
@@ -45,7 +45,7 @@ methods:
           doc: |
             TODO DOC
         - name: replicaTimestamps
-          type: Map_UUID_Long
+          type: EntryList_UUID_Long
           nullable: false
           since: 2.0
           doc: |
@@ -95,7 +95,7 @@ methods:
             counter value before the addition, {@code false}
             if it should return the value after the addition
         - name: replicaTimestamps
-          type: Map_UUID_Long
+          type: EntryList_UUID_Long
           nullable: false
           since: 2.0
           doc: |
@@ -115,7 +115,7 @@ methods:
           doc: |
             TODO DOC
         - name: replicaTimestamps
-          type: Map_UUID_Long
+          type: EntryList_UUID_Long
           nullable: false
           since: 2.0
           doc: |

--- a/protocol-definitions/ReplicatedMap.yaml
+++ b/protocol-definitions/ReplicatedMap.yaml
@@ -241,7 +241,7 @@ methods:
           doc: |
             Name of the ReplicatedMap
         - name: entries
-          type: Map_Data_Data
+          type: EntryList_Data_Data
           nullable: false
           since: 2.0
           doc: |
@@ -696,7 +696,7 @@ methods:
     response:
       params:
         - name: response
-          type: Map_Data_Data
+          type: EntryList_Data_Data
           nullable: false
           since: 2.0
           doc: |

--- a/protocol-definitions/ScheduledExecutor.yaml
+++ b/protocol-definitions/ScheduledExecutor.yaml
@@ -144,7 +144,7 @@ methods:
     response:
       params:
         - name: handlers
-          type: Map_Member_List_ScheduledTaskHandler
+          type: EntryList_Member_List_ScheduledTaskHandler
           nullable: false
           since: 2.0
           doc: |

--- a/protocol-definitions/custom/Custom.yaml
+++ b/protocol-definitions/custom/Custom.yaml
@@ -1,0 +1,745 @@
+customTypes:
+  - name: Address
+    since: 2.0
+    returnWithFactory: true
+    params:
+      - name: host
+        type: String
+        nullable: false
+        since: 2.0
+      - name: port
+        type: int
+        nullable: false
+        since: 2.0
+  - name: CacheEventData
+    since: 2.0
+    returnWithFactory: true
+    params:
+      - name: name
+        type: String
+        nullable: false
+        since: 2.0
+      - name: cacheEventType
+        type: Enum_int_CacheEventType
+        nullable: false
+        since: 2.0
+      - name: dataKey
+        type: Data
+        nullable: true
+        since: 2.0
+      - name: dataValue
+        type: Data
+        nullable: true
+        since: 2.0
+      - name: dataOldValue
+        type: Data
+        nullable: true
+        since: 2.0
+      - name: oldValueAvailable
+        type: boolean
+        nullable: false
+        since: 2.0
+  - name: CacheSimpleEntryListenerConfig
+    since: 2.0
+    returnWithFactory: true
+    params:
+      - name: oldValueRequired
+        type: boolean
+        nullable: false
+        since: 2.0
+      - name: synchronous
+        type: boolean
+        nullable: false
+        since: 2.0
+      - name: cacheEntryListenerFactory
+        type: String
+        nullable: true
+        since: 2.0
+      - name: cacheEntryEventFilterFactory
+        type: String
+        nullable: true
+        since: 2.0
+  - name: DistributedObjectInfo
+    since: 2.0
+    params:
+      - name: serviceName
+        type: String
+        nullable: false
+        since: 2.0
+      - name: name
+        type: String
+        nullable: false
+        since: 2.0
+  - name: ErrorHolder
+    since: 2.0
+    params:
+      - name: errorCode
+        type: int
+        nullable: false
+        since: 2.0
+      - name: className
+        type: String
+        nullable: false
+        since: 2.0
+      - name: message
+        type: String
+        nullable: true
+        since: 2.0
+      - name: stackTraceElements
+        type: List_StackTraceElement
+        nullable: false
+        since: 2.0
+  - name: EventJournalConfig
+    since: 2.0
+    returnWithFactory: true
+    params:
+      - name: enabled
+        type: boolean
+        nullable: false
+        since: 2.0
+      - name: capacity
+        type: int
+        nullable: false
+        since: 2.0
+      - name: timeToLiveSeconds
+        type: int
+        nullable: false
+        since: 2.0
+  - name: EvictionConfigHolder
+    since: 2.0
+    params:
+      - name: size
+        type: int
+        nullable: false
+        since: 2.0
+      - name: maxSizePolicy
+        type: String
+        nullable: false
+        since: 2.0
+      - name: evictionPolicy
+        type: String
+        nullable: false
+        since: 2.0
+      - name: comparatorClassName
+        type: String
+        nullable: true
+        since: 2.0
+      - name: comparator
+        type: Data
+        nullable: true
+        since: 2.0
+  - name: HotRestartConfig
+    since: 2.0
+    returnWithFactory: true
+    params:
+      - name: enabled
+        type: boolean
+        nullable: false
+        since: 2.0
+      - name: fsync
+        type: boolean
+        nullable: false
+        since: 2.0
+  - name: ListenerConfigHolder
+    since: 2.0
+    params:
+      - name: listenerType
+        type: int
+        nullable: false
+        since: 2.0
+      - name: listenerImplementation
+        type: Data
+        nullable: true
+        since: 2.0
+      - name: className
+        type: String
+        nullable: true
+        since: 2.0
+      - name: includeValue
+        type: boolean
+        nullable: false
+        since: 2.0
+      - name: local
+        type: boolean
+        nullable: false
+        since: 2.0
+  - name: AttributeConfig
+    since: 2.0
+    params:
+      - name: name
+        type: String
+        nullable: false
+        since: 2.0
+      - name: extractorClassName
+        type: String
+        nullable: false
+        since: 2.0
+  - name: MapIndexConfig
+    since: 2.0
+    params:
+      - name: attribute
+        type: String
+        nullable: false
+        since: 2.0
+      - name: ordered
+        type: boolean
+        nullable: false
+        since: 2.0
+  - name: MapStoreConfigHolder
+    since: 2.0
+    params:
+      - name: enabled
+        type: boolean
+        nullable: false
+        since: 2.0
+      - name: writeCoalescing
+        type: boolean
+        nullable: false
+        since: 2.0
+      - name: writeDelaySeconds
+        type: int
+        nullable: false
+        since: 2.0
+      - name: writeBatchSize
+        type: int
+        nullable: false
+        since: 2.0
+      - name: className
+        type: String
+        nullable: true
+        since: 2.0
+      - name: implementation
+        type: Data
+        nullable: true
+        since: 2.0
+      - name: factoryClassName
+        type: String
+        nullable: true
+        since: 2.0
+      - name: factoryImplementation
+        type: Data
+        nullable: true
+        since: 2.0
+      - name: properties
+        type: Map_String_String
+        nullable: true
+        since: 2.0
+      - name: initialLoadMode
+        type: String
+        nullable: false
+        since: 2.0
+  - name: Member
+    since: 2.0
+    params:
+      - name: address
+        type: Address
+        nullable: false
+        since: 2.0
+      - name: uuid
+        type: UUID
+        nullable: false
+        since: 2.0
+      - name: attributes
+        type: Map_String_String
+        nullable: false
+        since: 2.0
+      - name: liteMember
+        type: boolean
+        nullable: false
+        since: 2.0
+  - name: MerkleTreeConfig
+    since: 2.0
+    returnWithFactory: true
+    params:
+      - name: enabled
+        type: boolean
+        nullable: false
+        since: 2.0
+      - name: depth
+        type: int
+        nullable: false
+        since: 2.0
+  - name: NearCacheConfigHolder
+    since: 2.0
+    params:
+      - name: name
+        type: String
+        nullable: false
+        since: 2.0
+      - name: inMemoryFormat
+        type: String
+        nullable: false
+        since: 2.0
+      - name: serializeKeys
+        type: boolean
+        nullable: false
+        since: 2.0
+      - name: invalidateOnChange
+        type: boolean
+        nullable: false
+        since: 2.0
+      - name: timeToLiveSeconds
+        type: int
+        nullable: false
+        since: 2.0
+      - name: maxIdleSeconds
+        type: int
+        nullable: false
+        since: 2.0
+      - name: evictionConfigHolder
+        type: EvictionConfigHolder
+        nullable: false
+        since: 2.0
+      - name: cacheLocalEntries
+        type: boolean
+        nullable: false
+        since: 2.0
+      - name: localUpdatePolicy
+        type: String
+        nullable: false
+        since: 2.0
+      - name: preloaderConfig
+        type: NearCachePreloaderConfig
+        nullable: true
+        since: 2.0
+  - name: NearCachePreloaderConfig
+    since: 2.0
+    returnWithFactory: true
+    params:
+      - name: enabled
+        type: boolean
+        nullable: false
+        since: 2.0
+      - name: directory
+        type: String
+        nullable: false
+        since: 2.0
+      - name: storeInitialDelaySeconds
+        type: int
+        nullable: false
+        since: 2.0
+      - name: storeIntervalSeconds
+        type: int
+        nullable: false
+        since: 2.0
+  - name: PredicateConfigHolder
+    since: 2.0
+    params:
+      - name: className
+        type: String
+        nullable: true
+        since: 2.0
+      - name: sql
+        type: String
+        nullable: true
+        since: 2.0
+      - name: implementation
+        type: Data
+        nullable: true
+        since: 2.0
+  - name: QueryCacheConfigHolder
+    since: 2.0
+    params:
+      - name: batchSize
+        type: int
+        nullable: false
+        since: 2.0
+      - name: bufferSize
+        type: int
+        nullable: false
+        since: 2.0
+      - name: delaySeconds
+        type: int
+        nullable: false
+        since: 2.0
+      - name: includeValue
+        type: boolean
+        nullable: false
+        since: 2.0
+      - name: populate
+        type: boolean
+        nullable: false
+        since: 2.0
+      - name: coalesce
+        type: boolean
+        nullable: false
+        since: 2.0
+      - name: inMemoryFormat
+        type: String
+        nullable: false
+        since: 2.0
+      - name: name
+        type: String
+        nullable: false
+        since: 2.0
+      - name: predicateConfigHolder
+        type: PredicateConfigHolder
+        nullable: false
+        since: 2.0
+      - name: evictionConfigHolder
+        type: EvictionConfigHolder
+        nullable: false
+        since: 2.0
+      - name: listenerConfigs
+        type: List_ListenerConfigHolder
+        nullable: true
+        since: 2.0
+      - name: indexConfigs
+        type: List_MapIndexConfig
+        nullable: true
+        since: 2.0
+  - name: QueryCacheEventData
+    since: 2.0
+    returnWithFactory: true
+    params:
+      - name: dataKey
+        type: Data
+        nullable: true
+        since: 2.0
+      - name: dataNewValue
+        type: Data
+        nullable: true
+        since: 2.0
+      - name: sequence
+        type: long
+        nullable: false
+        since: 2.0
+      - name: eventType
+        type: int
+        nullable: false
+        since: 2.0
+      - name: partitionId
+        type: int
+        nullable: false
+        since: 2.0
+  - name: QueueStoreConfigHolder
+    since: 2.0
+    params:
+      - name: className
+        type: String
+        nullable: true
+        since: 2.0
+      - name: factoryClassName
+        type: String
+        nullable: true
+        since: 2.0
+      - name: implementation
+        type: Data
+        nullable: true
+        since: 2.0
+      - name: factoryImplementation
+        type: Data
+        nullable: true
+        since: 2.0
+      - name: properties
+        type: Map_String_String
+        nullable: true
+        since: 2.0
+      - name: enabled
+        type: boolean
+        nullable: false
+        since: 2.0
+  - name: RaftGroupId
+    since: 2.0
+    params:
+      - name: name
+        type: String
+        nullable: false
+        since: 2.0
+      - name: seed
+        type: long
+        nullable: false
+        since: 2.0
+      - name: id
+        type: long
+        nullable: false
+        since: 2.0
+  - name: RingbufferStoreConfigHolder
+    since: 2.0
+    params:
+      - name: className
+        type: String
+        nullable: true
+        since: 2.0
+      - name: factoryClassName
+        type: String
+        nullable: true
+        since: 2.0
+      - name: implementation
+        type: Data
+        nullable: true
+        since: 2.0
+      - name: factoryImplementation
+        type: Data
+        nullable: true
+        since: 2.0
+      - name: properties
+        type: Map_String_String
+        nullable: true
+        since: 2.0
+      - name: enabled
+        type: boolean
+        nullable: false
+        since: 2.0
+  - name: ScheduledTaskHandler
+    since: 2.0
+    params:
+      - name: address
+        type: Address
+        nullable: true
+        since: 2.0
+      - name: partitionId
+        type: int
+        nullable: false
+        since: 2.0
+      - name: schedulerName
+        type: String
+        nullable: false
+        since: 2.0
+      - name: taskName
+        type: String
+        nullable: false
+        since: 2.0
+  - name: SimpleEntryView
+    since: 2.0
+    returnWithFactory: true
+    params:
+      - name: key
+        type: Data
+        nullable: false
+        since: 2.0
+      - name: value
+        type: Data
+        nullable: false
+        since: 2.0
+      - name: cost
+        type: long
+        nullable: false
+        since: 2.0
+      - name: creationTime
+        type: long
+        nullable: false
+        since: 2.0
+      - name: expirationTime
+        type: long
+        nullable: false
+        since: 2.0
+      - name: hits
+        type: long
+        nullable: false
+        since: 2.0
+      - name: lastAccessTime
+        type: long
+        nullable: false
+        since: 2.0
+      - name: lastStoredTime
+        type: long
+        nullable: false
+        since: 2.0
+      - name: lastUpdateTime
+        type: long
+        nullable: false
+        since: 2.0
+      - name: version
+        type: long
+        nullable: false
+        since: 2.0
+      - name: ttl
+        type: long
+        nullable: false
+        since: 2.0
+      - name: maxIdle
+        type: long
+        nullable: false
+        since: 2.0
+  - name: StackTraceElement
+    since: 2.0
+    params:
+      - name: className
+        type: String
+        nullable: false
+        since: 2.0
+      - name: methodName
+        type: String
+        nullable: false
+        since: 2.0
+      - name: fileName
+        type: String
+        nullable: true
+        since: 2.0
+      - name: lineNumber
+        type: int
+        nullable: false
+        since: 2.0
+  - name: DurationConfig
+    since: 2.0
+    returnWithFactory: true
+    params:
+      - name: durationAmount
+        type: long
+        nullable: false
+        since: 2.0
+      - name: timeUnit
+        type: Enum_String_TimeUnit
+        nullable: false
+        since: 2.0
+  - name: TimedExpiryPolicyFactoryConfig
+    since: 2.0
+    returnWithFactory: true
+    params:
+      - name: expiryPolicyType
+        type: Enum_String_ExpiryPolicyType
+        nullable: false
+        since: 2.0
+      - name: durationConfig
+        type: DurationConfig
+        nullable: False
+        since: 2.0
+  - name: WanReplicationRef
+    since: 2.0
+    params:
+      - name: name
+        type: String
+        nullable: false
+        since: 2.0
+      - name: mergePolicy
+        type: String
+        nullable: false
+        since: 2.0
+      - name: filters
+        type: List_String
+        nullable: true
+        since: 2.0
+      - name: republishingEnabled
+        type: boolean
+        nullable: false
+        since: 2.0
+  - name: Xid
+    since: 2.0
+    params:
+      - name: formatId
+        type: int
+        nullable: false
+        since: 2.0
+      - name: globalTransactionId
+        type: byteArray
+        nullable: false
+        since: 2.0
+      - name: branchQualifier
+        type: byteArray
+        nullable: false
+        since: 2.0
+  - name: MergePolicyConfig
+    since: 2.0
+    params:
+      - name: policy
+        type: String
+        nullable: false
+        since: 2.0
+      - name: batchSize
+        type: int
+        nullable: false
+        since: 2.0
+  - name: CacheConfigHolder
+    since: 2.0
+    params:
+      - name: name
+        type: String
+        nullable: false
+        since: 2.0
+      - name: managerPrefix
+        type: String
+        nullable: true
+        since: 2.0
+      - name: uriString
+        type: String
+        nullable: true
+        since: 2.0
+      - name: backupCount
+        type: int
+        nullable: false
+        since: 2.0
+      - name: asyncBackupCount
+        type: int
+        nullable: false
+        since: 2.0
+      - name: inMemoryFormat
+        type: String
+        nullable: false
+        since: 2.0
+      - name: evictionConfigHolder
+        type: EvictionConfigHolder
+        nullable: false
+        since: 2.0
+      - name: wanReplicationRef
+        type: WanReplicationRef
+        nullable: true
+        since: 2.0
+      - name: keyClassName
+        type: String
+        nullable: false
+        since: 2.0
+      - name: valueClassName
+        type: String
+        nullable: false
+        since: 2.0
+      - name: cacheLoaderFactory
+        type: Data
+        nullable: true
+        since: 2.0
+      - name: cacheWriterFactory
+        type: Data
+        nullable: true
+        since: 2.0
+      - name: expiryPolicyFactory
+        type: Data
+        nullable: false
+        since: 2.0
+      - name: readThrough
+        type: boolean
+        nullable: false
+        since: 2.0
+      - name: writeThrough
+        type: boolean
+        nullable: false
+        since: 2.0
+      - name: storeByValue
+        type: boolean
+        nullable: false
+        since: 2.0
+      - name: managementEnabled
+        type: boolean
+        nullable: false
+        since: 2.0
+      - name: statisticsEnabled
+        type: boolean
+        nullable: false
+        since: 2.0
+      - name: hotRestartConfig
+        type: HotRestartConfig
+        nullable: true
+        since: 2.0
+      - name: eventJournalConfig
+        type: EventJournalConfig
+        nullable: true
+        since: 2.0
+      - name: splitBrainProtectionName
+        type: String
+        nullable: true
+        since: 2.0
+      - name: listenerConfigurations
+        type: List_Data
+        nullable: true
+        since: 2.0
+      - name: mergePolicyConfig
+        type: MergePolicyConfig
+        nullable: false
+        since: 2.0
+      - name: disablePerEntryInvalidationEvents
+        type: boolean
+        nullable: false
+        since: 2.0
+      - name: cachePartitionLostListenerConfigs
+        type: List_ListenerConfigHolder
+        nullable: true
+        since: 2.0

--- a/schema/custom-codec-schema.json
+++ b/schema/custom-codec-schema.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/schema#",
-  "id": "https://github.com/hazelcast/hazelcast-client-protocol/blob/master/schema/protocol-schema.json",
-  "title": "Hazelcast Client Protocol Definition",
+  "id": "https://github.com/hazelcast/hazelcast-client-protocol/blob/master/schema/custom-codec-schema.json",
+  "title": "Hazelcast Client Protocol Custom Codec Definitions",
   "type": "object",
   "definitions": {
     "since": {
@@ -98,130 +98,52 @@
         },
         "since": {
           "$ref": "#/definitions/since"
-        },
-        "doc": {
-          "type": "string",
-          "description": "parameter documentation"
         }
       },
       "required": [
         "name",
         "type",
         "nullable",
-        "since",
-        "doc"
+        "since"
       ]
-    },
-    "event": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "name": {
-          "type": "string",
-          "description": "Event name"
-        },
-        "params": {
-          "type": "array",
-          "items": {
-            "$ref": "#/definitions/param"
-          },
-          "minItems": 0,
-          "uniqueItems": false
-        }
-      }
     }
   },
   "additionalProperties": false,
   "properties": {
-    "id": {
-      "type": "integer",
-      "minimum": 0,
-      "maximum": 255,
-      "description": "Service unique id, 0-255"
-    },
-    "name": {
-      "type": "string",
-      "description": "Service name"
-    },
-    "methods": {
+    "customTypes": {
       "type": "array",
       "items": {
         "additionalProperties": false,
         "properties": {
-          "id": {
-            "type": "integer",
-            "minimum": 1,
-            "maximum": 255,
-            "description": "Method unique id, 1-255"
-          },
           "name": {
             "type": "string",
-            "description": "Method name"
+            "description": "Name of the custom type"
           },
           "since": {
             "$ref": "#/definitions/since"
           },
-          "doc": {
-            "type": "string",
-            "description": "method documentation"
+          "returnWithFactory": {
+            "type": "boolean",
+            "description": "True if the decode method should return with factory instead of the constructor"
           },
-          "request": {
-            "type": "object",
-            "description": "Request message definition",
-            "additionalProperties": false,
-            "properties": {
-              "retryable": {
-                "type": "boolean",
-                "description": "Is the request retryable or not"
-              },
-              "acquiresResource": {
-                "type": "boolean",
-                "description": "Does the request acquire resource or not"
-              },
-              "partitionIdentifier": {
-                "type": ["integer", "string"],
-                "description": "How should the partition Id calculated for this request. Used in documentation."
-              },
-              "params": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/param"
-                },
-                "minItems": 0,
-                "uniqueItems": false
-              }
-            },
-            "required": ["retryable", "acquiresResource", "partitionIdentifier"]
-          },
-          "response": {
-            "type": "object",
-            "additionalProperties": false,
-            "properties": {
-              "params": {
-                "type": "array",
-                "items": {
-                  "$ref": "#/definitions/param"
-                },
-                "minItems": 0,
-                "uniqueItems": false
-              }
-            }
-          },
-          "events": {
+          "params": {
             "type": "array",
             "items": {
-              "$ref": "#/definitions/event"
+              "$ref": "#/definitions/param"
             },
-            "minItems": 1,
-            "uniqueItems": true
+            "minItems": 0,
+            "uniqueItems": false
           }
         },
-        "required": ["name", "since", "doc", "request", "response"]
+        "required": [
+          "name",
+          "since",
+          "params"
+        ]
       }
     }
   },
   "required": [
-    "name",
-    "methods"
+    "customTypes"
   ]
 }


### PR DESCRIPTION
This pr includes the following changes
* Formerly, we named `List<Map.Entry<K, V>>` types as `Map_` but this is changed to `EntryList` because with the auto generation of the custom codecs, we do have `Map<K, V>` types. `Map_` is reserved for them.

* Custom codecs (formerly some of the codecs in the `builtin` directory) are now auto generated using the definition in the `protocol-definitions/custom/Custom.yaml`. For template rendering we use `java/custom-codec-template.java.j2` and for schema validation we use `schema/custom-codec-schema.json`. 

* Since custom codecs are auto-generated from now on, I seperated them from the hand written builtin codecs (`DataCodec`, `StringCodec` ...)