### PR TITLE
be more verbose on validation errors

### DIFF
--- a/util.py
+++ b/util.py
@@ -121,7 +121,7 @@ def validate_services(services, schema_path):
             try:
                 jsonschema.validate(service, schema)
             except jsonschema.ValidationError as e:
-                print("Validation error: %s. schema:%s" % (e.message, list(e.relative_schema_path)))
+                print("Validation error on %s: %s" % (service.get('name', None), e))
                 valid = False
     return valid
 


### PR DESCRIPTION
With this PR, instead of just showing the error path in validation process, we will show a much more verbose output that points to the faulty definition.

So, 
```
Validation error: None is not of type 'string'. schema:['properties', 'methods', 'items', 'properties', 'doc', 'type']
```
would become

```
Validation error on AtomicRef: None is not of type 'string'

Failed validating 'type' in schema['properties']['methods']['items']['properties']['doc']:
    {'description': 'method documentation', 'type': 'string'}

On instance['methods'][0]['doc']:
    None
```

Thanks to @cangencer for spotting that