### PR TITLE
Encode PagingPredicate into protocol and the query response returns anchor list

### DIFF
--- a/binary/__init__.py
+++ b/binary/__init__.py
@@ -47,6 +47,8 @@ CustomTypes = [
     'MemberInfo',
     'MemberVersion',
     'MCEvent',
+    'AnchorDataListHolder',
+    'PagingPredicateHolder',
 ]
 
 CustomConfigTypes = [

--- a/binary/util.py
+++ b/binary/util.py
@@ -248,7 +248,10 @@ class VarSizedEncoder:
             VarSizedEncoder.encode_multi_frame_map(client_message, VarSizedEncoder.encoder_for(key_type),
                                                    VarSizedEncoder.encoder_for(value_type))
         else:
-            VarSizedEncoder.encoder_for(type)(client_message)
+            try:
+                VarSizedEncoder.encoder_for(type)(client_message)
+            except:
+                print(type)
 
     @staticmethod
     def encode_multi_frame_list(client_message, encoder):
@@ -344,6 +347,8 @@ binary_output_directories = {
     # SupportedLanguages.GO: '',
 }
 
+
+
 reference_objects_dict = {
     'boolean': 'aBoolean',
     'byte': 'aByte',
@@ -421,9 +426,9 @@ reference_objects_dict = {
     'List_MCEvent': 'aListOfMCEvents',
     'MergePolicyConfig': 'aMergePolicyConfig',
     'CacheConfigHolder': 'aCacheConfigHolder',
+    'AnchorDataListHolder': 'anAnchorDataListHolder',
+    'PagingPredicateHolder': 'aPagingPredicateHolder',
 }
-
-
 def create_environment_for_binary_generator(lang, version):
     env = Environment(loader=PackageLoader(lang.value + '.binary', '.'))
     env.trim_blocks = True

--- a/java/__init__.py
+++ b/java/__init__.py
@@ -70,8 +70,11 @@ _java_types_encode = {
     "MemberInfo": "com.hazelcast.internal.cluster.MemberInfo",
     "MemberVersion": "com.hazelcast.version.MemberVersion",
     "MCEvent": "com.hazelcast.internal.management.dto.MCEventDTO",
+    "AnchorDataListHolder": "com.hazelcast.client.impl.protocol.codec.holder.AnchorDataListHolder",
+    "PagingPredicateHolder": "com.hazelcast.client.impl.protocol.codec.holder.PagingPredicateHolder",
 
     "List_Long": "java.util.Collection<java.lang.Long>",
+    "List_Integer": "java.util.Collection<java.lang.Integer>",
     "List_UUID": "java.util.Collection<java.util.UUID>",
     "List_String": "java.util.Collection<java.lang.String>",
     "List_Xid": "java.util.Collection<javax.transaction.xa.Xid>",
@@ -111,8 +114,11 @@ _java_types_decode = {
     "MemberInfo": "com.hazelcast.internal.cluster.MemberInfo",
     "MemberVersion": "com.hazelcast.version.MemberVersion",
     "MCEvent": "com.hazelcast.internal.management.dto.MCEventDTO",
+    "AnchorDataListHolder": "com.hazelcast.client.impl.protocol.codec.holder.AnchorDataListHolder",
+    "PagingPredicateHolder": "com.hazelcast.client.impl.protocol.codec.holder.PagingPredicateHolder",
 
     "List_Long": "java.util.List<java.lang.Long>",
+    "List_Integer": "java.util.List<java.lang.Integer>",
     "List_UUID": "java.util.List<java.util.UUID>",
     "List_Xid": "java.util.List<javax.transaction.xa.Xid>",
     "List_String": "java.util.List<java.lang.String>",

--- a/java/custom-codec-template.java.j2
+++ b/java/custom-codec-template.java.j2
@@ -2,7 +2,7 @@
     {% if is_var_sized_list(param.type) or is_var_sized_list_contains_nullable(param.type) -%}
         ListMultiFrameCodec.encode{% if is_var_sized_list_contains_nullable(param.type)%}ContainsNullable{% endif %}{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param_name(codec.name)}}.{% if param.type == 'boolean' %}is{% else %}get{% endif %}{{ param.name|capital }}(), {{ item_type(lang_name, param.type) }}Codec::encode)
     {%- elif is_var_sized_entry_list(param.type) -%}
-        EntryListCodec.encode{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param_name(codec.name)}}.{% if param.type == 'boolean' %}is{% else %}get{% endif %}{{ param.name|capital }}(), {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
+        EntryListCodec.encode{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param_name(codec.name)}}.{% if param.type == 'boolean' %}is{% else %}get{% endif %}{{ param.name|capital }}(), {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encodeNullable)
     {%- elif is_var_sized_map(param.type) -%}
         MapCodec.encode{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param_name(codec.name)}}.{% if param.type == 'boolean' %}is{% else %}get{% endif %}{{ param.name|capital }}(), {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
     {%- else -%}
@@ -17,7 +17,7 @@
     {%- if is_var_sized_list(param.type) or is_var_sized_list_contains_nullable(param.type) -%}
         ListMultiFrameCodec.decode{% if is_var_sized_list_contains_nullable(param.type) %}ContainsNullable{% endif %}{% if param.nullable  %}Nullable{% endif %}(iterator, {{ item_type(lang_name, param.type) }}Codec::decode)
     {%- elif is_var_sized_entry_list(param.type) -%}
-        EntryListCodec.decode{% if param.nullable  %}Nullable{% endif %}(iterator, {{ key_type(lang_name, param.type) }}Codec::decode, {{ value_type(lang_name, param.type) }}Codec::decode)
+        EntryListCodec.decode{% if param.nullable  %}Nullable{% endif %}(iterator, {{ key_type(lang_name, param.type) }}Codec::decode, {{ value_type(lang_name, param.type) }}Codec::decodeNullable)
     {%- elif is_var_sized_map(param.type) -%}
         MapCodec.decode{% if param.nullable  %}Nullable{% endif %}(iterator, {{ key_type(lang_name, param.type) }}Codec::decode, {{ value_type(lang_name, param.type) }}Codec::decode)
     {%- else -%}

--- a/protocol-definitions/Map.yaml
+++ b/protocol-definitions/Map.yaml
@@ -1999,7 +1999,7 @@ methods:
           doc: |
             name of map
         - name: predicate
-          type: Data
+          type: PagingPredicateHolder
           nullable: false
           since: 2.0
           doc: |
@@ -2012,12 +2012,12 @@ methods:
           since: 2.0
           doc: |
             result keys for the query.
-        - name: predicate
-          type: Data
+        - name: anchorDataList
+          type: AnchorDataListHolder
           nullable: false
           since: 2.0
           doc: |
-            The predicate with updated anchor list.
+            The updated anchor list.
   - id: 53
     name: valuesWithPagingPredicate
     since: 2.0
@@ -2037,7 +2037,7 @@ methods:
           doc: |
             name of map
         - name: predicate
-          type: Data
+          type: PagingPredicateHolder
           nullable: false
           since: 2.0
           doc: |
@@ -2050,12 +2050,12 @@ methods:
           since: 2.0
           doc: |
             values for the query.
-        - name: predicate
-          type: Data
+        - name: anchorDataList
+          type: AnchorDataListHolder
           nullable: false
           since: 2.0
           doc: |
-            The predicate with updated anchor list.
+            The updated anchor list.
   - id: 54
     name: entriesWithPagingPredicate
     since: 2.0
@@ -2072,7 +2072,7 @@ methods:
           doc: |
             name of map
         - name: predicate
-          type: Data
+          type: PagingPredicateHolder
           nullable: false
           since: 2.0
           doc: |
@@ -2085,12 +2085,12 @@ methods:
           since: 2.0
           doc: |
             key-value pairs for the query.
-        - name: predicate
-          type: Data
+        - name: anchorDataList
+          type: AnchorDataListHolder
           nullable: false
           since: 2.0
           doc: |
-            The predicate with updated anchor list.
+            The updated anchor list.
   - id: 55
     name: clearNearCache
     since: 2.0

--- a/protocol-definitions/Map.yaml
+++ b/protocol-definitions/Map.yaml
@@ -2012,6 +2012,12 @@ methods:
           since: 2.0
           doc: |
             result keys for the query.
+        - name: predicate
+          type: Data
+          nullable: false
+          since: 2.0
+          doc: |
+            The predicate with updated anchor list.
   - id: 53
     name: valuesWithPagingPredicate
     since: 2.0
@@ -2044,6 +2050,12 @@ methods:
           since: 2.0
           doc: |
             values for the query.
+        - name: predicate
+          type: Data
+          nullable: false
+          since: 2.0
+          doc: |
+            The predicate with updated anchor list.
   - id: 54
     name: entriesWithPagingPredicate
     since: 2.0
@@ -2073,6 +2085,12 @@ methods:
           since: 2.0
           doc: |
             key-value pairs for the query.
+        - name: predicate
+          type: Data
+          nullable: false
+          since: 2.0
+          doc: |
+            The predicate with updated anchor list.
   - id: 55
     name: clearNearCache
     since: 2.0

--- a/protocol-definitions/Map.yaml
+++ b/protocol-definitions/Map.yaml
@@ -2045,7 +2045,7 @@ methods:
     response:
       params:
         - name: response
-          type: EntryList_Data_Data
+          type: List_Data
           nullable: false
           since: 2.0
           doc: |

--- a/protocol-definitions/custom/Custom.yaml
+++ b/protocol-definitions/custom/Custom.yaml
@@ -813,3 +813,42 @@ customTypes:
         type: String
         nullable: false
         since: 2.0
+  - name: AnchorDataListHolder
+    since: 2.0
+    params:
+        - name: anchorPageList
+          type: List_Integer
+          nullable: false
+          since: 2.0
+        - name: anchorDataList
+          type: EntryList_Data_Data
+          nullable: false
+          since: 2.0
+  - name: PagingPredicateHolder
+    since: 2.0
+    params:
+        - name: anchorDataListHolder
+          type: AnchorDataListHolder
+          nullable: false
+          since: 2.0
+        - name: predicateData
+          type: Data
+          nullable: true
+          since: 2.0
+        - name: comparatorData
+          type: Data
+          nullable: true
+          since: 2.0
+        - name: pageSize
+          type: int
+          nullable: false
+          since: 2.0
+        - name: page
+          type: int
+          nullable: false
+          since: 2.0
+        - name: iterationTypeId
+          type: byte
+          nullable: false
+          since: 2.0
+

--- a/protocol-definitions/custom/Custom.yaml
+++ b/protocol-definitions/custom/Custom.yaml
@@ -851,4 +851,9 @@ customTypes:
           type: byte
           nullable: false
           since: 2.0
+        - name: partitionKeyData
+          type: Data
+          nullable: true
+          since: 2.0
+
 

--- a/schema/custom-codec-schema.json
+++ b/schema/custom-codec-schema.json
@@ -94,7 +94,9 @@
             "MergePolicyConfig",
             "MemberVersion",
             "MemberInfo",
-            "MCEvent"
+            "MCEvent",
+            "AnchorDataListHolder",
+            "PagingPredicateHolder"
           ]
         },
         "nullable": {

--- a/schema/protocol-schema.json
+++ b/schema/protocol-schema.json
@@ -94,7 +94,9 @@
             "MergePolicyConfig",
             "MemberVersion",
             "MemberInfo",
-            "MCEvent"
+            "MCEvent",
+            "AnchorDataListHolder",
+            "PagingPredicateHolder"
           ]
         },
         "nullable": {


### PR DESCRIPTION
Encoded the PagingPredicate into client protocol instead of using `Data` type.

Added the paging predicate to the paging predicate query responses so that the client can update its local anchor entry list.

Hazelcast PR: https://github.com/hazelcast/hazelcast/pull/16188