### PR TITLE
simplify binary generator and remove enum types

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,11 +211,13 @@ Then, depending on the selected `LANGUAGE`, a custom factory method is called to
 For example, for `java`, `CustomTypeFactory.createCustomType1(paramName1, paramName2)` method is called.
 You need to add the `CustomType1 createCustomType1(boolean paramName1, String paramName2)` method to the `CustomTypeFactory` class on the Hazelcast side.
 
-For the parameters of the custom type definition, an extra step is required for the `enum` types. 
-`enum`s are represented as integers in the protocol level. So, you need to specify how to convert `enum` type
-to integer by adding an encoder method to the `FixedSizeTypesCodec` for the enum type. 
-Also, you need to set `returnWithFactory` to `true` and add a factory method as described above. In the factory method,
-you will receive an integer for the `enum` and be expected to convert it to your `enum` type and construct the object with it.
+For the parameters of the custom type definition, an extra step is required for the enum types. 
+Enums are represented as integers in the protocol level. So, you need to specify the type as `int` in the protocol
+definition and add an `encodeInt` method to the `FixedSizeTypesCodec` for the enum type that performs the conversion
+if the enums are not represented by integers in the language you try to generate codecs for. 
+Also, you need to set `returnWithFactory` to `true` and add a factory method as described above if the conversion from 
+enum type to int is required. In the factory method, you will receive an integer for the enum and be expected to 
+convert it to your enum type and construct the object with it.
 
 Custom type definitions are also validated against a [schema](/schema/custom-codec-schema.json). See the [Schema Validation](#schema-validation) 
 section for details of the validation.

--- a/binary/__init__.py
+++ b/binary/__init__.py
@@ -4,7 +4,6 @@ FixedLengthTypes = [
     "int",
     "long",
     "UUID",
-    "enum"
 ]
 
 VarLengthTypes = [

--- a/binary/reference_objects.py
+++ b/binary/reference_objects.py
@@ -1,3 +1,8 @@
+class UuidHolder:
+    def __init__(self, most_sig_bits, least_sig_bits):
+        self.most_sig_bits = most_sig_bits
+        self.least_sig_bits = least_sig_bits
+
 BOOLEAN = True
 
 BYTE = 113
@@ -5,13 +10,6 @@ BYTE = 113
 INT = 25
 
 LONG = -50992225
-
-
-class UuidHolder:
-    def __init__(self, most_sig_bits, least_sig_bits):
-        self.most_sig_bits = most_sig_bits
-        self.least_sig_bits = least_sig_bits
-
 
 UUID = UuidHolder(123456789, 987654321)
 
@@ -23,8 +21,6 @@ STRING = "localhost"
 
 DATA = b'111313123131313131'
 
-ENUM = 1
-
 objects = {
     'boolean': BOOLEAN,
     'byte': BYTE,
@@ -35,7 +31,21 @@ objects = {
     'longArray': LONGARRAY,
     'String': STRING,
     'Data': DATA,
-    'enum': ENUM
+    'DurationConfig': {
+        'timeUnit': 1
+    },
+    'TimedExpiryPolicyFactoryConfig': {
+        'expiryPolicyType': 1
+    },
+    'ClientBwListEntry': {
+        'type': 1
+    },
+    'CacheEventData': {
+        'cacheEventType': 1
+    },
+    'IndexConfig': {
+        'type': 1
+    }
 }
 
 map_objects = {

--- a/binary/util.py
+++ b/binary/util.py
@@ -1,8 +1,8 @@
-import functools
 import struct
 
 from binary import *
 from binary.constants import *
+from functools import partial
 from util import *
 from . import reference_objects
 
@@ -12,7 +12,6 @@ formats = {
     'int': '<I',
     'long': '<q',
     'short': '<H',
-    'enum': '<I',
 }
 
 sizes = {
@@ -21,10 +20,9 @@ sizes = {
     'int': INT_SIZE_IN_BYTES,
     'long': LONG_SIZE_IN_BYTES,
     'UUID': UUID_SIZE_IN_BYTES,
-    'enum': INT_SIZE_IN_BYTES,
 }
 
-id_fmt = "0x%02x%02x%02x"
+id_fmt = '0x%02x%02x%02x'
 
 
 def read_definition(definition, protocol_defs_path):
@@ -39,9 +37,9 @@ def get_custom_type_params(protocol_defs_path):
         return {}
     definitions = read_definition('Custom', custom_codec_defs_path)
     params = {}
-    custom_types = definitions["customTypes"]
+    custom_types = definitions['customTypes']
     for definition in custom_types:
-        params[definition["name"]] = definition["params"]
+        params[definition['name']] = definition['params']
     return params
 
 
@@ -76,78 +74,44 @@ class ClientMessage:
         n = len(self.frames)
         for i in range(n):
             frame = self.frames[i]
-            file.write(struct.pack(formats['int'], SIZE_OF_FRAME_LENGTH_AND_FLAGS + len(frame.content)))
             is_last_frame = i == (n - 1)
-            flags = frame.flags | IS_FINAL_FLAG if is_last_frame else frame.flags
-            file.write(struct.pack(formats['short'], flags))
-            file.write(frame.content)
+            file.write(frame.encode_frame(is_last_frame))
 
 
 class Encoder:
-    CUSTOM_TYPE_PARAMS = None
+    def __init__(self, protocol_defs_path):
+        self.custom_type_params = get_custom_type_params(protocol_defs_path)
+        self.custom_type_encoder = CustomTypeEncoder(self, self.custom_type_params)
+        self.var_sized_encoder = VarSizedParamEncoder(self)
 
-    @staticmethod
-    def init_custom_type_params(protocol_defs_path):
-        Encoder.CUSTOM_TYPE_PARAMS = get_custom_type_params(protocol_defs_path)
-
-    @staticmethod
-    def encode_request(request, nullable=False):
-        params = request.get("params", [])
+    def encode(self, message_def, fix_sized_params_offset, is_event=False, is_null_test=False):
+        params = message_def.get('params', [])
         fix_sized_params = fixed_params(params)
         var_sized_params = var_size_params(params)
 
         client_message = ClientMessage()
-
-        initial_frame = FixSizedEncoder.create_initial_frame(fix_sized_params, request["id"],
-                                                             REQUEST_FIX_SIZED_PARAMS_OFFSET, nullable)
+        initial_frame = FixSizedParamEncoder.create_initial_frame(fix_sized_params, message_def['id'],
+                                                                  fix_sized_params_offset, is_null_test)
+        if is_event:
+            initial_frame.flags |= IS_EVENT_FLAG
         client_message.add_frame(initial_frame)
 
-        VarSizedEncoder.encode_var_sized_frames(var_sized_params, client_message, nullable)
-        return client_message
-
-    @staticmethod
-    def encode_response(response, nullable=False):
-        params = response.get("params", [])
-        fix_sized_params = fixed_params(params)
-        var_sized_params = var_size_params(params)
-
-        client_message = ClientMessage()
-
-        initial_frame = FixSizedEncoder.create_initial_frame(fix_sized_params, response["id"],
-                                                             RESPONSE_FIX_SIZED_PARAMS_OFFSET, nullable)
-        client_message.add_frame(initial_frame)
-
-        VarSizedEncoder.encode_var_sized_frames(var_sized_params, client_message, nullable)
-        return client_message
-
-    @staticmethod
-    def encode_event(event, nullable=False):
-        params = event.get("params", [])
-        fix_sized_params = fixed_params(params)
-        var_sized_params = var_size_params(params)
-
-        client_message = ClientMessage()
-
-        initial_frame = FixSizedEncoder.create_initial_frame(fix_sized_params, event["id"],
-                                                             EVENT_FIX_SIZED_PARAMS_OFFSET, nullable)
-        initial_frame.flags |= IS_EVENT_FLAG
-        client_message.add_frame(initial_frame)
-
-        VarSizedEncoder.encode_var_sized_frames(var_sized_params, client_message, nullable)
+        self.var_sized_encoder.encode_var_sized_frames(var_sized_params, client_message, is_null_test)
         return client_message
 
 
-class FixSizedEncoder:
+class FixSizedParamEncoder:
     @staticmethod
-    def create_initial_frame(fix_sized_params, message_id, offset, nullable=False):
-        frame_size = sum([sizes[p["type"]] for p in fix_sized_params])
-        frame = bytearray(offset + frame_size)
-        struct.pack_into(formats['int'], frame, TYPE_FIELD_OFFSET, message_id)
+    def create_initial_frame(fix_sized_params, message_id, offset, is_null_test=False):
+        content_size = sum([sizes[p['type']] for p in fix_sized_params])
+        content = bytearray(offset + content_size)
+        struct.pack_into(formats['int'], content, TYPE_FIELD_OFFSET, message_id)
         for param in fix_sized_params:
-            FixSizedEncoder.pack_into(frame, offset, param["type"], nullable=nullable and param["nullable"])
-            offset += sizes[param["type"]]
+            value = reference_objects.objects.get(param['type'])
+            FixSizedParamEncoder.pack_into(content, offset, param['type'], value, is_null_test and param['nullable'])
+            offset += sizes[param['type']]
 
-        return Frame(frame, UNFRAGMENTED_MESSAGE)
+        return Frame(content, UNFRAGMENTED_MESSAGE)
 
     @staticmethod
     def encode_fix_sized_entry_list_frame(client_message, key_type, value_type):
@@ -156,9 +120,9 @@ class FixSizedEncoder:
         content = bytearray(entry_size * len(obj))
         offset = 0
         for key in obj:
-            FixSizedEncoder.pack_into(content, offset, key_type, key)
+            FixSizedParamEncoder.pack_into(content, offset, key_type, key)
             offset += sizes[key_type]
-            FixSizedEncoder.pack_into(content, offset, value_type, obj[key])
+            FixSizedParamEncoder.pack_into(content, offset, value_type, obj[key])
             offset += sizes[value_type]
         client_message.add_frame(Frame(content))
 
@@ -168,86 +132,115 @@ class FixSizedEncoder:
         content = bytearray(sizes[item_type] * len(obj))
         offset = 0
         for item in obj:
-            FixSizedEncoder.pack_into(content, offset, item_type, item)
+            FixSizedParamEncoder.pack_into(content, offset, item_type, item)
+            offset += sizes[item_type]
         client_message.add_frame(Frame(content))
 
     @staticmethod
-    def pack_into(buffer, offset, type, value=None, nullable=False):
-        val = reference_objects.objects[type] if value is None else value
+    def pack_into(buffer, offset, type, value, should_be_null=False):
         if type == 'UUID':
-            struct.pack_into(formats["boolean"], buffer, offset, nullable)
-            if nullable:
+            struct.pack_into(formats['boolean'], buffer, offset, should_be_null)
+            if should_be_null:
                 return
-            offset += sizes["boolean"]
-            struct.pack_into(formats["long"], buffer, offset, val.most_sig_bits)
-            offset += sizes["long"]
-            struct.pack_into(formats["long"], buffer, offset, val.least_sig_bits)
+            offset += sizes['boolean']
+            struct.pack_into(formats['long'], buffer, offset, value.most_sig_bits)
+            offset += sizes['long']
+            struct.pack_into(formats['long'], buffer, offset, value.least_sig_bits)
         else:
-            struct.pack_into(formats[type], buffer, offset, val)
+            struct.pack_into(formats[type], buffer, offset, value)
 
 
 class CustomTypeEncoder:
-    @staticmethod
-    def encode_custom_type(client_message, type, nullable=False):
-        if nullable:
+    def __init__(self, encoder, custom_type_params):
+        self.encoder = encoder
+        self.custom_type_params = custom_type_params
+
+    def encode_custom_type(self, client_message, custom_type_name, is_null_test=False):
+        if is_null_test:
             client_message.add_frame(NULL_FRAME)
             return
 
-        params = Encoder.CUSTOM_TYPE_PARAMS.get(type, [])
+        params = self.custom_type_params.get(custom_type_name, [])
 
         fix_sized_params = fixed_params(params)
         var_sized_params = var_size_params(params)
 
         client_message.add_frame(BEGIN_FRAME)
 
-        initial_frame = CustomTypeEncoder.create_initial_frame(fix_sized_params, nullable)
+        initial_frame = self.create_initial_frame(custom_type_name, fix_sized_params)
         if initial_frame is not None:
             client_message.add_frame(initial_frame)
 
-        VarSizedEncoder.encode_var_sized_frames(var_sized_params, client_message, nullable)
+        self.encoder.var_sized_encoder.encode_var_sized_frames(var_sized_params, client_message)
 
         client_message.add_frame(END_FRAME)
 
     @staticmethod
-    def create_initial_frame(fix_sized_params, nullable=False):
-        frame_size = sum([sizes[p["type"]] for p in fix_sized_params])
-        if frame_size == 0:
+    def create_initial_frame(custom_type_name, fix_sized_params):
+        content_size = sum([sizes[p['type']] for p in fix_sized_params])
+        if content_size == 0:
             return None
-        frame = bytearray(frame_size)
+
+        content = bytearray(content_size)
         offset = 0
+
+        specific_values = reference_objects.objects.get(custom_type_name, None)
         for param in fix_sized_params:
-            FixSizedEncoder.pack_into(frame, offset, param["type"], nullable=nullable and param["nullable"])
-            offset += sizes[param["type"]]
+            specific_value = specific_values.get(param['name'], None) if specific_values is not None else None
+            value = specific_value if specific_value is not None else reference_objects.objects.get(param['type'])
+            FixSizedParamEncoder.pack_into(content, offset, param['type'], value)
+            offset += sizes[param['type']]
 
-        return Frame(frame, DEFAULT_FLAGS)
+        return Frame(content)
 
-    @staticmethod
-    def encoder_for(type, nullable=False):
-        return lambda client_message: CustomTypeEncoder.encode_custom_type(client_message, type, nullable)
+    def encoder_for(self, param_type, is_null_test=False):
+        return lambda client_message: self.encode_custom_type(client_message, param_type, is_null_test)
 
 
-class VarSizedEncoder:
-    @staticmethod
-    def encode_var_sized_frames(var_sized_params, client_message, nullable=False):
+class VarSizedParamEncoder:
+    def __init__(self, encoder):
+        self.encoder = encoder
+        self.var_sized_encoders = {
+            'byteArray': self.encode_byte_array_frame,
+            'longArray': self.encode_long_array_frame,
+            'String': self.encode_string_frame,
+            'Data': self.encode_data_frame,
+            'EntryList_Integer_UUID': partial(FixSizedParamEncoder.encode_fix_sized_entry_list_frame,
+                                              key_type='int', value_type='UUID'),
+            'EntryList_UUID_Long': partial(FixSizedParamEncoder.encode_fix_sized_entry_list_frame,
+                                           key_type='UUID', value_type='long'),
+            'EntryList_Integer_Long': partial(FixSizedParamEncoder.encode_fix_sized_entry_list_frame,
+                                              key_type='int', value_type='long'),
+            'EntryList_Integer_Integer': partial(FixSizedParamEncoder.encode_fix_sized_entry_list_frame,
+                                                 key_type='int', value_type='int'),
+            'EntryList_Long_byteArray': self.encode_long_byte_array_entry_list,
+            'EntryList_UUID_List_Integer': self.encode_uuid_integer_list_entry_list,
+            'List_Integer': partial(FixSizedParamEncoder.encode_fix_sized_list_frame, item_type='int'),
+            'List_Long': partial(FixSizedParamEncoder.encode_fix_sized_list_frame, item_type='long'),
+            'List_UUID': partial(FixSizedParamEncoder.encode_fix_sized_list_frame, item_type='UUID'),
+            'List_ScheduledTaskHandler': partial(self.encode_multi_frame_list, encoder=self.encoder.custom_type_encoder
+                                                 .encoder_for('ScheduledTaskHandler'))
+        }
+
+    def encode_var_sized_frames(self, var_sized_params, client_message, is_null_test=False):
         for param in var_sized_params:
-            type = param['type']
-            VarSizedEncoder.encode_var_sized_frame(client_message, type, nullable and param["nullable"])
+            param_type = param['type']
+            self.encode_var_sized_frame(client_message, param_type, is_null_test and param['nullable'])
 
-    @staticmethod
-    def encode_var_sized_frame(client_message, type, nullable=False):
+    def encode_var_sized_frame(self, client_message, param_type, nullable=False):
         if nullable:
             client_message.add_frame(NULL_FRAME)
             return
-        if is_var_sized_list(type) or is_var_sized_list_contains_nullable(type):
-            item_type = type.split('_', 1)[1]
-            VarSizedEncoder.encode_multi_frame_list(client_message, VarSizedEncoder.encoder_for(item_type))
-        elif is_var_sized_map(type) or is_var_sized_entry_list(type):
-            key_type = type.split('_', 2)[1]
-            value_type = type.split('_', 2)[2]
-            VarSizedEncoder.encode_multi_frame_map(client_message, VarSizedEncoder.encoder_for(key_type),
-                                                   VarSizedEncoder.encoder_for(value_type))
+
+        if is_var_sized_list(param_type) or is_var_sized_list_contains_nullable(param_type):
+            item_type = param_type.split('_', 1)[1]
+            self.encode_multi_frame_list(client_message, self.encoder_for(item_type))
+        elif is_var_sized_map(param_type) or is_var_sized_entry_list(param_type):
+            key_type = param_type.split('_', 2)[1]
+            value_type = param_type.split('_', 2)[2]
+            self.encode_multi_frame_map(client_message, self.encoder_for(key_type), self.encoder_for(value_type))
         else:
-            VarSizedEncoder.encoder_for(type)(client_message)
+            self.encoder_for(param_type)(client_message)
 
     @staticmethod
     def encode_multi_frame_list(client_message, encoder):
@@ -274,8 +267,8 @@ class VarSizedEncoder:
     def encode_long_array_frame(client_message):
         content = bytearray(len(reference_objects.LONGARRAY) * LONG_SIZE_IN_BYTES)
         offset = 0
-        for l in reference_objects.LONGARRAY:
-            struct.pack_into(formats["long"], content, offset, l)
+        for item in reference_objects.LONGARRAY:
+            struct.pack_into(formats['long'], content, offset, item)
             offset += LONG_SIZE_IN_BYTES
 
         client_message.add_frame(Frame(content))
@@ -293,54 +286,29 @@ class VarSizedEncoder:
     @staticmethod
     def encode_long_byte_array_entry_list(client_message):
         client_message.add_frame(BEGIN_FRAME)
-        VarSizedEncoder.encode_byte_array_frame(client_message)
+        VarSizedParamEncoder.encode_byte_array_frame(client_message)
         client_message.add_frame(END_FRAME)
-        FixSizedEncoder.encode_fix_sized_list_frame(client_message, 'long')
+        FixSizedParamEncoder.encode_fix_sized_list_frame(client_message, 'long')
 
-    @staticmethod
-    def encode_uuid_address_entry_list(client_message):
+    def encode_uuid_address_entry_list(self, client_message):
         client_message.add_frame(BEGIN_FRAME)
-        CustomTypeEncoder.encode_custom_type(client_message, 'Address')
+        self.encoder.custom_type_encoder.encode_custom_type(client_message, 'Address')
         client_message.add_frame(END_FRAME)
-        FixSizedEncoder.encode_fix_sized_list_frame(client_message, 'UUID')
+        FixSizedParamEncoder.encode_fix_sized_list_frame(client_message, 'UUID')
 
-    @staticmethod
-    def encode_uuid_integer_list_entry_list(client_message):
+    def encode_uuid_integer_list_entry_list(self, client_message):
         client_message.add_frame(BEGIN_FRAME)
-        VarSizedEncoder.encode_var_sized_frame(client_message, 'List_Integer')
+        self.encode_var_sized_frame(client_message, 'List_Integer')
         client_message.add_frame(END_FRAME)
-        FixSizedEncoder.encode_fix_sized_list_frame(client_message, 'UUID')
+        FixSizedParamEncoder.encode_fix_sized_list_frame(client_message, 'UUID')
 
-    @staticmethod
-    def encoder_for(type):
-        encoder = VarSizedEncoder.encoders.get(type, None)
+    def encoder_for(self, param_type):
+        encoder = self.var_sized_encoders.get(param_type, None)
         if encoder is not None:
             return encoder
-        if (type in CustomTypes) or (type in CustomConfigTypes):
-            return CustomTypeEncoder.encoder_for(type)
+        if (param_type in CustomTypes) or (param_type in CustomConfigTypes):
+            return self.encoder.custom_type_encoder.encoder_for(param_type)
 
-
-VarSizedEncoder.encoders = {
-    'byteArray': VarSizedEncoder.encode_byte_array_frame,
-    'longArray': VarSizedEncoder.encode_long_array_frame,
-    'String': VarSizedEncoder.encode_string_frame,
-    'Data': VarSizedEncoder.encode_data_frame,
-    'EntryList_Integer_UUID': functools.partial(FixSizedEncoder.encode_fix_sized_entry_list_frame,
-                                                key_type='int', value_type='UUID'),
-    'EntryList_UUID_Long': functools.partial(FixSizedEncoder.encode_fix_sized_entry_list_frame,
-                                             key_type='UUID', value_type='long'),
-    'EntryList_Integer_Long': functools.partial(FixSizedEncoder.encode_fix_sized_entry_list_frame,
-                                                key_type='int', value_type='long'),
-    'EntryList_Integer_Integer': functools.partial(FixSizedEncoder.encode_fix_sized_entry_list_frame,
-                                                key_type='int', value_type='int'),
-    'EntryList_Long_byteArray': VarSizedEncoder.encode_long_byte_array_entry_list,
-    'EntryList_UUID_List_Integer': VarSizedEncoder.encode_uuid_integer_list_entry_list,
-    'List_Integer': functools.partial(FixSizedEncoder.encode_fix_sized_list_frame, item_type='int'),
-    'List_Long': functools.partial(FixSizedEncoder.encode_fix_sized_list_frame, item_type='long'),
-    'List_UUID': functools.partial(FixSizedEncoder.encode_fix_sized_list_frame, item_type='UUID'),
-    'List_ScheduledTaskHandler': functools.partial(VarSizedEncoder.encode_multi_frame_list,
-                                                   encoder=CustomTypeEncoder.encoder_for('ScheduledTaskHandler'))
-}
 
 test_output_directories = {
     SupportedLanguages.JAVA: 'hazelcast/src/test/java/com/hazelcast/client/protocol/compatibility',
@@ -437,6 +405,8 @@ reference_objects_dict = {
     'AnchorDataListHolder': 'anAnchorDataListHolder',
     'PagingPredicateHolder': 'aPagingPredicateHolder',
 }
+
+
 def create_environment_for_binary_generator(lang, version):
     env = Environment(loader=PackageLoader(lang.value + '.binary', '.'))
     env.trim_blocks = True

--- a/binary_generator.py
+++ b/binary_generator.py
@@ -34,27 +34,27 @@ def save_test_files(test_output_dir, lang, version, services, templates):
 
 
 def _generate_binary_files(binary_file, null_binary_file, protocol_defs_path, services):
-    Encoder.init_custom_type_params(protocol_defs_path)
+    encoder = Encoder(protocol_defs_path)
     for service in services:
-        methods = service["methods"]
+        methods = service['methods']
         for method in methods:
-            method["request"]["id"] = int(id_fmt % (service["id"], method["id"], 0), 16)
-            method["response"]["id"] = int(id_fmt % (service["id"], method["id"], 1), 16)
-            events = method.get("events", None)
+            method['request']['id'] = int(id_fmt % (service['id'], method['id'], 0), 16)
+            method['response']['id'] = int(id_fmt % (service['id'], method['id'], 1), 16)
+            events = method.get('events', None)
             if events is not None:
                 for i in range(len(events)):
-                    method["events"][i]["id"] = int(id_fmt % (service["id"], method["id"], i + 2), 16)
-            request = Encoder.encode_request(method["request"])
-            null_request = Encoder.encode_request(method["request"], True)
+                    method['events'][i]['id'] = int(id_fmt % (service['id'], method['id'], i + 2), 16)
+            request = encoder.encode(method['request'], REQUEST_FIX_SIZED_PARAMS_OFFSET)
+            null_request = encoder.encode(method['request'], REQUEST_FIX_SIZED_PARAMS_OFFSET, is_null_test=True)
             request.write(binary_file)
             null_request.write(null_binary_file)
-            response = Encoder.encode_response(method["response"])
-            null_response = Encoder.encode_response(method["response"], True)
+            response = encoder.encode(method['response'], RESPONSE_FIX_SIZED_PARAMS_OFFSET)
+            null_response = encoder.encode(method['response'], RESPONSE_FIX_SIZED_PARAMS_OFFSET, is_null_test=True)
             response.write(binary_file)
             null_response.write(null_binary_file)
             if events is not None:
                 for e in events:
-                    event = Encoder.encode_event(e)
-                    null_event = Encoder.encode_event(e, True)
+                    event = encoder.encode(e, EVENT_FIX_SIZED_PARAMS_OFFSET, True)
+                    null_event = encoder.encode(e, EVENT_FIX_SIZED_PARAMS_OFFSET, True, True)
                     event.write(binary_file)
                     null_event.write(null_binary_file)

--- a/cs/__init__.py
+++ b/cs/__init__.py
@@ -44,7 +44,6 @@ _cs_types_common = {
     "Integer": "int",
     "Long": "long",
     "UUID": "Guid",
-    "enum": "int",
 
     "longArray": "long[]",
     "byteArray": "byte[]",

--- a/java/__init__.py
+++ b/java/__init__.py
@@ -20,7 +20,6 @@ _java_types_common = {
     "Integer": "java.lang.Integer",
     "Long": "java.lang.Long",
     "UUID": "java.util.UUID",
-    "enum": "int",
 
     "longArray": "long[]",
     "byteArray": "byte[]",

--- a/protocol-definitions/custom/Custom.yaml
+++ b/protocol-definitions/custom/Custom.yaml
@@ -20,7 +20,7 @@ customTypes:
         nullable: false
         since: 2.0
       - name: cacheEventType
-        type: enum
+        type: int
         nullable: false
         since: 2.0
       - name: dataKey
@@ -183,7 +183,7 @@ customTypes:
         nullable: true
         since: 2.0
       - name: type
-        type: enum
+        type: int
         nullable: false
         since: 2.0
       - name: attributes
@@ -566,7 +566,7 @@ customTypes:
         nullable: false
         since: 2.0
       - name: timeUnit
-        type: enum
+        type: int
         nullable: false
         since: 2.0
   - name: TimedExpiryPolicyFactoryConfig
@@ -574,7 +574,7 @@ customTypes:
     returnWithFactory: true
     params:
       - name: expiryPolicyType
-        type: enum
+        type: int
         nullable: false
         since: 2.0
       - name: durationConfig
@@ -734,7 +734,7 @@ customTypes:
     returnWithFactory: true
     params:
       - name: type
-        type: enum
+        type: int
         nullable: false
         since: 2.0
       - name: value

--- a/schema/custom-codec-schema.json
+++ b/schema/custom-codec-schema.json
@@ -24,7 +24,6 @@
             "int",
             "long",
             "UUID",
-            "enum",
             "byteArray",
             "longArray",
             "String",

--- a/schema/protocol-schema.json
+++ b/schema/protocol-schema.json
@@ -24,7 +24,6 @@
             "int",
             "long",
             "UUID",
-            "enum",
             "byteArray",
             "longArray",
             "String",


### PR DESCRIPTION
- Simplified the binary generator by merging some methods and refactoring some parts. 
- Removed enum type from the protocol and replaced it with int.
- Added an ability to set specific values for parameters of custom types
