### PR TITLE
Fix: namespace is not used in Java codec templates

### DIFF
--- a/java/codec-template.java.j2
+++ b/java/codec-template.java.j2
@@ -53,7 +53,11 @@ package com.hazelcast.client.impl.protocol.codec;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.Generated;
 import com.hazelcast.client.impl.protocol.codec.builtin.*;
+{% if namespace %}
+import {{ namespace }}.custom.*;
+{% else %}
 import com.hazelcast.client.impl.protocol.codec.custom.*;
+{% endif %}
 {% if method.events|length != 0 %}
 import com.hazelcast.logging.Logger;
 {% endif %}

--- a/java/custom-codec-template.java.j2
+++ b/java/custom-codec-template.java.j2
@@ -45,7 +45,7 @@
  */
 
 {% if namespace %}
-package {{ namespace }};
+package {{ namespace }}.custom;
 {% else %}
 package com.hazelcast.client.impl.protocol.codec.custom;
 {% endif %}


### PR DESCRIPTION
Fixes #306