### PR TITLE
removed refenreces to ICompletableFuture

### DIFF
--- a/protocol-definitions/Ringbuffer.yaml
+++ b/protocol-definitions/Ringbuffer.yaml
@@ -247,7 +247,7 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            the ICompletableFuture to synchronize on completion.
+            the CompletionStage to synchronize on completion.
   - id: 10
     name: readMany
     since: 2.0


### PR DESCRIPTION
This PR is part of the effort of hazelcast/hazelcast#15796 to remove references to ICompletableFuture.