### PR TITLE
Added `internal` field to `addDistributedObjectListener` Listener request 

### DIFF
--- a/protocol-definitions/Client.yaml
+++ b/protocol-definitions/Client.yaml
@@ -433,6 +433,12 @@ methods:
           doc: |
             If set to true, the server adds the listener only to itself, otherwise the listener is is added for all
             members in the cluster.
+        - name: internal
+          type: boolean
+          nullable: false
+          since: 2.0
+          doc: |
+            Set to true for the registration for ProxyManager initiation and set to false for user listeners.
     response:
       params:
         - name: response


### PR DESCRIPTION
Added `internal` field to `addDistributedObjectListener` request so that the ProxyManager internal registration to the distributed object listener can be differentiated from the user listeners.