### PR TITLE
Add missing docs

### DIFF
--- a/java/codec-template.java.j2
+++ b/java/codec-template.java.j2
@@ -259,6 +259,19 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
             Logger.getLogger(super.getClass()).finest("Unknown message type received on event handler :" + messageType);
         }
     {% for event in method.events%}
+
+        /**
+        {% for param in event.params %}
+         * @param {{ param.name }}
+        {%- for line in param.doc.splitlines() %}
+        {% if loop.first -%}
+        {{ " %s"|format(line) }}
+        {% else %}
+         * {{ line|indent(8 + param.name|length, True) }}
+        {% endif %}
+        {% endfor %}
+        {% endfor %}
+        */
         public abstract void handle{{ event.name|capital }}Event({% for param in event.params %}{% if param.nullable  %}@Nullable {% endif %}{{ lang_types_encode(param.type) }} {{param.name}}{% if not loop.last %}, {% endif %}{% endfor %});
     {% endfor %}
     }

--- a/protocol-definitions/AtomicLong.yaml
+++ b/protocol-definitions/AtomicLong.yaml
@@ -77,7 +77,7 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            The old or the new value depending on the returnValueType parameter.
   - id: 3
     name: addAndGet
     since: 2.0

--- a/protocol-definitions/CPSession.yaml
+++ b/protocol-definitions/CPSession.yaml
@@ -29,19 +29,19 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Id of the session.
         - name: ttlMillis
           type: long
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Time to live value in milliseconds that must be respected by the caller.
         - name: heartbeatMillis
           type: long
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Time between heartbeats in milliseconds that must be respected by the caller.
   - id: 2
     name: closeSession
     since: 2.0

--- a/protocol-definitions/Cache.yaml
+++ b/protocol-definitions/Cache.yaml
@@ -5,8 +5,8 @@ methods:
     name: addEntryListener
     since: 2.0
     doc: |
-      Adds an entry listener for this cache. The listener will be notified
-      for all cache created/removed/updated/expired events.
+      Adds an entry listener for this cache. For the types of events that the listener
+      will be notified for, see the documentation of the type field of the Cache event below.
     request:
       retryable: false
       partitionIdentifier: -1
@@ -709,7 +709,8 @@ methods:
     name: removeEntryListener
     since: 2.0
     doc: |
-      Removes the specified entry listener. Returns silently if there is no such listener added before.
+      Removes the specified entry listener. If there is no such listener added before, this call does no change in the
+      cluster and returns false.
     request:
       retryable: true
       partitionIdentifier: -1
@@ -738,7 +739,8 @@ methods:
     name: removeInvalidationListener
     since: 2.0
     doc: |
-      Removes the specified invalidation listener. Returns silently if there is no such listener added before.
+      Removes the specified invalidation listener. If there is no such listener added before, this call does no change
+      in the cluster and returns false.
     request:
       retryable: true
       partitionIdentifier: -1
@@ -938,7 +940,8 @@ methods:
     name: removePartitionLostListener
     since: 2.0
     doc: |
-      Removes the specified cache partition lost listener. Returns silently if there is no such listener added before
+      Removes the specified cache partition lost listener. If there is no such listener added before, this call does no
+      change in the cluster and returns false.
     request:
       retryable: true
       partitionIdentifier: -1

--- a/protocol-definitions/Cache.yaml
+++ b/protocol-definitions/Cache.yaml
@@ -5,7 +5,8 @@ methods:
     name: addEntryListener
     since: 2.0
     doc: |
-      TODO DOC
+      Adds an entry listener for this cache. The listener will be notified
+      for all cache created/removed/updated/expired events.
     request:
       retryable: false
       partitionIdentifier: -1
@@ -21,7 +22,7 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            if true fires events that originated from this node only, otherwise fires all events
+            If true fires events that originated from this node only, otherwise fires all events
     response:
       params:
         - name: response
@@ -38,19 +39,29 @@ methods:
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              The type of the event. Possible values for the event are:
+              CREATED(1): An event type indicating that the cache entry was created.
+              UPDATED(2): An event type indicating that the cache entry was updated, i.e. a previous mapping existed.
+              REMOVED(3): An event type indicating that the cache entry was removed.
+              EXPIRED(4): An event type indicating that the cache entry has expired.
+              EVICTED(5): An event type indicating that the cache entry has evicted.
+              INVALIDATED(6): An event type indicating that the cache entry has invalidated for near cache invalidation.
+              COMPLETED(7): An event type indicating that the cache operation has completed.
+              EXPIRATION_TIME_UPDATED(8): An event type indicating that the expiration time of cache record has been updated
+              PARTITION_LOST(9): An event type indicating that partition loss is detected in given cache with name
           - name: keys
             type: List_CacheEventData
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              The keys for the entries in the cache.
           - name: completionId
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              User generated id which shall be received as a field of the cache event upon completion of the
+              request in the cluster.
   - id: 2
     name: clear
     since: 2.0
@@ -158,7 +169,7 @@ methods:
     name: createConfig
     since: 2.0
     doc: |
-      TODO DOC
+      Creates the given cache configuration on Hazelcast members.
     request:
       retryable: true
       partitionIdentifier: name
@@ -203,7 +214,8 @@ methods:
     name: entryProcessor
     since: 2.0
     doc: |
-      TODO DOC
+      Applies the user defined EntryProcessor to entry mapped by the key.
+      Returns the result of the processing, if any, defined by the implementation.
     request:
       retryable: false
       partitionIdentifier: key
@@ -380,7 +392,7 @@ methods:
     name: getConfig
     since: 2.0
     doc: |
-      TODO DOC
+      Gets the cache configuration with the given name from members.
     request:
       retryable: true
       partitionIdentifier: name
@@ -486,12 +498,13 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            The keys fetched from the cache.
   - id: 15
     name: listenerRegistration
     since: 2.0
     doc: |
-      TODO DOC
+      Tries to register the listener configuration for the cache specified by its name
+      to the given member.
     request:
       retryable: false
       partitionIdentifier: -1
@@ -526,7 +539,7 @@ methods:
     name: loadAll
     since: 2.0
     doc: |
-      TODO DOC
+      Loads all the keys into the CacheRecordStore in batch.
     request:
       retryable: false
       partitionIdentifier: -1
@@ -555,7 +568,8 @@ methods:
     name: managementConfig
     since: 2.0
     doc: |
-      TODO DOC
+      Enables or disables the statistics or the management support for the
+      cache with the given name on a member with the given address.
     request:
       retryable: true
       partitionIdentifier: -1
@@ -640,7 +654,7 @@ methods:
     name: put
     since: 2.0
     doc: |
-      TODO DOC
+      Puts the entry with the given key, value and the expiry policy to the cache.
     request:
       retryable: false
       partitionIdentifier: key
@@ -695,7 +709,7 @@ methods:
     name: removeEntryListener
     since: 2.0
     doc: |
-      TODO DOC
+      Removes the specified entry listener. Returns silently if there is no such listener added before.
     request:
       retryable: true
       partitionIdentifier: -1
@@ -724,7 +738,7 @@ methods:
     name: removeInvalidationListener
     since: 2.0
     doc: |
-      TODO DOC
+      Removes the specified invalidation listener. Returns silently if there is no such listener added before.
     request:
       retryable: true
       partitionIdentifier: -1
@@ -913,13 +927,13 @@ methods:
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Id of the lost partition.
           - name: uuid
             type: UUID
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              UUID of the member that owns the lost partition.
   - id: 26
     name: removePartitionLostListener
     since: 2.0
@@ -953,7 +967,7 @@ methods:
     name: putAll
     since: 2.0
     doc: |
-      TODO DOC
+      Copies all the mappings from the specified map to this cache with the given expiry policy.
     request:
       retryable: false
       partitionIdentifier: -1
@@ -1025,7 +1039,7 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            The entries fetched from the cache.
   - id: 29
     name: addNearCacheInvalidationListener
     since: 2.0
@@ -1069,25 +1083,25 @@ methods:
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              The key of the invalidated entry.
           - name: sourceUuid
             type: UUID
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              UUID of the member who fired this event.
           - name: partitionUuid
             type: UUID
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              UUID of the source partition that invalidation event belongs to.
           - name: sequence
             type: long
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Sequence number of the invalidation event.
       - name: CacheBatchInvalidation
         params:
           - name: name
@@ -1101,25 +1115,25 @@ methods:
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              List of the keys of the invalidated entries.
           - name: sourceUuids
             type: List_UUID
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              List of UUIDs of the members who fired these events.
           - name: partitionUuids
             type: List_UUID
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              List of UUIDs of the source partitions that invalidation events belong to.
           - name: sequences
             type: List_Long
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              List of sequence numbers of the invalidation events.
   - id: 30
     name: fetchNearCacheInvalidationMetadata
     since: 2.0
@@ -1140,7 +1154,7 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Address of the member.
     response:
       params:
         - name: namePartitionSequenceList
@@ -1148,30 +1162,14 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Map of partition ids and sequence number of invalidations mapped by the cache name.
         - name: partitionUuidList
           type: EntryList_Integer_UUID
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Map of member UUIDs mapped by the partition ids of invalidations.
   - id: 31
-    name: assignAndGetUuids
-    since: 2.0
-    doc: |
-      TODO DOC
-    request:
-      retryable: true
-      partitionIdentifier: -1
-    response:
-      params:
-        - name: partitionUuidList
-          type: EntryList_Integer_UUID
-          nullable: false
-          since: 2.0
-          doc: |
-            partitionId to assigned uuid entry list
-  - id: 32
     name: eventJournalSubscribe
     since: 2.0
     doc: |
@@ -1195,14 +1193,14 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Sequence id of the oldest event on in the event journal.
         - name: newestSequence
           type: long
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
-  - id: 33
+            Sequence id of the newest event on in the event journal.
+  - id: 32
     name: eventJournalRead
     since: 2.0
     doc: |
@@ -1261,26 +1259,26 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Number of items read.
         - name: items
           type: List_Data
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            List of read items.
         - name: itemSeqs
           type: longArray
           nullable: true
           since: 2.0
           doc: |
-            TODO DOC
+            Sequence numbers of items in the event journal.
         - name: nextSeq
           type: long
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
-  - id: 34
+            Next id of the sequence to read from in the future operations.
+  - id: 33
     name: setExpiryPolicy
     since: 2.0
     doc: |

--- a/protocol-definitions/Cache.yaml
+++ b/protocol-definitions/Cache.yaml
@@ -54,7 +54,7 @@ methods:
             nullable: false
             since: 2.0
             doc: |
-              The keys for the entries in the cache.
+              The keys of the entries in the cache.
           - name: completionId
             type: int
             nullable: false
@@ -1095,7 +1095,7 @@ methods:
             nullable: false
             since: 2.0
             doc: |
-              UUID of the source partition that invalidation event belongs to.
+              UUID of the source partition that invalidated entry belongs to.
           - name: sequence
             type: long
             nullable: false
@@ -1127,7 +1127,7 @@ methods:
             nullable: false
             since: 2.0
             doc: |
-              List of UUIDs of the source partitions that invalidation events belong to.
+              List of UUIDs of the source partitions that invalidated entries belong to.
           - name: sequences
             type: List_Long
             nullable: false
@@ -1193,13 +1193,13 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            Sequence id of the oldest event on in the event journal.
+            Sequence id of the oldest event in the event journal.
         - name: newestSequence
           type: long
           nullable: false
           since: 2.0
           doc: |
-            Sequence id of the newest event on in the event journal.
+            Sequence id of the newest event in the event journal.
   - id: 32
     name: eventJournalRead
     since: 2.0
@@ -1259,13 +1259,13 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            Number of items read.
+            Number of items that have been read.
         - name: items
           type: List_Data
           nullable: false
           since: 2.0
           doc: |
-            List of read items.
+            List of items that have been read.
         - name: itemSeqs
           type: longArray
           nullable: true
@@ -1277,7 +1277,7 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            Next id of the sequence to read from in the future operations.
+            Sequence number of the item following the last read item.
   - id: 33
     name: setExpiryPolicy
     since: 2.0

--- a/protocol-definitions/Client.yaml
+++ b/protocol-definitions/Client.yaml
@@ -5,7 +5,7 @@ methods:
     name: authentication
     since: 2.0
     doc: |
-      TODO DOC
+      Makes an authentication request to the cluster.
     request:
       retryable: true
       partitionIdentifier: -1
@@ -73,13 +73,14 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            A byte that represents the authentication status. It can be AUTHENTICATED(0), CREDENTIALS_FAILED(1),
+            SERIALIZATION_VERSION_MISMATCH(2) or NOT_ALLOWED_IN_CLUSTER(3).
         - name: address
           type: Address
           nullable: true
           since: 2.0
           doc: |
-            TODO DOC
+            Address of the Hazelcast member which sends the authentication response.
         - name: uuid
           type: UUID
           nullable: true
@@ -97,7 +98,7 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Version of the Hazelcast member which sends the authentication response.
         - name: partitionCount
           type: int
           nullable: false
@@ -120,7 +121,7 @@ methods:
     name: authenticationCustom
     since: 2.0
     doc: |
-      TODO DOC
+      Makes an authentication request to the cluster using custom credentials.
     request:
       retryable: true
       partitionIdentifier: -1
@@ -180,13 +181,14 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            A byte that represents the authentication status. It can be AUTHENTICATED(0), CREDENTIALS_FAILED(1),
+            SERIALIZATION_VERSION_MISMATCH(2) or NOT_ALLOWED_IN_CLUSTER(3).
         - name: address
           type: Address
           nullable: true
           since: 2.0
           doc: |
-            TODO DOC
+            Address of the Hazelcast member which sends the authentication response.
         - name: uuid
           type: UUID
           nullable: true
@@ -204,7 +206,7 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Version of the Hazelcast member which sends the authentication response.
         - name: partitionCount
           type: int
           nullable: false
@@ -227,7 +229,7 @@ methods:
     name: addClusterViewListener
     since: 2.0
     doc: |
-      TODO DOC
+      Adds a cluster view listener to one of the active connections.
     request:
       retryable: false
       partitionIdentifier: -1
@@ -266,7 +268,7 @@ methods:
     name: createProxy
     since: 2.0
     doc: |
-      TODO DOC
+      Creates a cluster-wide proxy with the given name and service.
     request:
       retryable: false
       partitionIdentifier: -1
@@ -303,7 +305,7 @@ methods:
     name: destroyProxy
     since: 2.0
     doc: |
-      TODO DOC
+      Destroys the proxy given by its name cluster-wide. Also, clears and releases all resources of this proxy.
     request:
       retryable: false
       partitionIdentifier: -1
@@ -337,19 +339,10 @@ methods:
             "hz:impl:xaService"
     response: {}
   - id: 6
-    name: removeAllListeners
-    since: 2.0
-    doc: |
-      TODO DOC
-    request:
-      retryable: false
-      partitionIdentifier: -1
-    response: {}
-  - id: 7
     name: addPartitionLostListener
     since: 2.0
     doc: |
-      TODO DOC
+      Adds a partition lost listener to the cluster.
     request:
       retryable: false
       partitionIdentifier: -1
@@ -377,24 +370,24 @@ methods:
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Id of the lost partition.
           - name: lostBackupCount
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              The number of lost backups for the partition. 0: the owner, 1: first backup, 2: second backup...
           - name: source
             type: Address
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
-  - id: 8
+              Address of the node that dispatches the event
+  - id: 7
     name: removePartitionLostListener
     since: 2.0
     doc: |
-      TODO DOC
+      Removes the specified partition lost listener. Returns silently if there is no such listener added before.
     request:
       retryable: true
       partitionIdentifier: -1
@@ -413,11 +406,11 @@ methods:
           since: 2.0
           doc: |
             true if the listener existed and removed, false otherwise.
-  - id: 9
+  - id: 8
     name: getDistributedObjects
     since: 2.0
     doc: |
-      TODO DOC
+      Gets the list of distributed objects in the cluster.
     request:
       retryable: false
       partitionIdentifier: -1
@@ -429,11 +422,12 @@ methods:
           since: 2.0
           doc: |
             An array of distributed object info in the cluster.
-  - id: 10
+  - id: 9
     name: addDistributedObjectListener
     since: 2.0
     doc: |
-      TODO DOC
+      Adds a distributed object listener to the cluster. This listener will be notified
+      when a distributed object is created or destroyed.
     request:
       retryable: false
       partitionIdentifier: -1
@@ -467,30 +461,30 @@ methods:
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Name of the distributed object.
           - name: serviceName
             type: String
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Service name of the distributed object.
           - name: eventType
             type: String
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Type of the event. It is either CREATED or DESTROYED.
           - name: source
             type: UUID
             nullable: false
             since: 2.0
             doc: |
               The UUID (client or member) of the source of this proxy event.
-  - id: 11
+  - id: 10
     name: removeDistributedObjectListener
     since: 2.0
     doc: |
-      TODO DOC
+      Removes the specified distributed object listener. Returns silently if there is no such listener added before.
     request:
       retryable: true
       partitionIdentifier: -1
@@ -509,16 +503,16 @@ methods:
           since: 2.0
           doc: |
             true if the listener existed and removed, false otherwise.
-  - id: 12
+  - id: 11
     name: ping
     since: 2.0
     doc: |
-      TODO DOC
+      Sends a ping to the given connection.
     request:
       retryable: true
       partitionIdentifier: -1
     response: {}
-  - id: 13
+  - id: 12
     name: statistics
     since: 2.0
     doc: |
@@ -703,7 +697,7 @@ methods:
           doc: |
             Compressed byte array containing all metrics collected by the client.
     response: {}
-  - id: 14
+  - id: 13
     name: deployClasses
     since: 2.0
     doc: |
@@ -721,7 +715,7 @@ methods:
           doc: |
             list of class definitions
     response: {}
-  - id: 15
+  - id: 14
     name: createProxies
     since: 2.0
     doc: |
@@ -744,7 +738,7 @@ methods:
             Each entry's value is service name.
             For possible service names see createProxy message.
     response: {}
-  - id: 16
+  - id: 15
     name: localBackupListener
     since: 2.0
     doc: |
@@ -769,7 +763,7 @@ methods:
             since: 2.0
             doc: |
               correlation id of the invocation that backup acks belong to
-  - id: 17
+  - id: 16
     name: triggerPartitionAssignment
     since: 2.0
     doc: |

--- a/protocol-definitions/Client.yaml
+++ b/protocol-definitions/Client.yaml
@@ -387,7 +387,8 @@ methods:
     name: removePartitionLostListener
     since: 2.0
     doc: |
-      Removes the specified partition lost listener. Returns silently if there is no such listener added before.
+      Removes the specified partition lost listener. If there is no such listener added before, this call does no change
+      in the cluster and returns false.
     request:
       retryable: true
       partitionIdentifier: -1
@@ -484,7 +485,8 @@ methods:
     name: removeDistributedObjectListener
     since: 2.0
     doc: |
-      Removes the specified distributed object listener. Returns silently if there is no such listener added before.
+      Removes the specified distributed object listener. If there is no such listener added before, this call does no
+      change in the cluster and returns false.
     request:
       retryable: true
       partitionIdentifier: -1

--- a/protocol-definitions/Client.yaml
+++ b/protocol-definitions/Client.yaml
@@ -229,7 +229,7 @@ methods:
     name: addClusterViewListener
     since: 2.0
     doc: |
-      Adds a cluster view listener to one of the active connections.
+      Adds a cluster view listener to a connection.
     request:
       retryable: false
       partitionIdentifier: -1

--- a/protocol-definitions/ContinuousQuery.yaml
+++ b/protocol-definitions/ContinuousQuery.yaml
@@ -5,7 +5,7 @@ methods:
     name: publisherCreateWithValue
     since: 2.0
     doc: |
-      TODO DOC
+      Creates a publisher that includes value for the cache events it sends.
     request:
       retryable: true
       partitionIdentifier: -1
@@ -71,7 +71,7 @@ methods:
     name: publisherCreate
     since: 2.0
     doc: |
-      TODO DOC
+      Creates a publisher that does not include value for the cache events it sends.
     request:
       retryable: true
       partitionIdentifier: -1
@@ -137,7 +137,7 @@ methods:
     name: madePublishable
     since: 2.0
     doc: |
-      TODO DOC
+      Makes the query cache with the given name for a specific map publishable.
     request:
       retryable: true
       partitionIdentifier: -1
@@ -166,7 +166,7 @@ methods:
     name: addListener
     since: 2.0
     doc: |
-      TODO DOC
+      Adds a listener to be notified for the events fired on the underlying map on all nodes.
     request:
       retryable: false
       partitionIdentifier: -1
@@ -199,7 +199,7 @@ methods:
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Data that holds the details of the event such as key, value, old value, new value and creation time.
       - name: QueryCacheBatch
         params:
           - name: events
@@ -207,19 +207,20 @@ methods:
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              List of events in the form of data that holds the details of the event such as key, value, old value,
+              new value and creation time.
           - name: source
             type: String
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Source that dispathces this batch event.
           - name: partitionId
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Id of the partition that holds the keys of the batch event.
   - id: 5
     name: setReadCursor
     since: 2.0
@@ -264,7 +265,7 @@ methods:
     name: destroyCache
     since: 2.0
     doc: |
-      TODO DOC
+      Destroys the query cache with the given name for a specific map.
     request:
       retryable: false
       partitionIdentifier: -1

--- a/protocol-definitions/DynamicConfig.yaml
+++ b/protocol-definitions/DynamicConfig.yaml
@@ -68,16 +68,14 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            Name of a class implementing {@link com.hazelcast.spi.merge.SplitBrainMergePolicy}
-            that handles merging of values for this cache while recovering from
-            network partitioning
+            Name of a class implementing SplitBrainMergePolicy that handles merging of values for this cache
+            while recovering from network partitioning.
         - name: mergeBatchSize
           type: int
           nullable: false
           since: 2.0
           doc: |
             Number of entries to be sent in a merge operation.
-
     response: {}
   - id: 2
     name: addRingbufferConfig
@@ -146,9 +144,8 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            Name of a class implementing {@link com.hazelcast.spi.merge.SplitBrainMergePolicy}
-            that handles merging of values for this cache while recovering from
-            network partitioning
+            Name of a class implementing SplitBrainMergePolicy that handles merging of values for this cache
+            while recovering from network partitioning.
         - name: mergeBatchSize
           type: int
           nullable: false
@@ -198,9 +195,8 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            Name of a class implementing {@link com.hazelcast.spi.merge.SplitBrainMergePolicy}
-            that handles merging of values for this cache while recovering from
-            network partitioning
+            Name of a class implementing SplitBrainMergePolicy that handles merging of values for this cache
+            while recovering from network partitioning.
         - name: mergeBatchSize
           type: int
           nullable: false
@@ -268,9 +264,8 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            Name of a class implementing {@link com.hazelcast.spi.merge.SplitBrainMergePolicy}
-            that handles merging of values for this cache while recovering from
-            network partitioning
+            Name of a class implementing SplitBrainMergePolicy that handles merging of values for this cache
+            while recovering from network partitioning.
         - name: mergeBatchSize
           type: int
           nullable: false
@@ -338,9 +333,8 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            Name of a class implementing {@link com.hazelcast.spi.merge.SplitBrainMergePolicy}
-            that handles merging of values for this cache while recovering from
-            network partitioning
+            Name of a class implementing SplitBrainMergePolicy that handles merging of values for this cache
+            while recovering from network partitioning.
         - name: mergeBatchSize
           type: int
           nullable: false
@@ -391,7 +385,7 @@ methods:
           since: 2.0
           doc: |
             class name of a class implementing
-            {@link com.hazelcast.spi.merge.SplitBrainMergePolicy} to merge entries
+            SplitBrainMergePolicy to merge entries
             while recovering from a split brain
         - name: listenerConfigs
           type: List_ListenerConfigHolder
@@ -594,9 +588,8 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            Name of a class implementing {@link com.hazelcast.spi.merge.SplitBrainMergePolicy}
-            that handles merging of values for this cache while recovering from
-            network partitioning
+            Name of a class implementing SplitBrainMergePolicy that handles merging of values for this cache
+            while recovering from network partitioning.
         - name: mergeBatchSize
           type: int
           nullable: false
@@ -751,15 +744,14 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            Class name of a class implementing
-            {@link com.hazelcast.spi.merge.SplitBrainMergePolicy} to merge entries
-            while recovering from a split brain
+            Name of a class implementing SplitBrainMergePolicy that handles merging of values for this cache
+            while recovering from network partitioning.
         - name: mergeBatchSize
           type: int
           nullable: false
           since: 2.0
           doc: |
-            number of entries to be sent in a merge operation
+            Number of entries to be sent in a merge operation
         - name: inMemoryFormat
           type: String
           nullable: false
@@ -1027,7 +1019,7 @@ methods:
           nullable: true
           since: 2.0
           doc: |
-            name of a class implementing {@link com.hazelcast.spi.merge.SplitBrainMergePolicy}
+            name of a class implementing SplitBrainMergePolicy
             that handles merging of values for this cache while recovering from
             network partitioning
         - name: mergeBatchSize

--- a/protocol-definitions/DynamicConfig.yaml
+++ b/protocol-definitions/DynamicConfig.yaml
@@ -68,13 +68,16 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Name of a class implementing {@link com.hazelcast.spi.merge.SplitBrainMergePolicy}
+            that handles merging of values for this cache while recovering from
+            network partitioning
         - name: mergeBatchSize
           type: int
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Number of entries to be sent in a merge operation.
+
     response: {}
   - id: 2
     name: addRingbufferConfig
@@ -143,13 +146,15 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Name of a class implementing {@link com.hazelcast.spi.merge.SplitBrainMergePolicy}
+            that handles merging of values for this cache while recovering from
+            network partitioning
         - name: mergeBatchSize
           type: int
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Number of entries to be sent in a merge operation.
     response: {}
   - id: 3
     name: addCardinalityEstimatorConfig
@@ -193,13 +198,15 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Name of a class implementing {@link com.hazelcast.spi.merge.SplitBrainMergePolicy}
+            that handles merging of values for this cache while recovering from
+            network partitioning
         - name: mergeBatchSize
           type: int
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Number of entries to be sent in a merge operation.
     response: {}
   - id: 4
     name: addListConfig
@@ -261,13 +268,15 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Name of a class implementing {@link com.hazelcast.spi.merge.SplitBrainMergePolicy}
+            that handles merging of values for this cache while recovering from
+            network partitioning
         - name: mergeBatchSize
           type: int
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Number of entries to be sent in a merge operation.
     response: {}
   - id: 5
     name: addSetConfig
@@ -329,13 +338,15 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Name of a class implementing {@link com.hazelcast.spi.merge.SplitBrainMergePolicy}
+            that handles merging of values for this cache while recovering from
+            network partitioning
         - name: mergeBatchSize
           type: int
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Number of entries to be sent in a merge operation.
     response: {}
   - id: 6
     name: addReplicatedMapConfig
@@ -401,7 +412,7 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Number of entries to be sent in a merge operation.
     response: {}
   - id: 7
     name: addTopicConfig
@@ -583,13 +594,15 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Name of a class implementing {@link com.hazelcast.spi.merge.SplitBrainMergePolicy}
+            that handles merging of values for this cache while recovering from
+            network partitioning
         - name: mergeBatchSize
           type: int
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Number of entries to be sent in a merge operation.
     response: {}
   - id: 11
     name: addQueueConfig
@@ -663,13 +676,13 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Classname of the merge policy.
         - name: mergeBatchSize
           type: int
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Number of entries to be sent in a merge operation.
     response: {}
   - id: 12
     name: addMapConfig
@@ -738,7 +751,7 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            class name of a class implementing
+            Class name of a class implementing
             {@link com.hazelcast.spi.merge.SplitBrainMergePolicy} to merge entries
             while recovering from a split brain
         - name: mergeBatchSize
@@ -1120,7 +1133,7 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Offset that will be added to the node id assigned to the cluster members for this generator.
         - name: epochStart
           type: long
           nullable: false
@@ -1144,7 +1157,7 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            how far to the future is it allowed to go to generate IDs 
+            how far to the future is it allowed to go to generate IDs
     response: {}
   - id: 16
     name: addPNCounterConfig

--- a/protocol-definitions/ExecutorService.yaml
+++ b/protocol-definitions/ExecutorService.yaml
@@ -45,7 +45,7 @@ methods:
     name: cancelOnPartition
     since: 2.0
     doc: |
-      TODO DOC
+      Cancels the task running on the member that owns the partition with the given id.
     request:
       retryable: false
       partitionIdentifier: partitionId
@@ -74,7 +74,7 @@ methods:
     name: cancelOnAddress
     since: 2.0
     doc: |
-      TODO DOC
+      Cancels the task running on the member with the given address.
     request:
       retryable: false
       partitionIdentifier: -1
@@ -109,7 +109,7 @@ methods:
     name: submitToPartition
     since: 2.0
     doc: |
-      TODO DOC
+      Submits the task to the member that owns the partition with the given id.
     request:
       retryable: false
       partitionIdentifier: partitionId
@@ -144,7 +144,7 @@ methods:
     name: submitToAddress
     since: 2.0
     doc: |
-      TODO DOC
+      Submits the task to member specified by the address.
     request:
       retryable: false
       partitionIdentifier: -1

--- a/protocol-definitions/FencedLock.yaml
+++ b/protocol-definitions/FencedLock.yaml
@@ -196,22 +196,22 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Fence token of the lock
         - name: lockCount
           type: int
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Reenterant lock count
         - name: sessionId
           type: long
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Id of the session that holds the lock
         - name: threadId
           type: long
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Id of the thread that holds the lock

--- a/protocol-definitions/FlakeIdGenerator.yaml
+++ b/protocol-definitions/FlakeIdGenerator.yaml
@@ -5,7 +5,7 @@ methods:
     name: newIdBatch
     since: 2.0
     doc: |
-      TODO DOC
+      Fetches a new batch of ids for the given flake id generator.
     request:
       retryable: true
       partitionIdentifier: -1
@@ -15,13 +15,13 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Name of the flake id generator.
         - name: batchSize
           type: int
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Number of ids that will be fetched on one call.
     response:
       params:
         - name: base
@@ -29,16 +29,16 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            First id in the batch.
         - name: increment
           type: long
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Increment for the next id in the batch.
         - name: batchSize
           type: int
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Number of ids in the batch.

--- a/protocol-definitions/List.yaml
+++ b/protocol-definitions/List.yaml
@@ -320,19 +320,19 @@ methods:
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Item that the event is fired for.
           - name: uuid
             type: UUID
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              UUID of the member that dispatches this event.
           - name: eventType
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Type of the event. It is either ADDED(1) or REMOVED(2).
   - id: 12
     name: removeListener
     since: 2.0

--- a/protocol-definitions/List.yaml
+++ b/protocol-definitions/List.yaml
@@ -337,7 +337,8 @@ methods:
     name: removeListener
     since: 2.0
     doc: |
-      Removes the specified item listener. Returns silently if the specified listener was not added before.
+      Removes the specified item listener. If there is no such listener added before, this call does no change in the
+      cluster and returns false.
     request:
       retryable: true
       partitionIdentifier: name

--- a/protocol-definitions/Map.yaml
+++ b/protocol-definitions/Map.yaml
@@ -881,43 +881,53 @@ methods:
             nullable: true
             since: 2.0
             doc: |
-              Key for the map entry.
+              Key of the entry event.
           - name: value
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Value of the entry event.
           - name: oldValue
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Old value of the entry event.
           - name: mergingValue
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Incoming merging value of the entry event.
           - name: eventType
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Type of the entry event. Possible values are
+              ADDED(1)
+              REMOVED(2)
+              UPDATED(4)
+              EVICTED(8)
+              EXPIRED(16)
+              EVICT_ALL(32)
+              CLEAR_ALL(64)
+              MERGED(128)
+              INVALIDATION(256)
+              LOADED(512)
           - name: uuid
             type: UUID
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              UUID of the member that dispatches the event.
           - name: numberOfAffectedEntries
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Number of entries affected by this event.
   - id: 23
     name: addEntryListenerWithPredicate
     since: 2.0
@@ -975,43 +985,53 @@ methods:
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Key of the entry event.
           - name: value
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Value of the entry event.
           - name: oldValue
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Old value of the entry event.
           - name: mergingValue
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Incoming merging value of the entry event.
           - name: eventType
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Type of the entry event. Possible values are
+              ADDED(1)
+              REMOVED(2)
+              UPDATED(4)
+              EVICTED(8)
+              EXPIRED(16)
+              EVICT_ALL(32)
+              CLEAR_ALL(64)
+              MERGED(128)
+              INVALIDATION(256)
+              LOADED(512)
           - name: uuid
             type: UUID
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              UUID of the member that dispatches the event.
           - name: numberOfAffectedEntries
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Number of entries affected by this event.
   - id: 24
     name: addEntryListenerToKey
     since: 2.0
@@ -1068,43 +1088,53 @@ methods:
             nullable: true
             since: 2.0
             doc: |
-              Key for the map entry.
+              Key of the entry event.
           - name: value
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Value of the entry event.
           - name: oldValue
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Old value of the entry event.
           - name: mergingValue
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Incoming merging value of the entry event.
           - name: eventType
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Type of the entry event. Possible values are
+              ADDED(1)
+              REMOVED(2)
+              UPDATED(4)
+              EVICTED(8)
+              EXPIRED(16)
+              EVICT_ALL(32)
+              CLEAR_ALL(64)
+              MERGED(128)
+              INVALIDATION(256)
+              LOADED(512)
           - name: uuid
             type: UUID
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              UUID of the member that dispatches the event.
           - name: numberOfAffectedEntries
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Number of entries affected by this event.
   - id: 25
     name: addEntryListener
     since: 2.0
@@ -1155,43 +1185,53 @@ methods:
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Key of the entry event.
           - name: value
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Value of the entry event.
           - name: oldValue
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Old value of the entry event.
           - name: mergingValue
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Incoming merging value of the entry event.
           - name: eventType
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Type of the entry event. Possible values are
+              ADDED(1)
+              REMOVED(2)
+              UPDATED(4)
+              EVICTED(8)
+              EXPIRED(16)
+              EVICT_ALL(32)
+              CLEAR_ALL(64)
+              MERGED(128)
+              INVALIDATION(256)
+              LOADED(512)
           - name: uuid
             type: UUID
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              UUID of the member that dispatches the event.
           - name: numberOfAffectedEntries
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Number of entries affected by this event.
   - id: 26
     name: removeEntryListener
     since: 2.0
@@ -1263,13 +1303,13 @@ methods:
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Id of the lost partition.
           - name: uuid
             type: UUID
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              UUID of the member that owns the lost partition.
   - id: 28
     name: removePartitionLostListener
     since: 2.0
@@ -1335,13 +1375,13 @@ methods:
           nullable: true
           since: 2.0
           doc: |
-            TODO DOC
+            Entry view for the specified key.
         - name: maxIdle
           type: long
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Last set max idle in millis.
   - id: 30
     name: evict
     since: 2.0
@@ -1801,7 +1841,7 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Id of the thread that the task is submitted from.
     response:
       params:
         - name: response
@@ -1844,7 +1884,7 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Id of the thread that the task is submitted from.
     response:
       params:
         - name: response
@@ -1987,7 +2027,10 @@ methods:
     name: keySetWithPagingPredicate
     since: 2.0
     doc: |
-      TODO DOC
+      Queries the map based on the specified predicate and returns the keys of matching entries. Specified predicate
+      runs on all members in parallel. The collection is NOT backed by the map, so changes to the map are NOT reflected
+      in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw a
+      QueryResultSizeExceededException if query result size limit is configured.
     request:
       retryable: true
       partitionIdentifier: -1
@@ -2060,7 +2103,10 @@ methods:
     name: entriesWithPagingPredicate
     since: 2.0
     doc: |
-      TODO DOC
+      Queries the map based on the specified predicate and returns the matching entries. Specified predicate
+      runs on all members in parallel. The collection is NOT backed by the map, so changes to the map are NOT reflected
+      in the collection, and vice-versa. This method is always executed by a distributed query, so it may throw a
+      QueryResultSizeExceededException if query result size limit is configured.
     request:
       retryable: true
       partitionIdentifier: -1
@@ -2092,28 +2138,6 @@ methods:
           doc: |
             The updated anchor list.
   - id: 55
-    name: clearNearCache
-    since: 2.0
-    doc: |
-      TODO DOC
-    request:
-      retryable: false
-      partitionIdentifier: -1
-      params:
-        - name: name
-          type: String
-          nullable: false
-          since: 2.0
-          doc: |
-            TODO DOC
-        - name: target
-          type: Address
-          nullable: false
-          since: 2.0
-          doc: |
-            TODO DOC
-    response: {}
-  - id: 56
     name: fetchKeys
     since: 2.0
     doc: |
@@ -2153,8 +2177,8 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
-  - id: 57
+            List of keys.
+  - id: 56
     name: fetchEntries
     since: 2.0
     doc: |
@@ -2194,8 +2218,8 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
-  - id: 58
+            List of entries.
+  - id: 57
     name: aggregate
     since: 2.0
     doc: |
@@ -2224,7 +2248,7 @@ methods:
           since: 2.0
           doc: |
             the aggregation result
-  - id: 59
+  - id: 58
     name: aggregateWithPredicate
     since: 2.0
     doc: |
@@ -2259,7 +2283,7 @@ methods:
           since: 2.0
           doc: |
             the aggregation result
-  - id: 60
+  - id: 59
     name: project
     since: 2.0
     doc: |
@@ -2288,7 +2312,7 @@ methods:
           since: 2.0
           doc: |
             the resulted collection upon transformation to the type of the projection
-  - id: 61
+  - id: 60
     name: projectWithPredicate
     since: 2.0
     doc: |
@@ -2323,7 +2347,7 @@ methods:
           since: 2.0
           doc: |
             the resulted collection upon transformation to the type of the projection
-  - id: 62
+  - id: 61
     name: fetchNearCacheInvalidationMetadata
     since: 2.0
     doc: |
@@ -2343,7 +2367,7 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Address of the member.
     response:
       params:
         - name: namePartitionSequenceList
@@ -2351,30 +2375,14 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Map of partition ids and sequence number of invalidations mapped by the map name.
         - name: partitionUuidList
           type: EntryList_Integer_UUID
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
-  - id: 63
-    name: assignAndGetUuids
-    since: 2.0
-    doc: |
-      TODO DOC
-    request:
-      retryable: true
-      partitionIdentifier: -1
-    response:
-      params:
-        - name: partitionUuidList
-          type: EntryList_Integer_UUID
-          nullable: false
-          since: 2.0
-          doc: |
-            partitionId to assigned uuid entry list
-  - id: 64
+            Map of member UUIDs mapped by the partition ids of invalidations.
+  - id: 62
     name: removeAll
     since: 2.0
     doc: |
@@ -2396,7 +2404,7 @@ methods:
           doc: |
             used to select entries to be removed from map.
     response: {}
-  - id: 65
+  - id: 63
     name: addNearCacheInvalidationListener
     since: 2.0
     doc: |
@@ -2439,25 +2447,25 @@ methods:
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              The key of the invalidated entry.
           - name: sourceUuid
             type: UUID
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              UUID of the member who fired this event.
           - name: partitionUuid
             type: UUID
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              UUID of the source partition that invalidation event belongs to.
           - name: sequence
             type: long
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Sequence number of the invalidation event.
       - name: IMapBatchInvalidation
         params:
           - name: keys
@@ -2465,26 +2473,26 @@ methods:
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              List of the keys of the invalidated entries.
           - name: sourceUuids
             type: List_UUID
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              List of UUIDs of the members who fired these events.
           - name: partitionUuids
             type: List_UUID
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              List of UUIDs of the source partitions that invalidation events belong to.
           - name: sequences
             type: List_Long
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
-  - id: 66
+              List of sequence numbers of the invalidation events.
+  - id: 64
     name: fetchWithQuery
     since: 2.0
     doc: |
@@ -2531,14 +2539,14 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            List of fetched entries.
         - name: iterationPointers
           type: EntryList_Integer_Integer
           nullable: false
           since: 2.0
           doc: |
             The index-size pairs that define the state of iteration
-  - id: 67
+  - id: 65
     name: eventJournalSubscribe
     since: 2.0
     doc: |
@@ -2562,14 +2570,14 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Sequence id of the oldest event on in the event journal.
         - name: newestSequence
           type: long
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
-  - id: 68
+            Sequence id of the newest event on in the event journal.
+  - id: 66
     name: eventJournalRead
     since: 2.0
     doc: |
@@ -2628,26 +2636,26 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Number of items read.
         - name: items
           type: List_Data
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            List of read items.
         - name: itemSeqs
           type: longArray
           nullable: true
           since: 2.0
           doc: |
-            TODO DOC
+            Sequence numbers of items in the event journal.
         - name: nextSeq
           type: long
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
-  - id: 69
+            Next id of the sequence to read from in the future operations.
+  - id: 67
     name: setTtl
     since: 2.0
     doc: |
@@ -2694,7 +2702,7 @@ methods:
           since: 2.0
           doc: |
             'true' if the entry is affected, 'false' otherwise
-  - id: 70
+  - id: 68
     name: putWithMaxIdle
     since: 2.0
     doc: |
@@ -2751,7 +2759,7 @@ methods:
           since: 2.0
           doc: |
             old value of the entry
-  - id: 71
+  - id: 69
     name: putTransientWithMaxIdle
     since: 2.0
     doc: |
@@ -2806,7 +2814,7 @@ methods:
           since: 2.0
           doc: |
             old value of the entry
-  - id: 72
+  - id: 70
     name: putIfAbsentWithMaxIdle
     since: 2.0
     doc: |
@@ -2861,7 +2869,7 @@ methods:
           since: 2.0
           doc: |
             old value of the entry
-  - id: 73
+  - id: 71
     name: setWithMaxIdle
     since: 2.0
     doc: |

--- a/protocol-definitions/Map.yaml
+++ b/protocol-definitions/Map.yaml
@@ -1236,7 +1236,8 @@ methods:
     name: removeEntryListener
     since: 2.0
     doc: |
-      Removes the specified entry listener. Returns silently if there is no such listener added before.
+      Removes the specified entry listener. If there is no such listener added before, this call does no change in the
+      cluster and returns false.
     request:
       retryable: true
       partitionIdentifier: -1
@@ -1314,7 +1315,8 @@ methods:
     name: removePartitionLostListener
     since: 2.0
     doc: |
-      Removes the specified map partition lost listener. Returns silently if there is no such listener added before.
+      Removes the specified map partition lost listener. If there is no such listener added before, this call does no
+      change in the cluster and returns false.
     request:
       retryable: true
       partitionIdentifier: -1

--- a/protocol-definitions/Map.yaml
+++ b/protocol-definitions/Map.yaml
@@ -1375,7 +1375,7 @@ methods:
           nullable: true
           since: 2.0
           doc: |
-            Entry view for the specified key.
+            Entry view of the specified key.
         - name: maxIdle
           type: long
           nullable: false
@@ -2459,7 +2459,7 @@ methods:
             nullable: false
             since: 2.0
             doc: |
-              UUID of the source partition that invalidation event belongs to.
+              UUID of the source partition that invalidated entry belongs to.
           - name: sequence
             type: long
             nullable: false
@@ -2485,7 +2485,7 @@ methods:
             nullable: false
             since: 2.0
             doc: |
-              List of UUIDs of the source partitions that invalidation events belong to.
+              List of UUIDs of the source partitions that invalidated entries belong to.
           - name: sequences
             type: List_Long
             nullable: false
@@ -2570,13 +2570,13 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            Sequence id of the oldest event on in the event journal.
+            Sequence id of the oldest event in the event journal.
         - name: newestSequence
           type: long
           nullable: false
           since: 2.0
           doc: |
-            Sequence id of the newest event on in the event journal.
+            Sequence id of the newest event in the event journal.
   - id: 66
     name: eventJournalRead
     since: 2.0
@@ -2636,13 +2636,13 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            Number of items read.
+            Number of items that have been read.
         - name: items
           type: List_Data
           nullable: false
           since: 2.0
           doc: |
-            List of read items.
+            List of items that have been read.
         - name: itemSeqs
           type: longArray
           nullable: true
@@ -2654,7 +2654,7 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            Next id of the sequence to read from in the future operations.
+            Sequence number of the item following the last read item.
   - id: 67
     name: setTtl
     since: 2.0

--- a/protocol-definitions/MultiMap.yaml
+++ b/protocol-definitions/MultiMap.yaml
@@ -414,43 +414,53 @@ methods:
             nullable: true
             since: 2.0
             doc: |
-              The key to listen to
+              Key of the entry event.
           - name: value
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Value of the entry event.
           - name: oldValue
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Old value of the entry event.
           - name: mergingValue
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Incoming merging value of the entry event.
           - name: eventType
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Type of the entry event. Possible values are
+              ADDED(1)
+              REMOVED(2)
+              UPDATED(4)
+              EVICTED(8)
+              EXPIRED(16)
+              EVICT_ALL(32)
+              CLEAR_ALL(64)
+              MERGED(128)
+              INVALIDATION(256)
+              LOADED(512)
           - name: uuid
             type: UUID
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              UUID of the member that dispatches the event.
           - name: numberOfAffectedEntries
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Number of entries affected by this event.
   - id: 14
     name: addEntryListener
     since: 2.0
@@ -494,43 +504,53 @@ methods:
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Key of the entry event.
           - name: value
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Value of the entry event.
           - name: oldValue
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Old value of the entry event.
           - name: mergingValue
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Incoming merging value of the entry event.
           - name: eventType
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Type of the entry event. Possible values are
+              ADDED(1)
+              REMOVED(2)
+              UPDATED(4)
+              EVICTED(8)
+              EXPIRED(16)
+              EVICT_ALL(32)
+              CLEAR_ALL(64)
+              MERGED(128)
+              INVALIDATION(256)
+              LOADED(512)
           - name: uuid
             type: UUID
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              UUID of the member that dispatches the event.
           - name: numberOfAffectedEntries
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Number of entries affected by this event.
   - id: 15
     name: removeEntryListener
     since: 2.0

--- a/protocol-definitions/MultiMap.yaml
+++ b/protocol-definitions/MultiMap.yaml
@@ -555,7 +555,8 @@ methods:
     name: removeEntryListener
     since: 2.0
     doc: |
-      Removes the specified entry listener. Returns silently if no such listener was added before.
+      Removes the specified entry listener. If there is no such listener added before, this call does no change in the
+      cluster and returns false.
     request:
       retryable: true
       partitionIdentifier: -1

--- a/protocol-definitions/PNCounter.yaml
+++ b/protocol-definitions/PNCounter.yaml
@@ -42,7 +42,7 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Value of the counter.
         - name: replicaTimestamps
           type: EntryList_UUID_Long
           nullable: false
@@ -54,7 +54,7 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Number of replicas that keep the state of this counter.
   - id: 2
     name: add
     since: 2.0
@@ -111,7 +111,7 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Value of the counter.
         - name: replicaTimestamps
           type: EntryList_UUID_Long
           nullable: false
@@ -123,7 +123,7 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Number of replicas that keep the state of this counter.
   - id: 3
     name: getConfiguredReplicaCount
     since: 2.0

--- a/protocol-definitions/Queue.yaml
+++ b/protocol-definitions/Queue.yaml
@@ -501,7 +501,8 @@ methods:
     name: removeListener
     since: 2.0
     doc: |
-      Removes the specified item listener.Returns silently if the specified listener was not added before.
+      Removes the specified item listener. If there is no such listener added before, this call does no change in the
+      cluster and returns false.
     request:
       retryable: true
       partitionIdentifier: -1

--- a/protocol-definitions/Queue.yaml
+++ b/protocol-definitions/Queue.yaml
@@ -484,19 +484,19 @@ methods:
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Item that the event is fired for.
           - name: uuid
             type: UUID
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              UUID of the member that dispatches this event.
           - name: eventType
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Type of the event. It is either ADDED(1) or REMOVED(2).
   - id: 18
     name: removeListener
     since: 2.0

--- a/protocol-definitions/ReplicatedMap.yaml
+++ b/protocol-definitions/ReplicatedMap.yaml
@@ -308,43 +308,53 @@ methods:
             nullable: true
             since: 2.0
             doc: |
-              Key with which the specified value is to be associated.
+              Key of the entry event.
           - name: value
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Value of the entry event.
           - name: oldValue
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Old value of the entry event.
           - name: mergingValue
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Incoming merging value of the entry event.
           - name: eventType
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Type of the entry event. Possible values are
+              ADDED(1)
+              REMOVED(2)
+              UPDATED(4)
+              EVICTED(8)
+              EXPIRED(16)
+              EVICT_ALL(32)
+              CLEAR_ALL(64)
+              MERGED(128)
+              INVALIDATION(256)
+              LOADED(512)
           - name: uuid
             type: UUID
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              UUID of the member that dispatches the event.
           - name: numberOfAffectedEntries
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Number of entries affected by this event.
   - id: 11
     name: addEntryListenerWithPredicate
     since: 2.0
@@ -389,43 +399,53 @@ methods:
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Key of the entry event.
           - name: value
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Value of the entry event.
           - name: oldValue
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Old value of the entry event.
           - name: mergingValue
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Incoming merging value of the entry event.
           - name: eventType
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Type of the entry event. Possible values are
+              ADDED(1)
+              REMOVED(2)
+              UPDATED(4)
+              EVICTED(8)
+              EXPIRED(16)
+              EVICT_ALL(32)
+              CLEAR_ALL(64)
+              MERGED(128)
+              INVALIDATION(256)
+              LOADED(512)
           - name: uuid
             type: UUID
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              UUID of the member that dispatches the event.
           - name: numberOfAffectedEntries
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Number of entries affected by this event.
   - id: 12
     name: addEntryListenerToKey
     since: 2.0
@@ -470,43 +490,53 @@ methods:
             nullable: true
             since: 2.0
             doc: |
-              Key with which the specified value is to be associated.
+              Key of the entry event.
           - name: value
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Value of the entry event.
           - name: oldValue
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Old value of the entry event.
           - name: mergingValue
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Incoming merging value of the entry event.
           - name: eventType
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Type of the entry event. Possible values are
+              ADDED(1)
+              REMOVED(2)
+              UPDATED(4)
+              EVICTED(8)
+              EXPIRED(16)
+              EVICT_ALL(32)
+              CLEAR_ALL(64)
+              MERGED(128)
+              INVALIDATION(256)
+              LOADED(512)
           - name: uuid
             type: UUID
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              UUID of the member that dispatches the event.
           - name: numberOfAffectedEntries
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Number of entries affected by this event.
   - id: 13
     name: addEntryListener
     since: 2.0
@@ -544,43 +574,53 @@ methods:
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Key of the entry event.
           - name: value
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Value of the entry event.
           - name: oldValue
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Old value of the entry event.
           - name: mergingValue
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Incoming merging value of the entry event.
           - name: eventType
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Type of the entry event. Possible values are
+              ADDED(1)
+              REMOVED(2)
+              UPDATED(4)
+              EVICTED(8)
+              EXPIRED(16)
+              EVICT_ALL(32)
+              CLEAR_ALL(64)
+              MERGED(128)
+              INVALIDATION(256)
+              LOADED(512)
           - name: uuid
             type: UUID
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              UUID of the member that dispatches the event.
           - name: numberOfAffectedEntries
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Number of entries affected by this event.
   - id: 14
     name: removeEntryListener
     since: 2.0
@@ -642,7 +682,7 @@ methods:
     name: values
     since: 2.0
     doc: |
-      TODO DOC
+      Returns a lazy collection view of the values contained in this map.
     request:
       retryable: true
       partitionIdentifier: random
@@ -665,7 +705,7 @@ methods:
     name: entrySet
     since: 2.0
     doc: |
-      TODO DOC
+      Gets a lazy set view of the mappings contained in this map.
     request:
       retryable: true
       partitionIdentifier: random
@@ -688,7 +728,7 @@ methods:
     name: addNearCacheEntryListener
     since: 2.0
     doc: |
-      TODO DOC
+      Adds a near cache entry listener for this map. This listener will be notified when an entry is added/removed/updated/evicted/expired etc. so that the near cache entries can be invalidated.
     request:
       retryable: false
       partitionIdentifier: -1
@@ -727,40 +767,50 @@ methods:
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Key of the entry event.
           - name: value
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Value of the entry event.
           - name: oldValue
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Old value of the entry event.
           - name: mergingValue
             type: Data
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Incoming merging value of the entry event.
           - name: eventType
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Type of the entry event. Possible values are
+              ADDED(1)
+              REMOVED(2)
+              UPDATED(4)
+              EVICTED(8)
+              EXPIRED(16)
+              EVICT_ALL(32)
+              CLEAR_ALL(64)
+              MERGED(128)
+              INVALIDATION(256)
+              LOADED(512)
           - name: uuid
             type: UUID
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              UUID of the member that dispatches the event.
           - name: numberOfAffectedEntries
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Number of entries affected by this event.

--- a/protocol-definitions/ReplicatedMap.yaml
+++ b/protocol-definitions/ReplicatedMap.yaml
@@ -625,7 +625,8 @@ methods:
     name: removeEntryListener
     since: 2.0
     doc: |
-      Removes the specified entry listener. Returns silently if there was no such listener added before.
+      Removes the specified entry listener. If there is no such listener added before, this call does no change in the
+      cluster and returns false.
     request:
       retryable: true
       partitionIdentifier: -1

--- a/protocol-definitions/Ringbuffer.yaml
+++ b/protocol-definitions/Ringbuffer.yaml
@@ -292,22 +292,22 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Number of items that have been read before filtering.
         - name: items
           type: List_Data
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            List of items that have beee read.
         - name: itemSeqs
           type: longArray
           nullable: true
           since: 2.0
           doc: |
-            TODO DOC
+            List of sequence numbers for the items that have been read.
         - name: nextSeq
           type: long
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Sequence number of the item following the last read item.

--- a/protocol-definitions/ScheduledExecutor.yaml
+++ b/protocol-definitions/ScheduledExecutor.yaml
@@ -173,31 +173,31 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Last period of time the task was idle, waiting to get scheduled.
         - name: totalIdleTimeNanos
           type: long
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Total amount of time the task was idle, waiting to get scheduled in.
         - name: totalRuns
           type: long
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            How many times the task was ran/called.
         - name: totalRunTimeNanos
           type: long
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            The total amount of time the task spent while scheduled in.
         - name: lastRunDurationNanos
           type: long
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            The duration of the task's last execution.
   - id: 6
     name: getStatsFromAddress
     since: 2.0
@@ -232,31 +232,31 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Last period of time the task was idle, waiting to get scheduled.
         - name: totalIdleTimeNanos
           type: long
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            Total amount of time the task was idle, waiting to get scheduled in.
         - name: totalRuns
           type: long
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            How many times the task was ran/called.
         - name: totalRunTimeNanos
           type: long
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            The total amount of time the task spent while scheduled in.
         - name: lastRunDurationNanos
           type: long
           nullable: false
           since: 2.0
           doc: |
-            TODO DOC
+            The duration of the task's last execution.
   - id: 7
     name: getDelayFromPartition
     since: 2.0

--- a/protocol-definitions/Set.yaml
+++ b/protocol-definitions/Set.yaml
@@ -329,19 +329,19 @@ methods:
             nullable: true
             since: 2.0
             doc: |
-              TODO DOC
+              Item that the event is fired for.
           - name: uuid
             type: UUID
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              UUID of the member that dispatches this event.
           - name: eventType
             type: int
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Type of the event. It is either ADDED(1) or REMOVED(2).
   - id: 12
     name: removeListener
     since: 2.0

--- a/protocol-definitions/Set.yaml
+++ b/protocol-definitions/Set.yaml
@@ -346,7 +346,8 @@ methods:
     name: removeListener
     since: 2.0
     doc: |
-      Removes the specified item listener. Returns silently if the specified listener was not added before.
+      Removes the specified item listener. If there is no such listener added before, this call does no change in the
+      cluster and returns false.
     request:
       retryable: true
       partitionIdentifier: -1

--- a/protocol-definitions/Topic.yaml
+++ b/protocol-definitions/Topic.yaml
@@ -61,19 +61,19 @@ methods:
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Item that the event is fired for.
           - name: publishTime
             type: long
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              Time that the item is published to the topic.
           - name: uuid
             type: UUID
             nullable: false
             since: 2.0
             doc: |
-              TODO DOC
+              UUID of the member that dispatches this event.
   - id: 3
     name: removeMessageListener
     since: 2.0

--- a/protocol-definitions/Transaction.yaml
+++ b/protocol-definitions/Transaction.yaml
@@ -5,7 +5,7 @@ methods:
     name: commit
     since: 2.0
     doc: |
-      TODO DOC
+      Commits the transaction with the given id.
     request:
       retryable: false
       partitionIdentifier: -1
@@ -27,7 +27,7 @@ methods:
     name: create
     since: 2.0
     doc: |
-      TODO DOC
+      Creates a transaction with the given parameters.
     request:
       retryable: false
       partitionIdentifier: -1
@@ -74,7 +74,7 @@ methods:
     name: rollback
     since: 2.0
     doc: |
-      TODO DOC
+      Rollbacks the transaction with the given id.
     request:
       retryable: false
       partitionIdentifier: -1

--- a/protocol-definitions/XATransaction.yaml
+++ b/protocol-definitions/XATransaction.yaml
@@ -5,7 +5,7 @@ methods:
     name: clearRemote
     since: 2.0
     doc: |
-      TODO DOC
+      Clears the XA transaction with the given xid from remote member.
     request:
       retryable: false
       partitionIdentifier: xid
@@ -21,7 +21,7 @@ methods:
     name: collectTransactions
     since: 2.0
     doc: |
-      TODO DOC
+      Obtains a list of prepared transaction branches from a resource manager.
     request:
       retryable: false
       partitionIdentifier: -1
@@ -37,7 +37,7 @@ methods:
     name: finalize
     since: 2.0
     doc: |
-      TODO DOC
+      Finalizes the commit of XA transaction with the given xid.
     request:
       retryable: false
       partitionIdentifier: xid
@@ -59,7 +59,7 @@ methods:
     name: commit
     since: 2.0
     doc: |
-      TODO DOC
+      Commits the global transaction specified by xid.
     request:
       retryable: false
       partitionIdentifier: -1
@@ -81,7 +81,7 @@ methods:
     name: create
     since: 2.0
     doc: |
-      TODO DOC
+      Creates an XA transaction with the given parameters.
     request:
       retryable: false
       partitionIdentifier: -1
@@ -110,7 +110,7 @@ methods:
     name: prepare
     since: 2.0
     doc: |
-      TODO DOC
+      Ask the resource manager to prepare for a transaction commit of the transaction specified in xid.
     request:
       retryable: false
       partitionIdentifier: -1
@@ -126,7 +126,7 @@ methods:
     name: rollback
     since: 2.0
     doc: |
-      TODO DOC
+      Informs the resource manager to roll back work done on behalf of a transaction branch.
     request:
       retryable: false
       partitionIdentifier: -1

--- a/protocol-definitions/XATransaction.yaml
+++ b/protocol-definitions/XATransaction.yaml
@@ -21,7 +21,7 @@ methods:
     name: collectTransactions
     since: 2.0
     doc: |
-      Obtains a list of prepared transaction branches from a resource manager.
+      Obtains a list of prepared transaction from the cluster.
     request:
       retryable: false
       partitionIdentifier: -1
@@ -110,7 +110,7 @@ methods:
     name: prepare
     since: 2.0
     doc: |
-      Ask the resource manager to prepare for a transaction commit of the transaction specified in xid.
+      Ask a member to prepare for a transaction commit of the transaction specified in xid.
     request:
       retryable: false
       partitionIdentifier: -1
@@ -126,7 +126,7 @@ methods:
     name: rollback
     since: 2.0
     doc: |
-      Informs the resource manager to roll back work done on behalf of a transaction branch.
+      Informs the member to roll back work done on behalf of a transaction.
     request:
       retryable: false
       partitionIdentifier: -1


### PR DESCRIPTION
Added missing docs to the protocol definitions. Also, removed unused definitions: `CacheAssignAndGetUuidsCodec`, `ClientRemoveAllListenersCodec`, `MapClearNearCacheCodec` and `MapAssignAndGetUuidsCodec` 