### PR TITLE
allow enum types to be used in codecs

### DIFF
--- a/java/codec-template.java.j2
+++ b/java/codec-template.java.j2
@@ -1,3 +1,10 @@
+{% macro get_type(type) -%}
+    {% if is_enum(type) -%}
+        {{ enum_type(lang_name, type) }}
+    {%- else -%}
+        {{ lang_name(type) }}
+    {%- endif %}
+{%-  endmacro %}
 {% macro encode_var_sized(param) -%}
     {% if is_var_sized_list(param.type) or is_var_sized_list_contains_nullable(param.type) -%}
         ListMultiFrameCodec.encode{% if is_var_sized_list_contains_nullable(param.type)%}ContainsNullable{% endif %}{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param.name }}, {{ item_type(lang_name, param.type) }}Codec::encode)
@@ -7,9 +14,9 @@
         MapCodec.encode{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param.name }}, {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
     {%- else -%}
         {%- if param.nullable  -%}
-            CodecUtil.encodeNullable(clientMessage, {{ param.name }}, {{ lang_name(param.type) }}Codec::encode)
+            CodecUtil.encodeNullable(clientMessage, {{ param.name }}, {{ get_type(param.type) }}Codec::encode)
         {%- else -%}
-            {{ lang_name(param.type) }}Codec.encode(clientMessage, {{ param.name }})
+            {{ get_type(param.type) }}Codec.encode(clientMessage, {{ param.name }})
         {%- endif %}
     {% endif %}
 {%- endmacro %}
@@ -22,9 +29,9 @@
         MapCodec.decode{% if param.nullable  %}Nullable{% endif %}(iterator, {{ key_type(lang_name, param.type) }}Codec::decode, {{ value_type(lang_name, param.type) }}Codec::decode)
     {%- else -%}
         {%- if param.nullable  -%}
-            CodecUtil.decodeNullable(iterator, {{ lang_name(param.type) }}Codec::decode)
+            CodecUtil.decodeNullable(iterator, {{ get_type(param.type) }}Codec::decode)
         {%- else -%}
-            {{ lang_name(param.type) }}Codec.decode(iterator)
+            {{ get_type(param.type) }}Codec.decode(iterator)
         {%- endif -%}
     {%- endif -%}
 {%- endmacro %}
@@ -83,26 +90,26 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
     public static final int RESPONSE_MESSAGE_TYPE = {{ method.response.id }};
 {#FIXED SIZED PARAMETER OFFSET CONSTANTS#}
 {% for param in fixed_params(method.request.params) %}
-    private static final int REQUEST_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET = {% if loop.first %}PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES{% else %}REQUEST_{{ to_upper_snake_case(loop.previtem.name)}}_FIELD_OFFSET + {{loop.previtem.type.upper()}}_SIZE_IN_BYTES{% endif %};
+    private static final int REQUEST_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET = {% if loop.first %}PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES{% else %}REQUEST_{{ to_upper_snake_case(loop.previtem.name)}}_FIELD_OFFSET + {{ get_type(loop.previtem.type).upper() }}_SIZE_IN_BYTES{% endif %};
     {% if loop.last %}
-    private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET + {{param.type.upper()}}_SIZE_IN_BYTES;
+    private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET + {{ get_type(param.type).upper() }}_SIZE_IN_BYTES;
     {% endif %}
 {% else %}
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 {% endfor %}
 {% for param in fixed_params(method.response.params) %}
-    private static final int RESPONSE_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET = {% if loop.first %}RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES{% else %}RESPONSE_{{ to_upper_snake_case(loop.previtem.name)}}_FIELD_OFFSET + {{loop.previtem.type.upper()}}_SIZE_IN_BYTES{% endif %};
+    private static final int RESPONSE_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET = {% if loop.first %}RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES{% else %}RESPONSE_{{ to_upper_snake_case(loop.previtem.name)}}_FIELD_OFFSET + {{ get_type(loop.previtem.type).upper() }}_SIZE_IN_BYTES{% endif %};
     {% if loop.last %}
-    private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET + {{param.type.upper()}}_SIZE_IN_BYTES;
+    private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET + {{ get_type(param.type).upper() }}_SIZE_IN_BYTES;
     {% endif %}
 {% else %}
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 {% endfor %}
 {% for event in method.events%}
     {% for param in fixed_params(event.params) %}
-    private static final int EVENT_{{ to_upper_snake_case(event.name)}}_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET = {% if loop.first %}PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES{% else %}EVENT_{{ to_upper_snake_case(event.name)}}_{{ to_upper_snake_case(loop.previtem.name)}}_FIELD_OFFSET + {{loop.previtem.type.upper()}}_SIZE_IN_BYTES{% endif %};
+    private static final int EVENT_{{ to_upper_snake_case(event.name)}}_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET = {% if loop.first %}PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES{% else %}EVENT_{{ to_upper_snake_case(event.name)}}_{{ to_upper_snake_case(loop.previtem.name)}}_FIELD_OFFSET + {{ get_type(loop.previtem.type).upper() }}_SIZE_IN_BYTES{% endif %};
     {% if loop.last %}
-    private static final int EVENT_{{ to_upper_snake_case(event.name)}}_INITIAL_FRAME_SIZE = EVENT_{{ to_upper_snake_case(event.name)}}_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET + {{param.type.upper()}}_SIZE_IN_BYTES;
+    private static final int EVENT_{{ to_upper_snake_case(event.name)}}_INITIAL_FRAME_SIZE = EVENT_{{ to_upper_snake_case(event.name)}}_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET + {{ get_type(param.type).upper() }}_SIZE_IN_BYTES;
     {% endif %}
     {% else %}
     private static final int EVENT_{{ to_upper_snake_case(event.name)}}_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
@@ -137,7 +144,7 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);
         encodeInt(initialFrame.content, TYPE_FIELD_OFFSET, REQUEST_MESSAGE_TYPE);
     {% for param in fixed_params(method.request.params) %}
-        encode{{ param.type|capital }}(initialFrame.content, REQUEST_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET, {{ param.name }});
+        encode{{ get_type(param.type)|capital }}(initialFrame.content, REQUEST_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET, {{ param.name }});
     {% endfor %}
         clientMessage.add(initialFrame);
     {% for param in var_size_params(method.request.params) %}
@@ -157,7 +164,7 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
         iterator.next();
     {% endif %}
     {% for param in fixed_params(method.request.params) %}
-        request.{{ param.name }} = decode{{ param.type|capital }}(initialFrame.content, REQUEST_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET);
+        request.{{ param.name }} = decode{{ get_type(param.type)|capital }}(initialFrame.content, REQUEST_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET);
     {% endfor %}
     {% for param in var_size_params(method.request.params) %}
         request.{{ param.name }} = {{ decode_var_sized(param) }};
@@ -185,7 +192,7 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[RESPONSE_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);
         encodeInt(initialFrame.content, TYPE_FIELD_OFFSET, RESPONSE_MESSAGE_TYPE);
     {% for param in fixed_params(method.response.params) %}
-        encode{{ param.type|capital }}(initialFrame.content, RESPONSE_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET, {{ param.name }});
+        encode{{ get_type(param.type)|capital }}(initialFrame.content, RESPONSE_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET, {{ param.name }});
     {% endfor %}
         clientMessage.add(initialFrame);
 
@@ -206,7 +213,7 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
         iterator.next();
         {% endif %}
     {% for param in fixed_params(method.response.params) %}
-        response.{{ param.name }} = decode{{ param.type|capital }}(initialFrame.content, RESPONSE_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET);
+        response.{{ param.name }} = decode{{ get_type(param.type)|capital }}(initialFrame.content, RESPONSE_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET);
     {% endfor %}
     {% for param in var_size_params(method.response.params) %}
         response.{{ param.name }} = {{ decode_var_sized(param) }};
@@ -223,7 +230,7 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
         initialFrame.flags |= ClientMessage.IS_EVENT_FLAG;
         encodeInt(initialFrame.content, TYPE_FIELD_OFFSET, EVENT_{{ to_upper_snake_case(event.name)}}_MESSAGE_TYPE);
     {% for param in fixed_params(event.params) %}
-        encode{{ param.type|capital }}(initialFrame.content, EVENT_{{ to_upper_snake_case(event.name)}}_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET, {{ param.name }});
+        encode{{ get_type(param.type)|capital }}(initialFrame.content, EVENT_{{ to_upper_snake_case(event.name)}}_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET, {{ param.name }});
     {% endfor %}
         clientMessage.add(initialFrame);
 
@@ -248,7 +255,7 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
                 iterator.next();
             {% endif %}
             {% for param in fixed_params(event.params) %}
-                {{ lang_types_encode(param.type) }} {{param.name}} = decode{{ param.type|capital }}(initialFrame.content, EVENT_{{ to_upper_snake_case(event.name)}}_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET);
+                {{ lang_types_encode(param.type) }} {{param.name}} = decode{{ get_type(param.type)|capital }}(initialFrame.content, EVENT_{{ to_upper_snake_case(event.name)}}_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET);
             {% endfor %}
             {% for param in var_size_params(event.params) %}
                 {{ lang_types_encode(param.type) }} {{param.name}} = {{ decode_var_sized(param) }};

--- a/java/custom-codec-template.java.j2
+++ b/java/custom-codec-template.java.j2
@@ -1,15 +1,22 @@
+{% macro get_type(type) -%}
+    {% if is_enum(type) -%}
+        {{ enum_type(lang_name, type) }}
+    {%- else -%}
+        {{ lang_name(type) }}
+    {%- endif %}
+{%-  endmacro %}
 {% macro encode_var_sized(param) -%}
     {% if is_var_sized_list(param.type) or is_var_sized_list_contains_nullable(param.type) -%}
         ListMultiFrameCodec.encode{% if is_var_sized_list_contains_nullable(param.type)%}ContainsNullable{% endif %}{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param_name(codec.name)}}.{% if param.type == 'boolean' %}is{% else %}get{% endif %}{{ param.name|capital }}(), {{ item_type(lang_name, param.type) }}Codec::encode)
     {%- elif is_var_sized_entry_list(param.type) -%}
-        EntryList.encode{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param_name(codec.name)}}.{% if param.type == 'boolean' %}is{% else %}get{% endif %}{{ param.name|capital }}(), {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
+        EntryListCodec.encode{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param_name(codec.name)}}.{% if param.type == 'boolean' %}is{% else %}get{% endif %}{{ param.name|capital }}(), {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
     {%- elif is_var_sized_map(param.type) -%}
         MapCodec.encode{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param_name(codec.name)}}.{% if param.type == 'boolean' %}is{% else %}get{% endif %}{{ param.name|capital }}(), {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
     {%- else -%}
         {%- if param.nullable  -%}
-            CodecUtil.encodeNullable(clientMessage, {{ param_name(codec.name)}}.{% if param.type == 'boolean' %}is{% else %}get{% endif %}{{ param.name|capital }}(), {% if is_enum(param.type) %}{{ lang_name(enum_type(lang_name, param.type)) }}{% else %}{{ lang_name(param.type) }}{% endif %}Codec::encode)
+            CodecUtil.encodeNullable(clientMessage, {{ param_name(codec.name)}}.{% if param.type == 'boolean' %}is{% else %}get{% endif %}{{ param.name|capital }}(), {{ get_type(param.type) }}Codec::encode)
         {%- else -%}
-            {% if is_enum(param.type) %}{{ lang_name(enum_type(lang_name, param.type)) }}{% else %}{{ lang_name(param.type) }}{% endif %}Codec.encode(clientMessage, {{ param_name(codec.name)}}.{% if param.type == 'boolean' %}is{% else %}get{% endif %}{{ param.name|capital }}())
+            {{ get_type(param.type) }}Codec.encode(clientMessage, {{ param_name(codec.name)}}.{% if param.type == 'boolean' %}is{% else %}get{% endif %}{{ param.name|capital }}())
         {%- endif %}
     {% endif %}
 {%- endmacro %}
@@ -22,9 +29,9 @@
         MapCodec.decode{% if param.nullable  %}Nullable{% endif %}(iterator, {{ key_type(lang_name, param.type) }}Codec::decode, {{ value_type(lang_name, param.type) }}Codec::decode)
     {%- else -%}
         {%- if param.nullable  -%}
-            CodecUtil.decodeNullable(iterator, {% if is_enum(param.type) %}{{ lang_name(enum_type(lang_name, param.type)) }}{% else %}{{ lang_name(param.type) }}{% endif %}Codec::decode)
+            CodecUtil.decodeNullable(iterator, {{ get_type(param.type) }}Codec::decode)
         {%- else -%}
-            {% if is_enum(param.type) %}{{ lang_name(enum_type(lang_name, param.type)) }}{% else %}{{ lang_name(param.type) }}{% endif %}Codec.decode(iterator)
+            {{ get_type(param.type) }}Codec.decode(iterator)
         {%- endif -%}
     {%- endif -%}
 {%- endmacro %}
@@ -63,9 +70,9 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 @Generated("!codec_hash!")
 public final class {{ codec.name|capital }}Codec {
     {% for param in fixed_params(codec.params) %}
-    private static final int {{ to_upper_snake_case(param.name) }}_FIELD_OFFSET = {% if loop.first %}0{% else %}{{ to_upper_snake_case(loop.previtem.name)}}_FIELD_OFFSET + {% if is_enum(loop.previtem.type) %}{{ enum_type(lang_name, loop.previtem.type).upper() }}{% else %}{{ loop.previtem.type.upper() }}{% endif %}_SIZE_IN_BYTES{% endif %};
+    private static final int {{ to_upper_snake_case(param.name) }}_FIELD_OFFSET = {% if loop.first %}0{% else %}{{ to_upper_snake_case(loop.previtem.name)}}_FIELD_OFFSET + {{ get_type(loop.previtem.type).upper() }}_SIZE_IN_BYTES{% endif %};
     {% if loop.last %}
-    private static final int INITIAL_FRAME_SIZE = {{to_upper_snake_case(param.name)}}_FIELD_OFFSET + {% if is_enum(param.type) %}{{ enum_type(lang_name, param.type).upper() }}{% else %}{{ param.type.upper() }}{% endif %}_SIZE_IN_BYTES;
+    private static final int INITIAL_FRAME_SIZE = {{to_upper_snake_case(param.name)}}_FIELD_OFFSET + {{ get_type(param.type).upper() }}_SIZE_IN_BYTES;
     {% endif %}
     {% endfor %}
 
@@ -79,7 +86,7 @@ public final class {{ codec.name|capital }}Codec {
 
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[INITIAL_FRAME_SIZE]);
         {% endif %}
-        encode{% if is_enum(param.type) %}{{ enum_type(lang_name, param.type)|capital }}{% else %}{{ param.type|capital }}{% endif %}(initialFrame.content, {{to_upper_snake_case(param.name)}}_FIELD_OFFSET, {{ param_name(codec.name)}}.{% if param.type == 'boolean' %}is{% else %}get{% endif %}{{ param.name|capital }}());
+        encode{{ get_type(param.type)|capital }}(initialFrame.content, {{to_upper_snake_case(param.name)}}_FIELD_OFFSET, {{ param_name(codec.name)}}.{% if param.type == 'boolean' %}is{% else %}get{% endif %}{{ param.name|capital }}());
         {% if loop.last %}
         clientMessage.add(initialFrame);
         {% endif %}
@@ -102,7 +109,7 @@ public final class {{ codec.name|capital }}Codec {
 
         ClientMessage.Frame initialFrame = iterator.next();
         {% endif %}
-        {{ lang_types_decode(param.type) }} {{ param.name }} = decode{% if is_enum(param.type) %}{{ enum_type(lang_name, param.type)|capital }}{% else %}{{ param.type|capital }}{% endif %}(initialFrame.content, {{ to_upper_snake_case(param.name) }}_FIELD_OFFSET);
+        {{ lang_types_decode(param.type) }} {{ param.name }} = decode{{ get_type(param.type)|capital }}(initialFrame.content, {{ to_upper_snake_case(param.name) }}_FIELD_OFFSET);
         {% endfor %}
         {% for param in var_size_params(codec.params) %}
         {% if loop.first %}


### PR DESCRIPTION
this pr allows enum types to be used in the codecs. This PR does not require a change in the Hazelcast side since there is no behaviour change for the existing definitions. It is meant to be used for the #237 