### PR TITLE
Add codec versioning support

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ You can generate codecs for a specific language by calling,
 
 ```bash
 
-./generator.py [-r ROOT_DIRECTORY] [-l LANGUAGE] [-p PROTOCOL_DEFS_PATH] [-o OUTPUT_DIRECTORY] [-n NAMESPACE] [-b BINARY_OUTPUT_DIR] [-t TEST_OUTPUT_DIR] [-v VERSION] [--no-binary] [--no-id-check]
+./generator.py [-r ROOT_DIRECTORY] [-l LANGUAGE] [-p PROTOCOL_DEFS_PATH] [-o OUTPUT_DIRECTORY] [-n NAMESPACE] [-b BINARY_OUTPUT_DIR] [-t TEST_OUTPUT_DIR] [--no-binary] [--no-id-check]
 
 ```
 
@@ -131,8 +131,6 @@ When left empty, default value is inferred from the selected `LANGUAGE`.
 
 * `TEST_OUTPUT_DIR` is the output directory relative to the `ROOT_DIRECTORY` that is used for the test files for the binary compatibility tests.
 Default value is inferred from the selected `LANGUAGE`.
-
-* `VERSION` is the protocol version to generate binary and test files for the binary compatibility tests. When left empty, default value is set to the latest protocol version.
 
 * `--no-binary` flag restrains the generator from creating binary and test files for the binary compatibility tests.
 

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ When left empty, default value is inferred from the selected `LANGUAGE`.
 * `TEST_OUTPUT_DIR` is the output directory relative to the `ROOT_DIRECTORY` that is used for the test files for the binary compatibility tests.
 Default value is inferred from the selected `LANGUAGE`.
 
+
 * `--no-binary` flag restrains the generator from creating binary and test files for the binary compatibility tests.
 
 * `--no-id-check` flag restrains the generator from checking sequentiality of service and method ids of protocol definitions.
@@ -219,3 +220,28 @@ convert it to your enum type and construct the object with it.
 
 Custom type definitions are also validated against a [schema](/schema/custom-codec-schema.json). See the [Schema Validation](#schema-validation) 
 section for details of the validation.
+
+### Expanding the Client Protocol
+
+Client protocol can be expanded by adding new
+* services
+* methods
+* parameters to existing method requests, responses or events
+* events to existing methods
+* custom types
+* parameters to existing custom types
+
+While expanding the protocol, one needs to follow these simple guidelines:
+* `since` field of the protocol definitions of the the newly added parameters, methods, events and custom types should 
+be equal to the current protocol version. 
+* New services should have the id of the 1 + the highest id of the existing services.
+* New methods should come after the existing methods on the protocol definitions and have the id of the 1 + the id 
+of the method that comes before it.
+* New request, response or event parameters should come after the existing parameters on the protocol definitions 
+and they should be in the increasing order of the protocol versions that is 2.1 parameters should follow 
+2.0.1 parameters which should follow 2.0 parameters.
+* New parameters to custom types should come after the existing parameters on the protocol definitions and they should
+be in the increasing order of protocol versions as described above.
+* Although not necessary, new events or custom types should come after the existing custom types or events on the 
+protocol definitions.
+ 

--- a/binary/util.py
+++ b/binary/util.py
@@ -168,12 +168,18 @@ class CustomTypeEncoder:
         params = filter_new_params(definition.get('params', []), self.encoder.version)
 
         fix_sized_params = fixed_params(params)
+        fix_sized_new_params = new_params(definition['since'], fix_sized_params)
         var_sized_params = var_size_params(params)
 
-        client_message.add_frame(BEGIN_FRAME)
+        should_add_begin_frame = (len(fix_sized_params) > len(fix_sized_new_params)) or len(fix_sized_params) == 0
+
+        if should_add_begin_frame:
+            client_message.add_frame(BEGIN_FRAME)
 
         initial_frame = self.create_initial_frame(custom_type_name, fix_sized_params)
         if initial_frame is not None:
+            if not should_add_begin_frame:
+                initial_frame.flags |= BEGIN_DATA_STRUCTURE_FLAG
             client_message.add_frame(initial_frame)
 
         self.encoder.var_sized_encoder.encode_var_sized_frames(var_sized_params, client_message)

--- a/binary/util.py
+++ b/binary/util.py
@@ -408,15 +408,18 @@ reference_objects_dict = {
 }
 
 
-def create_environment_for_binary_generator(lang, version):
-    env = Environment(loader=PackageLoader(lang.value + '.binary', '.'))
+def create_environment_for_binary_generator(lang):
+    env = Environment(loader=PackageLoader(lang.value + '.binary', '.'), extensions=['jinja2.ext.loopcontrols'])
     env.trim_blocks = True
     env.lstrip_blocks = True
     env.keep_trailing_newline = False
     env.filters['capital'] = capital
     env.globals['lang_types_encode'] = language_specific_funcs['lang_types_encode'][lang]
-    env.globals['protocol_version'] = version
     env.globals['reference_objects_dict'] = reference_objects_dict
+    env.globals['get_version_as_number'] = get_version_as_number
+    env.globals['get_param_versions'] = get_param_versions
+    env.globals['new_params'] = new_params
+    env.globals['filter_new_params'] = filter_new_params
     return env
 
 

--- a/binary_generator.py
+++ b/binary_generator.py
@@ -4,8 +4,8 @@ from binary.util import *
 from jinja2.exceptions import TemplateNotFound
 
 
-def get_binary_templates(lang, version):
-    env = create_environment_for_binary_generator(lang, version)
+def get_binary_templates(lang):
+    env = create_environment_for_binary_generator(lang)
     templates = {}
     try:
         templates['Client'] = env.get_template('client-binary-compatibility-template.j2')
@@ -30,7 +30,7 @@ def save_test_files(test_output_dir, lang, version, services, templates):
     for test_type in ['Client', 'Member']:
         for test_null_type in ['', 'Null']:
             with open(os.path.join(test_output_dir, class_name.format(type=test_type, null=test_null_type)), 'w', newline='\n') as f:
-                f.write(templates[test_type].render(services=services, test_nullable=test_null_type == 'Null'))
+                f.write(templates[test_type].render(protocol_version=version, services=services, test_nullable=test_null_type == 'Null'))
 
 
 def _generate_binary_files(binary_file, null_binary_file, protocol_defs_path, services):

--- a/binary_generator.py
+++ b/binary_generator.py
@@ -20,7 +20,7 @@ def save_binary_files(binary_output_dir, protocol_defs_path, version, services):
     with open(os.path.join(binary_output_dir, version + '.protocol.compatibility.binary'), 'wb') as binary_file:
         with open(os.path.join(binary_output_dir, version + '.protocol.compatibility.null.binary'),
                   'wb') as null_binary_file:
-            _generate_binary_files(binary_file, null_binary_file, protocol_defs_path, services)
+            _generate_binary_files(binary_file, null_binary_file, protocol_defs_path, services, version)
 
 
 def save_test_files(test_output_dir, lang, version, services, templates):
@@ -33,11 +33,15 @@ def save_test_files(test_output_dir, lang, version, services, templates):
                 f.write(templates[test_type].render(protocol_version=version, services=services, test_nullable=test_null_type == 'Null'))
 
 
-def _generate_binary_files(binary_file, null_binary_file, protocol_defs_path, services):
-    encoder = Encoder(protocol_defs_path)
+def _generate_binary_files(binary_file, null_binary_file, protocol_defs_path, services, version):
+    encoder = Encoder(protocol_defs_path, version)
+    version_as_number = get_version_as_number(version)
     for service in services:
         methods = service['methods']
         for method in methods:
+            if get_version_as_number(method['since']) > version_as_number:
+                continue
+
             method['request']['id'] = int(id_fmt % (service['id'], method['id'], 0), 16)
             method['response']['id'] = int(id_fmt % (service['id'], method['id'], 1), 16)
             events = method.get('events', None)
@@ -55,6 +59,9 @@ def _generate_binary_files(binary_file, null_binary_file, protocol_defs_path, se
             null_response.write(null_binary_file)
             if events is not None:
                 for e in events:
+                    if get_version_as_number(e['since']) > version_as_number:
+                        continue
+
                     event = encoder.encode(e, EVENT_FIX_SIZED_PARAMS_OFFSET, is_event=True, set_partition_id=True)
                     null_event = encoder.encode(e, EVENT_FIX_SIZED_PARAMS_OFFSET, is_event=True,
                                                 set_partition_id=True, is_null_test=True)

--- a/generator.py
+++ b/generator.py
@@ -7,8 +7,6 @@ from binary.util import test_output_directories, binary_output_directories
 from binary_generator import save_test_files, save_binary_files, get_binary_templates
 from util import *
 
-RELEASED_PROTOCOL_VERSIONS = ['2.0']
-PROTOCOL_VERSION = '2.1'
 
 start = time.time()
 
@@ -105,6 +103,7 @@ codec_template = env.get_template("codec-template.%s.j2" % lang_str_arg)
 generate_codecs(protocol_defs, codec_template, codec_output_dir, lang)
 print('Generated codecs are at \'%s\'' % os.path.abspath(codec_output_dir))
 
+custom_protocol_defs = None
 if os.path.exists(custom_protocol_defs_path):
     custom_protocol_defs = load_services(custom_protocol_defs_path)
     if not validate_custom_protocol_definitions(custom_protocol_defs, custom_codec_schema_path):
@@ -122,14 +121,15 @@ if not no_binary_arg:
     test_output_dir = os.path.join(root_dir, relative_test_output_dir)
     binary_output_dir = os.path.join(root_dir, relative_binary_output_dir)
 
+    protocol_versions = get_protocol_versions(protocol_defs, custom_protocol_defs)
+
     error, binary_templates = get_binary_templates(lang)
     if binary_templates is not None:
-        for released_version in RELEASED_PROTOCOL_VERSIONS:
-            save_test_files(test_output_dir, lang, released_version, protocol_defs, binary_templates)
-        save_test_files(test_output_dir, lang, PROTOCOL_VERSION, protocol_defs, binary_templates)
-        print('Generated binary compatibility tests are at \'%s\'' % test_output_dir)
-        save_binary_files(binary_output_dir, protocol_defs_path, PROTOCOL_VERSION, protocol_defs)
+        for version in protocol_versions:
+            save_test_files(test_output_dir, lang, version, protocol_defs, binary_templates)
+            save_binary_files(binary_output_dir, protocol_defs_path, version, protocol_defs)
         print('Generated binary compatibility files are at \'%s\'' % binary_output_dir)
+        print('Generated binary compatibility tests are at \'%s\'' % test_output_dir)
     else:
         print('Binary compatibility test cannot be generated because the templates for the selected '
               'language cannot be loaded. Verify that the \'%s\' exists.' % error)

--- a/generator.py
+++ b/generator.py
@@ -7,7 +7,8 @@ from binary.util import test_output_directories, binary_output_directories
 from binary_generator import save_test_files, save_binary_files, get_binary_templates
 from util import *
 
-PROTOCOL_VERSION = '2.0'
+RELEASED_PROTOCOL_VERSIONS = ['2.0']
+PROTOCOL_VERSION = '2.1'
 
 start = time.time()
 
@@ -57,12 +58,6 @@ parser.add_argument('-t', '--test-output-dir',
                                    'root directory for the binary compatibility test files.(default value is '
                                    'set according to the selected language)')
 
-parser.add_argument('-v', '--version',
-                    dest='version', action='store',
-                    metavar='VERSION', default=PROTOCOL_VERSION,
-                    type=str, help='Version of the protocol to generate binary compatibility files for. '
-                                   '(default value is the version of the protocol)')
-
 parser.add_argument('--no-binary',
                     dest='no_binary', action='store_true', default=False,
                     help='Flag to signal that binary compatibility files and tests'
@@ -81,7 +76,6 @@ out_dir_arg = args.out_dir
 namespace_arg = args.namespace
 test_out_dir_arg = args.test_out_dir
 bin_out_dir_arg = args.bin_out_dir
-version_arg = args.version
 no_binary_arg = args.no_binary
 no_id_check = args.no_id_check
 
@@ -128,11 +122,13 @@ if not no_binary_arg:
     test_output_dir = os.path.join(root_dir, relative_test_output_dir)
     binary_output_dir = os.path.join(root_dir, relative_binary_output_dir)
 
-    error, binary_templates = get_binary_templates(lang, version_arg)
+    error, binary_templates = get_binary_templates(lang)
     if binary_templates is not None:
-        save_test_files(test_output_dir, lang, version_arg, protocol_defs, binary_templates)
+        for released_version in RELEASED_PROTOCOL_VERSIONS:
+            save_test_files(test_output_dir, lang, released_version, protocol_defs, binary_templates)
+        save_test_files(test_output_dir, lang, PROTOCOL_VERSION, protocol_defs, binary_templates)
         print('Generated binary compatibility tests are at \'%s\'' % test_output_dir)
-        save_binary_files(binary_output_dir, protocol_defs_path, version_arg, protocol_defs)
+        save_binary_files(binary_output_dir, protocol_defs_path, PROTOCOL_VERSION, protocol_defs)
         print('Generated binary compatibility files are at \'%s\'' % binary_output_dir)
     else:
         print('Binary compatibility test cannot be generated because the templates for the selected '

--- a/java/binary/client-binary-compatibility-template.j2
+++ b/java/binary/client-binary-compatibility-template.j2
@@ -16,10 +16,10 @@
 
 package com.hazelcast.client.protocol.compatibility;
 
+import com.hazelcast.client.HazelcastClientUtil;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.ClientMessageReader;
 import com.hazelcast.client.impl.protocol.codec.*;
-import com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -37,7 +37,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.hazelcast.client.impl.protocol.ClientMessage.END_DATA_STRUCTURE_FLAG;
 import static com.hazelcast.client.impl.protocol.ClientMessage.IS_FINAL_FLAG;
 import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.*;
 import static org.junit.Assert.assertArrayEquals;
@@ -150,37 +149,24 @@ public class ClientCompatibility{% if test_nullable %}Null{% endif %}Test_{{ '_'
 
         ClientMessage.ForwardFrameIterator binaryFrameIterator = binaryMessage.frameIterator();
         ClientMessage.ForwardFrameIterator encodedFrameIterator = encodedMessage.frameIterator();
+        assertTrue("Client message that is read from the binary file does not have any frames", binaryFrameIterator.hasNext());
 
-        boolean isInitialFramesCompared = false;
         while (binaryFrameIterator.hasNext()) {
             binaryFrame = binaryFrameIterator.next();
             encodedFrame = encodedFrameIterator.next();
             assertNotNull("Encoded client message has less frames.", encodedFrame);
 
-            boolean isFinal = binaryFrameIterator.peekNext() == null;
-            boolean isEndFrame = binaryFrame.isEndFrame();
-            if (!isInitialFramesCompared) {
-                compareInitialFrame(binaryFrame, encodedFrame, isFinal);
-                isInitialFramesCompared = true;
-            } else {
-                assertArrayEquals("Frames have different contents", binaryFrame.content, Arrays.copyOf(encodedFrame.content, binaryFrame.content.length));
-                int flags = isFinal ? encodedFrame.flags | IS_FINAL_FLAG : encodedFrame.flags;
-                flags = isEndFrame ? flags | END_DATA_STRUCTURE_FLAG : flags;
-                assertEquals("Frames have different flags", binaryFrame.flags, flags);
-                if (isEndFrame && !ClientMessage.isFlagSet(encodedFrame.flags, END_DATA_STRUCTURE_FLAG)) {
-                    CodecUtil.fastForwardToEndFrame(encodedFrameIterator);
+            if (binaryFrame.isEndFrame() && !encodedFrame.isEndFrame()) {
+                if (encodedFrame.isBeginFrame()) {
+                    HazelcastClientUtil.fastForwardToEndFrame(encodedFrameIterator);
                 }
+                encodedFrame = HazelcastClientUtil.fastForwardToEndFrame(encodedFrameIterator);
             }
-        }
-        assertTrue("Client message that is read from the binary file does not have any frames", isInitialFramesCompared);
-    }
 
-    private void compareInitialFrame(ClientMessage.Frame binaryFrame, ClientMessage.Frame encodedFrame, boolean isFinal) {
-        assertTrue("Encoded client message have shorter initial frame",
-                binaryFrame.content.length <= encodedFrame.content.length);
-        assertArrayEquals("Initial frames have different contents",
-                binaryFrame.content, Arrays.copyOf(encodedFrame.content, binaryFrame.content.length));
-        int flags = isFinal ? encodedFrame.flags | IS_FINAL_FLAG : encodedFrame.flags;
-        assertEquals("Initial frames have different flags", binaryFrame.flags, flags);
+            boolean isFinal = binaryFrameIterator.peekNext() == null;
+            int flags = isFinal ? encodedFrame.flags | IS_FINAL_FLAG : encodedFrame.flags;
+            assertArrayEquals("Frames have different contents", binaryFrame.content, Arrays.copyOf(encodedFrame.content, binaryFrame.content.length));
+            assertEquals("Frames have different flags", binaryFrame.flags, flags);
+        }
     }
 }

--- a/java/binary/client-binary-compatibility-template.j2
+++ b/java/binary/client-binary-compatibility-template.j2
@@ -19,6 +19,7 @@ package com.hazelcast.client.protocol.compatibility;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.ClientMessageReader;
 import com.hazelcast.client.impl.protocol.codec.*;
+import com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -36,12 +37,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.hazelcast.client.impl.protocol.ClientMessage.END_DATA_STRUCTURE_FLAG;
 import static com.hazelcast.client.impl.protocol.ClientMessage.IS_FINAL_FLAG;
 import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.*;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.fail;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -61,9 +65,13 @@ public class ClientCompatibility{% if test_nullable %}Null{% endif %}Test_{{ '_'
             reader.reset();
         }
     }
+    {% set protocol_version_as_number = get_version_as_number(protocol_version) %}
     {% set counter = namespace(count=0) %}
     {% for service in services %}
     {% for method in service.methods %}
+        {% if get_version_as_number(method.since) >  protocol_version_as_number %}
+            {% continue %}
+        {% endif %}
 
     @Test
     public void test_{{ service.name|capital}}{{ method.name|capital }}Codec_encodeRequest() {
@@ -79,24 +87,44 @@ public class ClientCompatibility{% if test_nullable %}Null{% endif %}Test_{{ '_'
         int fileClientMessageIndex = {{ counter.count }};
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
         {{ service.name|capital }}{{ method.name|capital }}Codec.ResponseParameters parameters = {{ service.name|capital }}{{ method.name|capital }}Codec.decodeResponse(fromFile);
+        {% set new_response_params = new_params(method.since, method.response.params) %}
         {% for param in method.response.params %}
+            {% if get_version_as_number(param.since) > protocol_version_as_number %}
+        assertFalse(parameters.is{{ param.name|capital }}Exists);
+            {% else %}
+                {% if param in new_response_params %}
+        assertTrue(parameters.is{{ param.name|capital }}Exists);
+                {% endif %}
         assertTrue(isEqual({%if test_nullable and param.nullable %}null{% else %}{{ reference_objects_dict[param.type] }}{% endif %}, parameters.{{ param.name }}));
+            {% endif %}
         {% endfor %}
     }
     {% set counter.count = counter.count + 1 %}
     {% if method.events|length != 0%}
 
-    private class {{ service.name|capital }}{{ method.name|capital }}CodecHandler extends {{ service.name|capital }}{{ method.name|capital }}Codec.AbstractEventHandler {
+    private static class {{ service.name|capital }}{{ method.name|capital }}CodecHandler extends {{ service.name|capital }}{{ method.name|capital }}Codec.AbstractEventHandler {
         {% for event in method.events %}
+            {% set event_versions = get_param_versions(event.since, event.params) %}
+            {% for version in event_versions %}
+                {% set filtered_params = filter_new_params(event.params, version) %}
+
         @Override
-        public void handle{{ event.name|capital }}Event({% for param in event.params %}{{ lang_types_encode(param.type) }} {{param.name}}{% if not loop.last %}, {% endif %}{% endfor %}) {
-            {% for param in event.params %}
+        public void handle{{ event.name|capital }}Event{% if not loop.first %}V{{ version|string|replace('.', '_') }}{% endif %}({% for param in filtered_params %}{{ lang_types_encode(param.type) }} {{param.name}}{% if not loop.last %}, {% endif %}{% endfor %}) {
+                {% if get_version_as_number(version) != protocol_version_as_number %}
+            fail("This method should not be called since this is an v{{ version }} event handler, but the compatibility test is for v{{ protocol_version }}.");
+                {% else %}
+                {% for param in filtered_params %}
             assertTrue(isEqual({%if test_nullable and param.nullable %}null{% else %}{{ reference_objects_dict[param.type] }}{% endif %}, {{ param.name }}));
-            {% endfor %}
+                {% endfor %}
+                {% endif %}
         }
+            {% endfor %}
         {% endfor %}
     }
     {% for event in method.events %}
+        {% if get_version_as_number(event.since) > protocol_version_as_number %}
+            {% continue %}
+        {% endif %}
 
     @Test
     public void test_{{ service.name|capital }}{{ method.name|capital }}Codec_handle{{ event.name|capital }}Event() {
@@ -128,9 +156,12 @@ public class ClientCompatibility{% if test_nullable %}Null{% endif %}Test_{{ '_'
                 compareInitialFrame(binaryFrame, encodedFrame, isFinal);
                 isInitialFramesCompared = true;
             } else {
-                assertArrayEquals("Frames have different contents", binaryFrame.content, encodedFrame.content);
+                assertArrayEquals("Frames have different contents", binaryFrame.content, Arrays.copyOf(encodedFrame.content, binaryFrame.content.length));
                 int flags = isFinal ? encodedFrame.flags | IS_FINAL_FLAG : encodedFrame.flags;
                 assertEquals("Frames have different flags", binaryFrame.flags, flags);
+                if (ClientMessage.isFlagSet(binaryFrame.flags, END_DATA_STRUCTURE_FLAG) && !ClientMessage.isFlagSet(flags, END_DATA_STRUCTURE_FLAG)) {
+                    CodecUtil.fastForwardToEndFrame(encodedFrameIterator);
+                }
             }
         }
         assertTrue("Client message that is read from the binary file does not have any frames", isInitialFramesCompared);

--- a/java/binary/client-binary-compatibility-template.j2
+++ b/java/binary/client-binary-compatibility-template.j2
@@ -104,21 +104,27 @@ public class ClientCompatibility{% if test_nullable %}Null{% endif %}Test_{{ '_'
 
     private static class {{ service.name|capital }}{{ method.name|capital }}CodecHandler extends {{ service.name|capital }}{{ method.name|capital }}Codec.AbstractEventHandler {
         {% for event in method.events %}
-            {% set event_versions = get_param_versions(event.since, event.params) %}
-            {% for version in event_versions %}
-                {% set filtered_params = filter_new_params(event.params, version) %}
-
+            {% set new_event_params = new_params(event.since, event.params) %}
+            {% set event_version = get_version_as_number(event.since) %}
         @Override
-        public void handle{{ event.name|capital }}Event{% if not loop.first %}V{{ version|string|replace('.', '_') }}{% endif %}({% for param in filtered_params %}{{ lang_types_encode(param.type) }} {{param.name}}{% if not loop.last %}, {% endif %}{% endfor %}) {
-                {% if get_version_as_number(version) != protocol_version_as_number %}
-            fail("This method should not be called since this is an v{{ version }} event handler, but the compatibility test is for v{{ protocol_version }}.");
+        public void handle{{ event.name|capital }}Event({% for param in event.params %}{% if param in new_event_params %}boolean is{{ param.name|capital }}Exists, {% endif %}{{ lang_types_encode(param.type) }} {{param.name}}{% if not loop.last %}, {% endif %}{% endfor %}) {
+                {% if event_version > protocol_version_as_number %}
+            fail("This method should not be called since this is an v{{ event.since }} event handler but the test is for v{{ protocol_version }}");
                 {% else %}
-                {% for param in filtered_params %}
+                    {% for param in event.params %}
+                        {% if param in new_event_params %}
+                            {% if get_version_as_number(param.since) > protocol_version_as_number %}
+            assertFalse(is{{ param.name|capital }}Exists);
+                            {% else %}
+            assertTrue(is{{ param.name|capital }}Exists);
             assertTrue(isEqual({%if test_nullable and param.nullable %}null{% else %}{{ reference_objects_dict[param.type] }}{% endif %}, {{ param.name }}));
-                {% endfor %}
+                            {% endif %}
+                        {% else %}
+            assertTrue(isEqual({%if test_nullable and param.nullable %}null{% else %}{{ reference_objects_dict[param.type] }}{% endif %}, {{ param.name }}));
+                        {% endif %}
+                    {% endfor %}
                 {% endif %}
         }
-            {% endfor %}
         {% endfor %}
     }
     {% for event in method.events %}
@@ -152,14 +158,16 @@ public class ClientCompatibility{% if test_nullable %}Null{% endif %}Test_{{ '_'
             assertNotNull("Encoded client message has less frames.", encodedFrame);
 
             boolean isFinal = binaryFrameIterator.peekNext() == null;
+            boolean isEndFrame = binaryFrame.isEndFrame();
             if (!isInitialFramesCompared) {
                 compareInitialFrame(binaryFrame, encodedFrame, isFinal);
                 isInitialFramesCompared = true;
             } else {
                 assertArrayEquals("Frames have different contents", binaryFrame.content, Arrays.copyOf(encodedFrame.content, binaryFrame.content.length));
                 int flags = isFinal ? encodedFrame.flags | IS_FINAL_FLAG : encodedFrame.flags;
+                flags = isEndFrame ? flags | END_DATA_STRUCTURE_FLAG : flags;
                 assertEquals("Frames have different flags", binaryFrame.flags, flags);
-                if (ClientMessage.isFlagSet(binaryFrame.flags, END_DATA_STRUCTURE_FLAG) && !ClientMessage.isFlagSet(flags, END_DATA_STRUCTURE_FLAG)) {
+                if (isEndFrame && !ClientMessage.isFlagSet(encodedFrame.flags, END_DATA_STRUCTURE_FLAG)) {
                     CodecUtil.fastForwardToEndFrame(encodedFrameIterator);
                 }
             }

--- a/java/binary/member-binary-compatibility-template.j2
+++ b/java/binary/member-binary-compatibility-template.j2
@@ -16,10 +16,10 @@
 
 package com.hazelcast.client.protocol.compatibility;
 
+import com.hazelcast.client.HazelcastClientUtil;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.ClientMessageReader;
 import com.hazelcast.client.impl.protocol.codec.*;
-import com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -37,7 +37,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import static com.hazelcast.client.impl.protocol.ClientMessage.END_DATA_STRUCTURE_FLAG;
 import static com.hazelcast.client.impl.protocol.ClientMessage.IS_FINAL_FLAG;
 import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.*;
 import static org.junit.Assert.assertArrayEquals;
@@ -123,37 +122,24 @@ public class MemberCompatibility{% if test_nullable %}Null{% endif %}Test_{{ '_'
 
         ClientMessage.ForwardFrameIterator binaryFrameIterator = binaryMessage.frameIterator();
         ClientMessage.ForwardFrameIterator encodedFrameIterator = encodedMessage.frameIterator();
+        assertTrue("Client message that is read from the binary file does not have any frames", binaryFrameIterator.hasNext());
 
-        boolean isInitialFramesCompared = false;
         while (binaryFrameIterator.hasNext()) {
             binaryFrame = binaryFrameIterator.next();
             encodedFrame = encodedFrameIterator.next();
             assertNotNull("Encoded client message has less frames.", encodedFrame);
 
-            boolean isFinal = binaryFrameIterator.peekNext() == null;
-            boolean isEndFrame = binaryFrame.isEndFrame();
-            if (!isInitialFramesCompared) {
-                compareInitialFrame(binaryFrame, encodedFrame, isFinal);
-                isInitialFramesCompared = true;
-            } else {
-                assertArrayEquals("Frames have different contents", binaryFrame.content, Arrays.copyOf(encodedFrame.content, binaryFrame.content.length));
-                int flags = isFinal ? encodedFrame.flags | IS_FINAL_FLAG : encodedFrame.flags;
-                flags = isEndFrame ? flags | END_DATA_STRUCTURE_FLAG : flags;
-                assertEquals("Frames have different flags", binaryFrame.flags, flags);
-                if (isEndFrame && !ClientMessage.isFlagSet(encodedFrame.flags, END_DATA_STRUCTURE_FLAG)) {
-                    CodecUtil.fastForwardToEndFrame(encodedFrameIterator);
+            if (binaryFrame.isEndFrame() && !encodedFrame.isEndFrame()) {
+                if (encodedFrame.isBeginFrame()) {
+                    HazelcastClientUtil.fastForwardToEndFrame(encodedFrameIterator);
                 }
+                encodedFrame = HazelcastClientUtil.fastForwardToEndFrame(encodedFrameIterator);
             }
-        }
-        assertTrue("Client message that is read from the binary file does not have any frames", isInitialFramesCompared);
-    }
 
-    private void compareInitialFrame(ClientMessage.Frame binaryFrame, ClientMessage.Frame encodedFrame, boolean isFinal) {
-        assertTrue("Encoded client message have shorter initial frame",
-                binaryFrame.content.length <= encodedFrame.content.length);
-        assertArrayEquals("Initial frames have different contents",
-                binaryFrame.content, Arrays.copyOf(encodedFrame.content, binaryFrame.content.length));
-        int flags = isFinal ? encodedFrame.flags | IS_FINAL_FLAG : encodedFrame.flags;
-        assertEquals("Initial frames have different flags", binaryFrame.flags, flags);
+            boolean isFinal = binaryFrameIterator.peekNext() == null;
+            int flags = isFinal ? encodedFrame.flags | IS_FINAL_FLAG : encodedFrame.flags;
+            assertArrayEquals("Frames have different contents", binaryFrame.content, Arrays.copyOf(encodedFrame.content, binaryFrame.content.length));
+            assertEquals("Frames have different flags", binaryFrame.flags, flags);
+        }
     }
 }

--- a/java/binary/member-binary-compatibility-template.j2
+++ b/java/binary/member-binary-compatibility-template.j2
@@ -19,6 +19,7 @@ package com.hazelcast.client.protocol.compatibility;
 import com.hazelcast.client.impl.protocol.ClientMessage;
 import com.hazelcast.client.impl.protocol.ClientMessageReader;
 import com.hazelcast.client.impl.protocol.codec.*;
+import com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil;
 import com.hazelcast.test.HazelcastParallelClassRunner;
 import com.hazelcast.test.annotation.ParallelJVMTest;
 import com.hazelcast.test.annotation.QuickTest;
@@ -36,12 +37,14 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
+import static com.hazelcast.client.impl.protocol.ClientMessage.END_DATA_STRUCTURE_FLAG;
 import static com.hazelcast.client.impl.protocol.ClientMessage.IS_FINAL_FLAG;
 import static com.hazelcast.client.protocol.compatibility.ReferenceObjects.*;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
@@ -61,17 +64,29 @@ public class MemberCompatibility{% if test_nullable %}Null{% endif %}Test_{{ '_'
             reader.reset();
         }
     }
+    {% set protocol_version_as_number = get_version_as_number(protocol_version) %}
     {% set counter = namespace(count=0) %}
     {% for service in services %}
     {% for method in service.methods %}
+        {% if get_version_as_number(method.since) > protocol_version_as_number %}
+            {% continue %}
+        {% endif %}
 
     @Test
     public void test_{{ service.name|capital}}{{ method.name|capital }}Codec_decodeRequest() {
         int fileClientMessageIndex = {{ counter.count }};
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
         {{ service.name|capital }}{{ method.name|capital }}Codec.RequestParameters parameters = {{ service.name|capital }}{{ method.name|capital }}Codec.decodeRequest(fromFile);
+        {% set new_request_params = new_params(method.since, method.request.params) %}
         {% for param in method.request.params %}
+            {% if get_version_as_number(param.since) > protocol_version_as_number %}
+        assertFalse(parameters.is{{ param.name|capital }}Exists);
+            {% else %}
+                {% if param in new_request_params %}
+        assertTrue(parameters.is{{ param.name|capital }}Exists);
+                {% endif %}
         assertTrue(isEqual({%if test_nullable and param.nullable %}null{% else %}{{ reference_objects_dict[param.type] }}{% endif %}, parameters.{{ param.name }}));
+            {% endif %}
         {% endfor %}
     }
     {% set counter.count = counter.count + 1 %}
@@ -86,6 +101,9 @@ public class MemberCompatibility{% if test_nullable %}Null{% endif %}Test_{{ '_'
     {% set counter.count = counter.count + 1 %}
     {% if method.events|length != 0%}
     {% for event in method.events %}
+        {% if get_version_as_number(event.since) > protocol_version_as_number %}
+            {% continue %}
+        {% endif %}
 
     @Test
     public void test_{{ service.name|capital }}{{ method.name|capital }}Codec_encode{{ event.name|capital }}Event() {
@@ -100,7 +118,7 @@ public class MemberCompatibility{% if test_nullable %}Null{% endif %}Test_{{ '_'
     {% endfor %}
     {% endfor %}
 
-     private void compareClientMessages(ClientMessage binaryMessage, ClientMessage encodedMessage) {
+    private void compareClientMessages(ClientMessage binaryMessage, ClientMessage encodedMessage) {
         ClientMessage.Frame binaryFrame, encodedFrame;
 
         ClientMessage.ForwardFrameIterator binaryFrameIterator = binaryMessage.frameIterator();
@@ -117,9 +135,12 @@ public class MemberCompatibility{% if test_nullable %}Null{% endif %}Test_{{ '_'
                 compareInitialFrame(binaryFrame, encodedFrame, isFinal);
                 isInitialFramesCompared = true;
             } else {
-                assertArrayEquals("Frames have different contents", binaryFrame.content, encodedFrame.content);
+                assertArrayEquals("Frames have different contents", binaryFrame.content, Arrays.copyOf(encodedFrame.content, binaryFrame.content.length));
                 int flags = isFinal ? encodedFrame.flags | IS_FINAL_FLAG : encodedFrame.flags;
                 assertEquals("Frames have different flags", binaryFrame.flags, flags);
+                if (ClientMessage.isFlagSet(binaryFrame.flags, END_DATA_STRUCTURE_FLAG) && !ClientMessage.isFlagSet(flags, END_DATA_STRUCTURE_FLAG)) {
+                    CodecUtil.fastForwardToEndFrame(encodedFrameIterator);
+                }
             }
         }
         assertTrue("Client message that is read from the binary file does not have any frames", isInitialFramesCompared);

--- a/java/binary/member-binary-compatibility-template.j2
+++ b/java/binary/member-binary-compatibility-template.j2
@@ -131,14 +131,16 @@ public class MemberCompatibility{% if test_nullable %}Null{% endif %}Test_{{ '_'
             assertNotNull("Encoded client message has less frames.", encodedFrame);
 
             boolean isFinal = binaryFrameIterator.peekNext() == null;
+            boolean isEndFrame = binaryFrame.isEndFrame();
             if (!isInitialFramesCompared) {
                 compareInitialFrame(binaryFrame, encodedFrame, isFinal);
                 isInitialFramesCompared = true;
             } else {
                 assertArrayEquals("Frames have different contents", binaryFrame.content, Arrays.copyOf(encodedFrame.content, binaryFrame.content.length));
                 int flags = isFinal ? encodedFrame.flags | IS_FINAL_FLAG : encodedFrame.flags;
+                flags = isEndFrame ? flags | END_DATA_STRUCTURE_FLAG : flags;
                 assertEquals("Frames have different flags", binaryFrame.flags, flags);
-                if (ClientMessage.isFlagSet(binaryFrame.flags, END_DATA_STRUCTURE_FLAG) && !ClientMessage.isFlagSet(flags, END_DATA_STRUCTURE_FLAG)) {
+                if (isEndFrame && !ClientMessage.isFlagSet(encodedFrame.flags, END_DATA_STRUCTURE_FLAG)) {
                     CodecUtil.fastForwardToEndFrame(encodedFrameIterator);
                 }
             }

--- a/java/codec-template.java.j2
+++ b/java/codec-template.java.j2
@@ -28,9 +28,6 @@
         {%- endif -%}
     {%- endif -%}
 {%- endmacro %}
-{% macro get_event_handler_statement(name, params, version=none) -%}
-handle{{ name|capital }}Event{% if version is not none %}V{{ version|string|replace('.', '_') }}{% endif %}({% for param in params %}{{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %});
-{%- endmacro %}
 {% set request_fix_sized_params = fixed_params(method.request.params) %}
 {% set request_var_sized_params = var_size_params(method.request.params) %}
 {% set request_new_params = new_params(method.since, method.request.params) %}
@@ -138,7 +135,8 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
 {% for param in request_new_params %}
 
         /**
-         * True if the {{ param.name }} exist, false otherwise.
+         * True if the {{ param.name }} is received from the client, false otherwise.
+         * If this is false, {{ param.name }} has the default value for its type.
         */
         public boolean is{{ param.name|capital }}Exists;
 {% endfor %}
@@ -214,7 +212,8 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
 {% for param in response_new_params %}
 
         /**
-         * True if the {{ param.name }} exist, false otherwise.
+         * True if the {{ param.name }} is received from the member, false otherwise.
+         * If this is false, {{ param.name }} has the default value for its type.
         */
         public boolean is{{ param.name|capital }}Exists;
 {% endfor %}
@@ -301,15 +300,7 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
             ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         {% for event in method.events%}
             if (messageType == EVENT_{{ to_upper_snake_case(event.name)}}_MESSAGE_TYPE) {
-            {% set event_versions = get_param_versions(event.since, event.params) %}
             {% set new_event_params = new_params(event.since, event.params) %}
-            {% if event_versions|length > 1 %}
-                {% for version in event_versions %}
-                    {% if not loop.first %}
-                boolean is{{ version|string|replace('.', '_') }}Event = false;
-                    {% endif %}
-                {% endfor %}
-            {% endif %}
             {% if fixed_params(event.params)|length != 0 %}
                 ClientMessage.Frame initialFrame = iterator.next();
             {% else %}
@@ -318,10 +309,11 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
             {% endif %}
             {% for param in fixed_params(event.params) %}
                 {% if param in new_event_params %}
+                boolean is{{ param.name|capital }}Exists = false;
                 {{ lang_types_encode(param.type) }} {{ param.name }} = {% if param.type == 'boolean' %}false{% elif param.type == 'UUID' %}null{% else %}0{% endif %};
                 if (initialFrame.content.length >= EVENT_{{ to_upper_snake_case(event.name)}}_{{ to_upper_snake_case(param.name) }}_FIELD_OFFSET + {{ param.type.upper() }}_SIZE_IN_BYTES) {
                     {{ param.name }} = decode{{ param.type|capital }}(initialFrame.content, EVENT_{{ to_upper_snake_case(event.name)}}_{{ to_upper_snake_case(param.name) }}_FIELD_OFFSET);
-                    is{{ param.since|string|replace('.', '_') }}Event = true;
+                    is{{ param.name|capital }}Exists = true;
                 }
                 {% else %}
                 {{ lang_types_encode(param.type) }} {{ param.name }} = decode{{ param.type|capital }}(initialFrame.content, EVENT_{{ to_upper_snake_case(event.name)}}_{{ to_upper_snake_case(param.name) }}_FIELD_OFFSET);
@@ -329,48 +321,30 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
             {% endfor %}
             {% for param in var_size_params(event.params) %}
                 {% if param in new_event_params %}
+                boolean is{{ param.name|capital }}Exists = false;
                 {{ lang_types_encode(param.type) }} {{ param.name }} = null;
                 if (iterator.hasNext()) {
                     {{ param.name }} = {{ decode_var_sized(param) }};
-                    is{{ param.since|string|replace('.', '_') }}Event = true;
+                    is{{ param.name|capital }}Exists = true;
                 }
                 {% else %}
                 {{ lang_types_encode(param.type) }} {{ param.name }} = {{ decode_var_sized(param) }};
                 {% endif %}
             {% endfor %}
-                {% if event_versions|length > 1 %}
-                    {% for version in event_versions|reverse %}
-                        {% set filtered_params = filter_new_params(event.params, version) %}
-                        {% if loop.first %}
-                if (is{{ version|string|replace('.', '_') }}Event) {
-                    {{ get_event_handler_statement(event.name, filtered_params, version) }}
-                    return;
-                }
-                        {% elif not loop.last %}
-                else if (is{{ version|string|replace('.', '_') }}Event) {
-                    {{ get_event_handler_statement(event.name, filtered_params, version) }}
-                    return;
-                }
-                        {% else %}
-                {{ get_event_handler_statement(event.name, filtered_params) }}
+                handle{{ event.name|capital }}Event({% for param in event.params %}{% if param in new_event_params %}is{{ param.name|capital }}Exists, {% endif %}{{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %});
                 return;
-                        {% endif %}
-                    {% endfor %}
-                {% else %}
-                {{ get_event_handler_statement(event.name, event.params) }}
-                return;
-                {% endif %}
             }
         {% endfor %}
             Logger.getLogger(super.getClass()).finest("Unknown message type received on event handler :" + messageType);
         }
     {% for event in method.events%}
-        {% set event_versions = get_param_versions(event.since, event.params) %}
-        {% for version in event_versions %}
-            {% set filtered_params = filter_new_params(event.params, version) %}
+        {% set new_event_params = new_params(event.since, event.params) %}
 
         /**
-            {% for param in filtered_params %}
+            {% for param in event.params %}
+                {% if param in new_event_params %}
+         * @param is{{ param.name|capital }}Exists True if {{ param.name }} exists, false otherwise.
+                {% endif %}
          * @param {{ param.name }}
                 {%- for line in param.doc.splitlines() %}
                     {% if loop.first -%}
@@ -381,8 +355,7 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
                 {% endfor %}
             {% endfor %}
         */
-        public abstract void handle{{ event.name|capital }}Event{% if not loop.first %}V{{ version|string|replace('.', '_') }}{% endif %}({% for param in filtered_params %}{% if param.nullable  %}@Nullable {% endif %}{{ lang_types_encode(param.type) }} {{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %});
-        {% endfor %}
+        public abstract void handle{{ event.name|capital }}Event({% for param in event.params %}{% if param.nullable  %}@Nullable {% endif %}{% if param in new_event_params %}boolean is{{ param.name|capital }}Exists, {% endif %}{{ lang_types_encode(param.type) }} {{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %});
     {% endfor %}
     }
 {% endif %}

--- a/java/codec-template.java.j2
+++ b/java/codec-template.java.j2
@@ -28,6 +28,15 @@
         {%- endif -%}
     {%- endif -%}
 {%- endmacro %}
+{% macro get_event_handler_statement(name, params, version=none) -%}
+handle{{ name|capital }}Event{% if version is not none %}V{{ version|string|replace('.', '_') }}{% endif %}({% for param in params %}{{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %});
+{%- endmacro %}
+{% set request_fix_sized_params = fixed_params(method.request.params) %}
+{% set request_var_sized_params = var_size_params(method.request.params) %}
+{% set request_new_params = new_params(method.since, method.request.params) %}
+{% set response_fix_sized_params = fixed_params(method.response.params) %}
+{% set response_var_sized_params = var_size_params(method.response.params) %}
+{% set response_new_params = new_params(method.since, method.response.params) %}
 /*
  * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
  *
@@ -82,27 +91,27 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
     //hex: {{ '0x%06X'|format(method.response.id) }}
     public static final int RESPONSE_MESSAGE_TYPE = {{ method.response.id }};
 {#FIXED SIZED PARAMETER OFFSET CONSTANTS#}
-{% for param in fixed_params(method.request.params) %}
-    private static final int REQUEST_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET = {% if loop.first %}PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES{% else %}REQUEST_{{ to_upper_snake_case(loop.previtem.name)}}_FIELD_OFFSET + {{loop.previtem.type.upper()}}_SIZE_IN_BYTES{% endif %};
+{% for param in request_fix_sized_params %}
+    private static final int REQUEST_{{ to_upper_snake_case(param.name) }}_FIELD_OFFSET = {% if loop.first %}PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES{% else %}REQUEST_{{ to_upper_snake_case(loop.previtem.name)}}_FIELD_OFFSET + {{ loop.previtem.type.upper() }}_SIZE_IN_BYTES{% endif %};
     {% if loop.last %}
-    private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET + {{param.type.upper()}}_SIZE_IN_BYTES;
+    private static final int REQUEST_INITIAL_FRAME_SIZE = REQUEST_{{ to_upper_snake_case(param.name) }}_FIELD_OFFSET + {{ param.type.upper() }}_SIZE_IN_BYTES;
     {% endif %}
 {% else %}
     private static final int REQUEST_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
 {% endfor %}
-{% for param in fixed_params(method.response.params) %}
-    private static final int RESPONSE_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET = {% if loop.first %}RESPONSE_BACKUP_ACKS_FIELD_OFFSET + BYTE_SIZE_IN_BYTES{% else %}RESPONSE_{{ to_upper_snake_case(loop.previtem.name)}}_FIELD_OFFSET + {{loop.previtem.type.upper()}}_SIZE_IN_BYTES{% endif %};
+{% for param in response_fix_sized_params %}
+    private static final int RESPONSE_{{ to_upper_snake_case(param.name) }}_FIELD_OFFSET = {% if loop.first %}RESPONSE_BACKUP_ACKS_FIELD_OFFSET + BYTE_SIZE_IN_BYTES{% else %}RESPONSE_{{ to_upper_snake_case(loop.previtem.name)}}_FIELD_OFFSET + {{ loop.previtem.type.upper() }}_SIZE_IN_BYTES{% endif %};
     {% if loop.last %}
-    private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET + {{param.type.upper()}}_SIZE_IN_BYTES;
+    private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_{{ to_upper_snake_case(param.name) }}_FIELD_OFFSET + {{ param.type.upper() }}_SIZE_IN_BYTES;
     {% endif %}
 {% else %}
     private static final int RESPONSE_INITIAL_FRAME_SIZE = RESPONSE_BACKUP_ACKS_FIELD_OFFSET + BYTE_SIZE_IN_BYTES;
 {% endfor %}
 {% for event in method.events%}
     {% for param in fixed_params(event.params) %}
-    private static final int EVENT_{{ to_upper_snake_case(event.name)}}_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET = {% if loop.first %}PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES{% else %}EVENT_{{ to_upper_snake_case(event.name)}}_{{ to_upper_snake_case(loop.previtem.name)}}_FIELD_OFFSET + {{loop.previtem.type.upper()}}_SIZE_IN_BYTES{% endif %};
+    private static final int EVENT_{{ to_upper_snake_case(event.name)}}_{{ to_upper_snake_case(param.name) }}_FIELD_OFFSET = {% if loop.first %}PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES{% else %}EVENT_{{ to_upper_snake_case(event.name)}}_{{ to_upper_snake_case(loop.previtem.name)}}_FIELD_OFFSET + {{ loop.previtem.type.upper() }}_SIZE_IN_BYTES{% endif %};
     {% if loop.last %}
-    private static final int EVENT_{{ to_upper_snake_case(event.name)}}_INITIAL_FRAME_SIZE = EVENT_{{ to_upper_snake_case(event.name)}}_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET + {{param.type.upper()}}_SIZE_IN_BYTES;
+    private static final int EVENT_{{ to_upper_snake_case(event.name)}}_INITIAL_FRAME_SIZE = EVENT_{{ to_upper_snake_case(event.name)}}_{{ to_upper_snake_case(param.name) }}_FIELD_OFFSET + {{ param.type.upper() }}_SIZE_IN_BYTES;
     {% endif %}
     {% else %}
     private static final int EVENT_{{ to_upper_snake_case(event.name)}}_INITIAL_FRAME_SIZE = PARTITION_ID_FIELD_OFFSET + INT_SIZE_IN_BYTES;
@@ -117,30 +126,37 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
 {#REQUEST PARAMETERS#}
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class RequestParameters {
-    {% for param in method.request.params %}
+{% for param in method.request.params %}
 
         /**
-        {% for line in param.doc.splitlines() %}
+    {% for line in param.doc.splitlines() %}
          * {{ line }}
-        {% endfor %}
+    {% endfor %}
          */
         public {% if param.nullable  %}@Nullable {% endif %}{{ lang_types_decode(param.type) }} {{ param.name }};
-    {% endfor %}
+{% endfor %}
+{% for param in request_new_params %}
+
+        /**
+         * True if the {{ param.name }} exist, false otherwise.
+        */
+        public boolean is{{ param.name|capital }}Exists;
+{% endfor %}
     }
 
 {#REQUEST_ENCODE#}
-    public static ClientMessage encodeRequest({% for param in method.request.params %}{% if param.nullable  %}@Nullable {% endif %}{{ lang_types_encode(param.type) }} {{param.name}}{% if not loop.last %}, {% endif %}{% endfor %}) {
+    public static ClientMessage encodeRequest({% for param in method.request.params %}{% if param.nullable  %}@Nullable {% endif %}{{ lang_types_encode(param.type) }} {{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %}) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         clientMessage.setRetryable({{ method.request.retryable|lower }});
         clientMessage.setOperationName("{{ service_name|capital }}.{{ method.name|capital }}");
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[REQUEST_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);
         encodeInt(initialFrame.content, TYPE_FIELD_OFFSET, REQUEST_MESSAGE_TYPE);
         encodeInt(initialFrame.content, PARTITION_ID_FIELD_OFFSET, -1);
-    {% for param in fixed_params(method.request.params) %}
-        encode{{ param.type|capital }}(initialFrame.content, REQUEST_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET, {{ param.name }});
+    {% for param in request_fix_sized_params %}
+        encode{{ param.type|capital }}(initialFrame.content, REQUEST_{{ to_upper_snake_case(param.name) }}_FIELD_OFFSET, {{ param.name }});
     {% endfor %}
         clientMessage.add(initialFrame);
-    {% for param in var_size_params(method.request.params) %}
+    {% for param in request_var_sized_params %}
         {{ encode_var_sized(param) }};
     {% endfor %}
         return clientMessage;
@@ -150,17 +166,35 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
     public static {{ service_name|capital }}{{ method.name|capital }}Codec.RequestParameters decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         RequestParameters request = new RequestParameters();
-    {% if  fixed_params(method.request.params)|length != 0 %}
+    {% if request_fix_sized_params|length != 0 %}
         ClientMessage.Frame initialFrame = iterator.next();
     {% else %}
         //empty initial frame
         iterator.next();
     {% endif %}
-    {% for param in fixed_params(method.request.params) %}
-        request.{{ param.name }} = decode{{ param.type|capital }}(initialFrame.content, REQUEST_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET);
+    {% for param in request_fix_sized_params %}
+        {% if param in request_new_params %}
+        if (initialFrame.content.length >= REQUEST_{{ to_upper_snake_case(param.name) }}_FIELD_OFFSET + {{ param.type.upper() }}_SIZE_IN_BYTES) {
+            request.{{ param.name }} = decode{{ param.type|capital }}(initialFrame.content, REQUEST_{{ to_upper_snake_case(param.name) }}_FIELD_OFFSET);
+            request.is{{ param.name|capital }}Exists = true;
+        } else {
+            request.is{{ param.name|capital }}Exists = false;
+        }
+        {% else %}
+        request.{{ param.name }} = decode{{ param.type|capital }}(initialFrame.content, REQUEST_{{ to_upper_snake_case(param.name) }}_FIELD_OFFSET);
+        {% endif %}
     {% endfor %}
-    {% for param in var_size_params(method.request.params) %}
+    {% for param in request_var_sized_params %}
+        {% if param in request_new_params %}
+        if (iterator.hasNext()) {
+            request.{{ param.name }} = {{ decode_var_sized(param) }};
+            request.is{{ param.name|capital }}Exists = true;
+        } else {
+            request.is{{ param.name|capital }}Exists = false;
+        }
+        {% else %}
         request.{{ param.name }} = {{ decode_var_sized(param) }};
+        {% endif %}
     {% endfor %}
         return request;
     }
@@ -177,19 +211,26 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
          */
         public {% if param.nullable  %}@Nullable {% endif %}{{ lang_types_decode(param.type) }} {{ param.name }};
 {% endfor %}
+{% for param in response_new_params %}
+
+        /**
+         * True if the {{ param.name }} exist, false otherwise.
+        */
+        public boolean is{{ param.name|capital }}Exists;
+{% endfor %}
     }
 
 {#RESPONSE ENCODE#}
-    public static ClientMessage encodeResponse({% for param in method.response.params %}{% if param.nullable  %}@Nullable {% endif %}{{ lang_types_encode(param.type) }} {{param.name}}{% if not loop.last %}, {% endif %}{% endfor %}) {
+    public static ClientMessage encodeResponse({% for param in method.response.params %}{% if param.nullable  %}@Nullable {% endif %}{{ lang_types_encode(param.type) }} {{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %}) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[RESPONSE_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);
         encodeInt(initialFrame.content, TYPE_FIELD_OFFSET, RESPONSE_MESSAGE_TYPE);
-    {% for param in fixed_params(method.response.params) %}
-        encode{{ param.type|capital }}(initialFrame.content, RESPONSE_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET, {{ param.name }});
+    {% for param in response_fix_sized_params %}
+        encode{{ param.type|capital }}(initialFrame.content, RESPONSE_{{ to_upper_snake_case(param.name) }}_FIELD_OFFSET, {{ param.name }});
     {% endfor %}
         clientMessage.add(initialFrame);
 
-    {% for param in var_size_params(method.response.params) %}
+    {% for param in response_var_sized_params %}
         {{ encode_var_sized(param) }};
     {% endfor %}
         return clientMessage;
@@ -199,17 +240,35 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
     public static {{ service_name|capital }}{{ method.name|capital }}Codec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
-        {% if  fixed_params(method.response.params)|length != 0 %}
+        {% if response_fix_sized_params|length != 0 %}
         ClientMessage.Frame initialFrame = iterator.next();
         {% else %}
         //empty initial frame
         iterator.next();
         {% endif %}
-    {% for param in fixed_params(method.response.params) %}
-        response.{{ param.name }} = decode{{ param.type|capital }}(initialFrame.content, RESPONSE_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET);
+    {% for param in response_fix_sized_params %}
+        {% if param in response_new_params %}
+        if (initialFrame.content.length >= RESPONSE_{{ to_upper_snake_case(param.name) }}_FIELD_OFFSET + {{ param.type.upper() }}_SIZE_IN_BYTES) {
+            response.{{ param.name }} = decode{{ param.type|capital }}(initialFrame.content, RESPONSE_{{ to_upper_snake_case(param.name) }}_FIELD_OFFSET);
+            response.is{{ param.name|capital }}Exists = true;
+        } else {
+            response.is{{ param.name|capital }}Exists = false;
+        }
+        {% else %}
+        response.{{ param.name }} = decode{{ param.type|capital }}(initialFrame.content, RESPONSE_{{ to_upper_snake_case(param.name) }}_FIELD_OFFSET);
+        {% endif %}
     {% endfor %}
-    {% for param in var_size_params(method.response.params) %}
+    {% for param in response_var_sized_params %}
+        {% if param in response_new_params %}
+        if (iterator.hasNext()) {
+            response.{{ param.name }} = {{ decode_var_sized(param) }};
+            response.is{{ param.name|capital }}Exists = true;
+        } else {
+            response.is{{ param.name|capital }}Exists = false;
+        }
+        {% else %}
         response.{{ param.name }} = {{ decode_var_sized(param) }};
+        {% endif %}
     {% endfor %}
         return response;
     }
@@ -217,14 +276,14 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
 {# EVENTS#}
 {% if method.events|length != 0 %}
 {% for event in method.events%}
-    public static ClientMessage encode{{ event.name|capital }}Event({% for param in event.params %}{% if param.nullable  %}@Nullable {% endif %}{{ lang_types_encode(param.type) }} {{param.name}}{% if not loop.last %}, {% endif %}{% endfor %}) {
+    public static ClientMessage encode{{ event.name|capital }}Event({% for param in event.params %}{% if param.nullable  %}@Nullable {% endif %}{{ lang_types_encode(param.type) }} {{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %}) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[EVENT_{{ to_upper_snake_case(event.name)}}_INITIAL_FRAME_SIZE], UNFRAGMENTED_MESSAGE);
         initialFrame.flags |= ClientMessage.IS_EVENT_FLAG;
         encodeInt(initialFrame.content, TYPE_FIELD_OFFSET, EVENT_{{ to_upper_snake_case(event.name)}}_MESSAGE_TYPE);
         encodeInt(initialFrame.content, PARTITION_ID_FIELD_OFFSET, -1);
     {% for param in fixed_params(event.params) %}
-        encode{{ param.type|capital }}(initialFrame.content, EVENT_{{ to_upper_snake_case(event.name)}}_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET, {{ param.name }});
+        encode{{ param.type|capital }}(initialFrame.content, EVENT_{{ to_upper_snake_case(event.name)}}_{{ to_upper_snake_case(param.name) }}_FIELD_OFFSET, {{ param.name }});
     {% endfor %}
         clientMessage.add(initialFrame);
 
@@ -233,7 +292,7 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
     {% endfor %}
         return clientMessage;
     }
-    {% endfor %}
+{% endfor %}
 
     public abstract static class AbstractEventHandler {
 
@@ -242,39 +301,88 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
             ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         {% for event in method.events%}
             if (messageType == EVENT_{{ to_upper_snake_case(event.name)}}_MESSAGE_TYPE) {
-            {% if  fixed_params(event.params)|length != 0 %}
+            {% set event_versions = get_param_versions(event.since, event.params) %}
+            {% set new_event_params = new_params(event.since, event.params) %}
+            {% if event_versions|length > 1 %}
+                {% for version in event_versions %}
+                    {% if not loop.first %}
+                boolean is{{ version|string|replace('.', '_') }}Event = false;
+                    {% endif %}
+                {% endfor %}
+            {% endif %}
+            {% if fixed_params(event.params)|length != 0 %}
                 ClientMessage.Frame initialFrame = iterator.next();
             {% else %}
                 //empty initial frame
                 iterator.next();
             {% endif %}
             {% for param in fixed_params(event.params) %}
-                {{ lang_types_encode(param.type) }} {{param.name}} = decode{{ param.type|capital }}(initialFrame.content, EVENT_{{ to_upper_snake_case(event.name)}}_{{to_upper_snake_case(param.name)}}_FIELD_OFFSET);
+                {% if param in new_event_params %}
+                {{ lang_types_encode(param.type) }} {{ param.name }} = {% if param.type == 'boolean' %}false{% elif param.type == 'UUID' %}null{% else %}0{% endif %};
+                if (initialFrame.content.length >= EVENT_{{ to_upper_snake_case(event.name)}}_{{ to_upper_snake_case(param.name) }}_FIELD_OFFSET + {{ param.type.upper() }}_SIZE_IN_BYTES) {
+                    {{ param.name }} = decode{{ param.type|capital }}(initialFrame.content, EVENT_{{ to_upper_snake_case(event.name)}}_{{ to_upper_snake_case(param.name) }}_FIELD_OFFSET);
+                    is{{ param.since|string|replace('.', '_') }}Event = true;
+                }
+                {% else %}
+                {{ lang_types_encode(param.type) }} {{ param.name }} = decode{{ param.type|capital }}(initialFrame.content, EVENT_{{ to_upper_snake_case(event.name)}}_{{ to_upper_snake_case(param.name) }}_FIELD_OFFSET);
+                {% endif %}
             {% endfor %}
             {% for param in var_size_params(event.params) %}
-                {{ lang_types_encode(param.type) }} {{param.name}} = {{ decode_var_sized(param) }};
+                {% if param in new_event_params %}
+                {{ lang_types_encode(param.type) }} {{ param.name }} = null;
+                if (iterator.hasNext()) {
+                    {{ param.name }} = {{ decode_var_sized(param) }};
+                    is{{ param.since|string|replace('.', '_') }}Event = true;
+                }
+                {% else %}
+                {{ lang_types_encode(param.type) }} {{ param.name }} = {{ decode_var_sized(param) }};
+                {% endif %}
             {% endfor %}
-                handle{{ event.name|capital }}Event({% for param in event.params %}{{param.name}}{% if not loop.last %}, {% endif %}{% endfor %});
+                {% if event_versions|length > 1 %}
+                    {% for version in event_versions|reverse %}
+                        {% set filtered_params = filter_new_params(event.params, version) %}
+                        {% if loop.first %}
+                if (is{{ version|string|replace('.', '_') }}Event) {
+                    {{ get_event_handler_statement(event.name, filtered_params, version) }}
+                    return;
+                }
+                        {% elif not loop.last %}
+                else if (is{{ version|string|replace('.', '_') }}Event) {
+                    {{ get_event_handler_statement(event.name, filtered_params, version) }}
+                    return;
+                }
+                        {% else %}
+                {{ get_event_handler_statement(event.name, filtered_params) }}
                 return;
+                        {% endif %}
+                    {% endfor %}
+                {% else %}
+                {{ get_event_handler_statement(event.name, event.params) }}
+                return;
+                {% endif %}
             }
         {% endfor %}
             Logger.getLogger(super.getClass()).finest("Unknown message type received on event handler :" + messageType);
         }
     {% for event in method.events%}
+        {% set event_versions = get_param_versions(event.since, event.params) %}
+        {% for version in event_versions %}
+            {% set filtered_params = filter_new_params(event.params, version) %}
 
         /**
-        {% for param in event.params %}
+            {% for param in filtered_params %}
          * @param {{ param.name }}
-        {%- for line in param.doc.splitlines() %}
-        {% if loop.first -%}
+                {%- for line in param.doc.splitlines() %}
+                    {% if loop.first -%}
         {{ " %s"|format(line) }}
-        {% else %}
+                    {% else %}
          * {{ line|indent(8 + param.name|length, True) }}
-        {% endif %}
-        {% endfor %}
-        {% endfor %}
+                    {% endif %}
+                {% endfor %}
+            {% endfor %}
         */
-        public abstract void handle{{ event.name|capital }}Event({% for param in event.params %}{% if param.nullable  %}@Nullable {% endif %}{{ lang_types_encode(param.type) }} {{param.name}}{% if not loop.last %}, {% endif %}{% endfor %});
+        public abstract void handle{{ event.name|capital }}Event{% if not loop.first %}V{{ version|string|replace('.', '_') }}{% endif %}({% for param in filtered_params %}{% if param.nullable  %}@Nullable {% endif %}{{ lang_types_encode(param.type) }} {{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %});
+        {% endfor %}
     {% endfor %}
     }
 {% endif %}

--- a/java/custom-codec-template.java.j2
+++ b/java/custom-codec-template.java.j2
@@ -121,7 +121,7 @@ public final class {{ codec.name|capital }}Codec {
             {% if param in new_codec_params %}
         boolean is{{ param.name|capital }}Exists = false;
         {{ lang_types_decode(param.type) }} {{ param.name }} = null;
-        if(iterator.hasNext() && !iterator.peekNext().isEndFrame()) {
+        if(!iterator.peekNext().isEndFrame()) {
             {{ param.name }} = {{ decode_var_sized(param) }};
             is{{ param.name|capital }}Exists = true;
         }

--- a/java/custom-codec-template.java.j2
+++ b/java/custom-codec-template.java.j2
@@ -28,13 +28,6 @@
         {%- endif -%}
     {%- endif -%}
 {%- endmacro %}
-{% macro get_return_statement(params) -%}
-    {%- if codec.returnWithFactory -%}
-    return CustomTypeFactory.create{{ codec.name }}({% for param in params %}{{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %});
-    {%- else -%}
-    return new {{ lang_types_decode(codec.name) }}({% for param in params %}{{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %});
-    {%- endif -%}
-{%- endmacro %}
 /*
  * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
  *
@@ -68,7 +61,6 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 {% set fix_sized_params = fixed_params(codec.params) %}
 {% set var_sized_params = var_size_params(codec.params) %}
 {% set new_codec_params = new_params(codec.since, codec.params) %}
-{% set codec_versions = get_param_versions(codec.since, codec.params) %}
 @Generated("!codec_hash!")
 public final class {{ codec.name|capital }}Codec {
     {% for param in fix_sized_params %}
@@ -104,13 +96,6 @@ public final class {{ codec.name|capital }}Codec {
     }
 
     public static {{ lang_types_decode(codec.name) }} decode(ClientMessage.ForwardFrameIterator iterator) {
-        {% if codec_versions|length > 1 %}
-            {% for version in codec_versions %}
-                {% if not loop.first %}
-        boolean is{{ version|string|replace('.', '_') }}Response = false;
-                {% endif %}
-            {% endfor %}
-        {% endif %}
         // begin frame
         iterator.next();
         {% for param in fix_sized_params %}
@@ -119,10 +104,11 @@ public final class {{ codec.name|capital }}Codec {
         ClientMessage.Frame initialFrame = iterator.next();
         {% endif %}
         {% if param in new_codec_params %}
+        boolean is{{ param.name|capital }}Exists = false;
         {{ lang_types_decode(param.type) }} {{ param.name }} = {% if param.type == 'boolean' %}false{% elif param.type == 'UUID' %}null{% else %}0{% endif %};
         if (initialFrame.content.length >= {{ to_upper_snake_case(param.name) }}_FIELD_OFFSET + {{ param.type.upper() }}_SIZE_IN_BYTES) {
             {{ param.name }} = decode{{ param.type|capital }}(initialFrame.content, {{ to_upper_snake_case(param.name) }}_FIELD_OFFSET);
-            is{{ param.since|string|replace('.', '_') }}Response = true;
+            is{{ param.name|capital }}Exists = true;
         }
         {% else %}
         {{ lang_types_decode(param.type) }} {{ param.name }} = decode{{ param.type|capital }}(initialFrame.content, {{ to_upper_snake_case(param.name) }}_FIELD_OFFSET);
@@ -133,10 +119,11 @@ public final class {{ codec.name|capital }}Codec {
 
         {% endif %}
             {% if param in new_codec_params %}
+        boolean is{{ param.name|capital }}Exists = false;
         {{ lang_types_decode(param.type) }} {{ param.name }} = null;
-        if(iterator.hasNext()) {
+        if(iterator.hasNext() && !iterator.peekNext().isEndFrame()) {
             {{ param.name }} = {{ decode_var_sized(param) }};
-            is{{ param.since|string|replace('.', '_') }}Response = true;
+            is{{ param.name|capital }}Exists = true;
         }
             {% else %}
         {{ lang_types_decode(param.type) }} {{ param.name }} = {{ decode_var_sized(param) }};
@@ -145,23 +132,10 @@ public final class {{ codec.name|capital }}Codec {
 
         fastForwardToEndFrame(iterator);
 
-        {% if codec_versions|length > 1 %}
-            {% for version in codec_versions|reverse %}
-                {% set filtered_params = filter_new_params(codec.params, version) %}
-                {% if loop.first %}
-        if (is{{ version|string|replace('.', '_') }}Response) {
-            {{ get_return_statement(filtered_params) }}
-        }
-                {% elif not loop.last %}
-        else if (is{{ version|string|replace('.', '_') }}Response) {
-            {{ get_return_statement(filtered_params) }}
-        }
-                {% else %}
-        {{ get_return_statement(filtered_params) }}
-                {% endif %}
-            {% endfor %}
+        {% if codec.returnWithFactory %}
+        return CustomTypeFactory.create{{ codec.name }}({% for param in codec.params %}{% if param in new_codec_params %}is{{ param.name|capital }}Exists, {% endif %}{{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %});
         {% else %}
-        {{ get_return_statement(codec.params) }}
+        return new {{ lang_types_decode(codec.name) }}({% for param in codec.params %}{% if param in new_codec_params %}is{{ param.name|capital }}Exists, {% endif %}{{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %});
         {% endif %}
     }
 }

--- a/java/custom-codec-template.java.j2
+++ b/java/custom-codec-template.java.j2
@@ -61,6 +61,8 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 {% set fix_sized_params = fixed_params(codec.params) %}
 {% set var_sized_params = var_size_params(codec.params) %}
 {% set new_codec_params = new_params(codec.since, codec.params) %}
+{% set fix_sized_new_params = new_params(codec.since, fix_sized_params) %}
+{% set should_add_begin_frame = (fix_sized_params|length > fix_sized_new_params|length) or fix_sized_params|length == 0 %}
 @Generated("!codec_hash!")
 public final class {{ codec.name|capital }}Codec {
     {% for param in fix_sized_params %}
@@ -74,36 +76,43 @@ public final class {{ codec.name|capital }}Codec {
     }
 
     public static void encode(ClientMessage clientMessage, {{ lang_types_encode(codec.name) }} {{ param_name(codec.name) }}) {
+        {% if should_add_begin_frame %}
         clientMessage.add(BEGIN_FRAME.copy());
+
+        {% endif %}
         {% for param in fix_sized_params %}
         {% if loop.first %}
-
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[INITIAL_FRAME_SIZE]);
         {% endif %}
         encode{{ param.type|capital }}(initialFrame.content, {{to_upper_snake_case(param.name)}}_FIELD_OFFSET, {{ param_name(codec.name)}}.{% if param.type == 'boolean' %}is{% else %}get{% endif %}{{ param.name|capital }}());
         {% if loop.last %}
+            {% if not should_add_begin_frame %}
+        initialFrame.flags |= BEGIN_DATA_STRUCTURE_FLAG;
+            {% endif %}
         clientMessage.add(initialFrame);
+
         {% endif %}
         {% endfor %}
         {% for param in var_sized_params %}
-        {% if loop.first %}
-
-        {% endif %}
         {{ encode_var_sized(param) }};
-        {% endfor %}
+            {% if loop.last %}
 
+            {% endif %}
+        {% endfor %}
         clientMessage.add(END_FRAME.copy());
     }
 
     public static {{ lang_types_decode(codec.name) }} decode(ClientMessage.ForwardFrameIterator iterator) {
         // begin frame
+        {% if should_add_begin_frame %}
         iterator.next();
+
+        {% endif %}
         {% for param in fix_sized_params %}
         {% if loop.first %}
-
         ClientMessage.Frame initialFrame = iterator.next();
         {% endif %}
-        {% if param in new_codec_params %}
+        {% if param in fix_sized_new_params %}
         boolean is{{ param.name|capital }}Exists = false;
         {{ lang_types_decode(param.type) }} {{ param.name }} = {% if param.type == 'boolean' %}false{% elif param.type == 'UUID' %}null{% else %}0{% endif %};
         if (initialFrame.content.length >= {{ to_upper_snake_case(param.name) }}_FIELD_OFFSET + {{ param.type.upper() }}_SIZE_IN_BYTES) {
@@ -113,11 +122,11 @@ public final class {{ codec.name|capital }}Codec {
         {% else %}
         {{ lang_types_decode(param.type) }} {{ param.name }} = decode{{ param.type|capital }}(initialFrame.content, {{ to_upper_snake_case(param.name) }}_FIELD_OFFSET);
         {% endif %}
+            {% if loop.last %}
+
+            {% endif %}
         {% endfor %}
         {% for param in var_sized_params %}
-        {% if loop.first %}
-
-        {% endif %}
             {% if param in new_codec_params %}
         boolean is{{ param.name|capital }}Exists = false;
         {{ lang_types_decode(param.type) }} {{ param.name }} = null;
@@ -128,8 +137,10 @@ public final class {{ codec.name|capital }}Codec {
             {% else %}
         {{ lang_types_decode(param.type) }} {{ param.name }} = {{ decode_var_sized(param) }};
             {% endif %}
-        {% endfor %}
+            {% if loop.last %}
 
+            {% endif %}
+        {% endfor %}
         fastForwardToEndFrame(iterator);
 
         {% if codec.returnWithFactory %}

--- a/java/custom-codec-template.java.j2
+++ b/java/custom-codec-template.java.j2
@@ -28,6 +28,13 @@
         {%- endif -%}
     {%- endif -%}
 {%- endmacro %}
+{% macro get_return_statement(params) -%}
+    {%- if codec.returnWithFactory -%}
+    return CustomTypeFactory.create{{ codec.name }}({% for param in params %}{{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %});
+    {%- else -%}
+    return new {{ lang_types_decode(codec.name) }}({% for param in params %}{{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %});
+    {%- endif -%}
+{%- endmacro %}
 /*
  * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
  *
@@ -58,9 +65,13 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.CodecUtil.fastFor
 import static com.hazelcast.client.impl.protocol.ClientMessage.*;
 import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCodec.*;
 
+{% set fix_sized_params = fixed_params(codec.params) %}
+{% set var_sized_params = var_size_params(codec.params) %}
+{% set new_codec_params = new_params(codec.since, codec.params) %}
+{% set codec_versions = get_param_versions(codec.since, codec.params) %}
 @Generated("!codec_hash!")
 public final class {{ codec.name|capital }}Codec {
-    {% for param in fixed_params(codec.params) %}
+    {% for param in fix_sized_params %}
     private static final int {{ to_upper_snake_case(param.name) }}_FIELD_OFFSET = {% if loop.first %}0{% else %}{{ to_upper_snake_case(loop.previtem.name)}}_FIELD_OFFSET + {{ loop.previtem.type.upper() }}_SIZE_IN_BYTES{% endif %};
     {% if loop.last %}
     private static final int INITIAL_FRAME_SIZE = {{to_upper_snake_case(param.name)}}_FIELD_OFFSET + {{ param.type.upper() }}_SIZE_IN_BYTES;
@@ -72,7 +83,7 @@ public final class {{ codec.name|capital }}Codec {
 
     public static void encode(ClientMessage clientMessage, {{ lang_types_encode(codec.name) }} {{ param_name(codec.name) }}) {
         clientMessage.add(BEGIN_FRAME.copy());
-        {% for param in fixed_params(codec.params) %}
+        {% for param in fix_sized_params %}
         {% if loop.first %}
 
         ClientMessage.Frame initialFrame = new ClientMessage.Frame(new byte[INITIAL_FRAME_SIZE]);
@@ -82,7 +93,7 @@ public final class {{ codec.name|capital }}Codec {
         clientMessage.add(initialFrame);
         {% endif %}
         {% endfor %}
-        {% for param in var_size_params(codec.params) %}
+        {% for param in var_sized_params %}
         {% if loop.first %}
 
         {% endif %}
@@ -93,28 +104,64 @@ public final class {{ codec.name|capital }}Codec {
     }
 
     public static {{ lang_types_decode(codec.name) }} decode(ClientMessage.ForwardFrameIterator iterator) {
+        {% if codec_versions|length > 1 %}
+            {% for version in codec_versions %}
+                {% if not loop.first %}
+        boolean is{{ version|string|replace('.', '_') }}Response = false;
+                {% endif %}
+            {% endfor %}
+        {% endif %}
         // begin frame
         iterator.next();
-        {% for param in fixed_params(codec.params) %}
+        {% for param in fix_sized_params %}
         {% if loop.first %}
 
         ClientMessage.Frame initialFrame = iterator.next();
         {% endif %}
+        {% if param in new_codec_params %}
+        {{ lang_types_decode(param.type) }} {{ param.name }} = {% if param.type == 'boolean' %}false{% elif param.type == 'UUID' %}null{% else %}0{% endif %};
+        if (initialFrame.content.length >= {{ to_upper_snake_case(param.name) }}_FIELD_OFFSET + {{ param.type.upper() }}_SIZE_IN_BYTES) {
+            {{ param.name }} = decode{{ param.type|capital }}(initialFrame.content, {{ to_upper_snake_case(param.name) }}_FIELD_OFFSET);
+            is{{ param.since|string|replace('.', '_') }}Response = true;
+        }
+        {% else %}
         {{ lang_types_decode(param.type) }} {{ param.name }} = decode{{ param.type|capital }}(initialFrame.content, {{ to_upper_snake_case(param.name) }}_FIELD_OFFSET);
+        {% endif %}
         {% endfor %}
-        {% for param in var_size_params(codec.params) %}
+        {% for param in var_sized_params %}
         {% if loop.first %}
 
         {% endif %}
+            {% if param in new_codec_params %}
+        {{ lang_types_decode(param.type) }} {{ param.name }} = null;
+        if(iterator.hasNext()) {
+            {{ param.name }} = {{ decode_var_sized(param) }};
+            is{{ param.since|string|replace('.', '_') }}Response = true;
+        }
+            {% else %}
         {{ lang_types_decode(param.type) }} {{ param.name }} = {{ decode_var_sized(param) }};
+            {% endif %}
         {% endfor %}
 
         fastForwardToEndFrame(iterator);
 
-        {% if codec.returnWithFactory %}
-        return CustomTypeFactory.create{{ codec.name }}({% for param in codec.params %}{{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %});
+        {% if codec_versions|length > 1 %}
+            {% for version in codec_versions|reverse %}
+                {% set filtered_params = filter_new_params(codec.params, version) %}
+                {% if loop.first %}
+        if (is{{ version|string|replace('.', '_') }}Response) {
+            {{ get_return_statement(filtered_params) }}
+        }
+                {% elif not loop.last %}
+        else if (is{{ version|string|replace('.', '_') }}Response) {
+            {{ get_return_statement(filtered_params) }}
+        }
+                {% else %}
+        {{ get_return_statement(filtered_params) }}
+                {% endif %}
+            {% endfor %}
         {% else %}
-        return new {{ lang_types_decode(codec.name) }}({% for param in codec.params %}{{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %});
+        {{ get_return_statement(codec.params) }}
         {% endif %}
     }
 }

--- a/protocol-definitions/Cache.yaml
+++ b/protocol-definitions/Cache.yaml
@@ -33,6 +33,7 @@ methods:
             Registration id for the registered listener.
     events:
       - name: Cache
+        since: 2.0
         params:
           - name: type
             type: int
@@ -923,6 +924,7 @@ methods:
             returns the registration id for the CachePartitionLostListener.
     events:
       - name: CachePartitionLost
+        since: 2.0
         params:
           - name: partitionId
             type: int
@@ -1074,6 +1076,7 @@ methods:
             Registration id for the registered listener.
     events:
       - name: CacheInvalidation
+        since: 2.0
         params:
           - name: name
             type: String
@@ -1106,6 +1109,7 @@ methods:
             doc: |
               Sequence number of the invalidation event.
       - name: CacheBatchInvalidation
+        since: 2.0
         params:
           - name: name
             type: String

--- a/protocol-definitions/Client.yaml
+++ b/protocol-definitions/Client.yaml
@@ -236,6 +236,7 @@ methods:
     response: {}
     events:
       - name: MembersView
+        since: 2.0
         params:
           - name: version
             type: int
@@ -251,6 +252,7 @@ methods:
               List of member infos  at the cluster associated with the given version
               params:
       - name: PartitionsView
+        since: 2.0
         params:
           - name: version
             type: int
@@ -364,6 +366,7 @@ methods:
             The listener registration id.
     events:
       - name: PartitionLost
+        since: 2.0
         params:
           - name: partitionId
             type: int
@@ -450,6 +453,7 @@ methods:
             The registration id for the distributed object listener.
     events:
       - name: DistributedObject
+        since: 2.0
         params:
           - name: name
             type: String
@@ -752,6 +756,7 @@ methods:
             Returns the registration id for the listener.
     events:
       - name: backup
+        since: 2.0
         params:
           - name: sourceInvocationCorrelationId
             type: long

--- a/protocol-definitions/ContinuousQuery.yaml
+++ b/protocol-definitions/ContinuousQuery.yaml
@@ -193,6 +193,7 @@ methods:
             Registration id for the listener.
     events:
       - name: QueryCacheSingle
+        since: 2.0
         params:
           - name: data
             type: QueryCacheEventData
@@ -201,6 +202,7 @@ methods:
             doc: |
               Data that holds the details of the event such as key, value, old value, new value and creation time.
       - name: QueryCacheBatch
+        since: 2.0
         params:
           - name: events
             type: List_QueryCacheEventData

--- a/protocol-definitions/List.yaml
+++ b/protocol-definitions/List.yaml
@@ -314,6 +314,7 @@ methods:
             Registration id for the listener.
     events:
       - name: Item
+        since: 2.0
         params:
           - name: item
             type: Data

--- a/protocol-definitions/Map.yaml
+++ b/protocol-definitions/Map.yaml
@@ -875,6 +875,7 @@ methods:
             A unique string which is used as a key to remove the listener.
     events:
       - name: Entry
+        since: 2.0
         params:
           - name: key
             type: Data
@@ -979,6 +980,7 @@ methods:
             A unique string which is used as a key to remove the listener.
     events:
       - name: Entry
+        since: 2.0
         params:
           - name: key
             type: Data
@@ -1082,6 +1084,7 @@ methods:
             A unique string which is used as a key to remove the listener.
     events:
       - name: Entry
+        since: 2.0
         params:
           - name: key
             type: Data
@@ -1179,6 +1182,7 @@ methods:
             A unique string which is used as a key to remove the listener.
     events:
       - name: Entry
+        since: 2.0
         params:
           - name: key
             type: Data
@@ -1298,6 +1302,7 @@ methods:
             returns the registration id for the MapPartitionLostListener.
     events:
       - name: MapPartitionLost
+        since: 2.0
         params:
           - name: partitionId
             type: int
@@ -2443,6 +2448,7 @@ methods:
             A unique string which is used as a key to remove the listener.
     events:
       - name: IMapInvalidation
+        since: 2.0
         params:
           - name: key
             type: Data
@@ -2469,6 +2475,7 @@ methods:
             doc: |
               Sequence number of the invalidation event.
       - name: IMapBatchInvalidation
+        since: 2.0
         params:
           - name: keys
             type: List_Data

--- a/protocol-definitions/MultiMap.yaml
+++ b/protocol-definitions/MultiMap.yaml
@@ -408,6 +408,7 @@ methods:
             Returns registration id for the entry listener
     events:
       - name: Entry
+        since: 2.0
         params:
           - name: key
             type: Data
@@ -498,6 +499,7 @@ methods:
             Returns registration id for the entry listener
     events:
       - name: Entry
+        since: 2.0
         params:
           - name: key
             type: Data

--- a/protocol-definitions/Queue.yaml
+++ b/protocol-definitions/Queue.yaml
@@ -478,6 +478,7 @@ methods:
             The registration id
     events:
       - name: Item
+        since: 2.0
         params:
           - name: item
             type: Data

--- a/protocol-definitions/ReplicatedMap.yaml
+++ b/protocol-definitions/ReplicatedMap.yaml
@@ -302,6 +302,7 @@ methods:
             A unique string  which is used as a key to remove the listener.
     events:
       - name: Entry
+        since: 2.0
         params:
           - name: key
             type: Data
@@ -393,6 +394,7 @@ methods:
             A unique string  which is used as a key to remove the listener.
     events:
       - name: Entry
+        since: 2.0
         params:
           - name: key
             type: Data
@@ -484,6 +486,7 @@ methods:
             A unique string  which is used as a key to remove the listener.
     events:
       - name: Entry
+        since: 2.0
         params:
           - name: key
             type: Data
@@ -568,6 +571,7 @@ methods:
             A unique string  which is used as a key to remove the listener.
     events:
       - name: Entry
+        since: 2.0
         params:
           - name: key
             type: Data
@@ -762,6 +766,7 @@ methods:
             A unique string  which is used as a key to remove the listener.
     events:
       - name: Entry
+        since: 2.0
         params:
           - name: key
             type: Data

--- a/protocol-definitions/Set.yaml
+++ b/protocol-definitions/Set.yaml
@@ -323,6 +323,7 @@ methods:
             The registration id.
     events:
       - name: Item
+        since: 2.0
         params:
           - name: item
             type: Data

--- a/protocol-definitions/Topic.yaml
+++ b/protocol-definitions/Topic.yaml
@@ -55,6 +55,7 @@ methods:
             returns the registration id
     events:
       - name: Topic
+        since: 2.0
         params:
           - name: item
             type: Data

--- a/schema/custom-codec-schema.json
+++ b/schema/custom-codec-schema.json
@@ -1,15 +1,14 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "id": "https://github.com/hazelcast/hazelcast-client-protocol/blob/master/schema/custom-codec-schema.json",
   "title": "Hazelcast Client Protocol Custom Codec Definitions",
   "type": "object",
   "definitions": {
     "since": {
-      "enum": [
-        2.0,
-        2.1
-      ],
-      "default": 2.0
+      "type": ["string", "number"],
+      "minimum": 2.0,
+      "exclusiveMaximum": 3.0,
+      "pattern": "^2\\.\\d*\\.?\\d*$"
     },
     "param": {
       "type": "object",

--- a/schema/custom-codec-schema.json
+++ b/schema/custom-codec-schema.json
@@ -6,7 +6,8 @@
   "definitions": {
     "since": {
       "enum": [
-        2.0
+        2.0,
+        2.1
       ],
       "default": 2.0
     },

--- a/schema/protocol-schema.json
+++ b/schema/protocol-schema.json
@@ -1,15 +1,14 @@
 {
-  "$schema": "http://json-schema.org/schema#",
+  "$schema": "http://json-schema.org/draft-07/schema#",
   "id": "https://github.com/hazelcast/hazelcast-client-protocol/blob/master/schema/protocol-schema.json",
   "title": "Hazelcast Client Protocol Definition",
   "type": "object",
   "definitions": {
     "since": {
-      "enum": [
-        2.0,
-        2.1
-      ],
-      "default": 2.0
+      "type": ["string", "number"],
+      "minimum": 2.0,
+      "exclusiveMaximum": 3.0,
+      "pattern": "^2\\.\\d*\\.?\\d*$"
     },
     "param": {
       "type": "object",

--- a/schema/protocol-schema.json
+++ b/schema/protocol-schema.json
@@ -6,7 +6,8 @@
   "definitions": {
     "since": {
       "enum": [
-        2.0
+        2.0,
+        2.1
       ],
       "default": 2.0
     },
@@ -124,6 +125,9 @@
         "name": {
           "type": "string",
           "description": "Event name"
+        },
+        "since": {
+          "$ref": "#/definitions/since"
         },
         "params": {
           "type": "array",

--- a/util.py
+++ b/util.py
@@ -13,6 +13,10 @@ from binary import FixedLengthTypes, FixedListTypes, FixedEntryListTypes, FixedM
 from java import java_types_encode, java_types_decode
 from cs import cs_types_encode, cs_types_decode, cs_escape_keyword, cs_ignore_service_list
 
+MAJOR_VERSION_MULTIPLIER = 10000
+MINOR_VERSION_MULTIPLIER = 100
+PATCH_VERSION_MULTIPLIER = 1
+
 
 def java_name(type_name):
     return "".join([capital(part) for part in type_name.replace("(", "").replace(")", "").split("_")])
@@ -41,7 +45,7 @@ def to_upper_snake_case(camel_case_str):
 
 
 def version_to_number(major, minor, patch=0):
-    return 10000 * major * 100 * minor + patch
+    return MAJOR_VERSION_MULTIPLIER * major + MINOR_VERSION_MULTIPLIER * minor + PATCH_VERSION_MULTIPLIER * patch
 
 
 def get_version_as_number(version):
@@ -164,40 +168,110 @@ def load_services(protocol_def_dir):
     return services
 
 
-def validate_services(services, schema_path, no_id_check):
+def validate_services(services, schema_path, no_id_check, protocol_versions):
     valid = True
     with open(schema_path, 'r') as schema_file:
         schema = json.load(schema_file)
         for i in range(len(services)):
             service = services[i]
-            if not no_id_check:
-                # Validate id ordering of services.
-                service_id = service.get('id', None)
-                if i != service_id:
-                    print('Check the service id of the %s. Expected: %s, found: %s.' % (
-                        service.get('name', None), i, service_id))
-                    valid = False
-                # Validate id ordering of service methods.
-                methods = service.get('methods', [])
-                for j in range(len(methods)):
-                    method = methods[j]
-                    method_id = method.get('id', None)
-                    if (j + 1) != method_id:
-                        print('Check the method id of %s#%s. Expected: %s, found: %s' % (
-                            service.get('name', None), method.get('name', None), (j + 1), method_id))
-                        valid = False
             # Validate against the schema.
             if not validate_against_schema(service, schema):
-                valid = False
+                return False
+
+            if not no_id_check:
+                # Validate id ordering of services.
+                service_id = service['id']
+                if i != service_id:
+                    print('Check the service id of the %s. Expected: %s, found: %s.' % (
+                        service['name'], i, service_id))
+                    valid = False
+                # Validate id ordering of service methods.
+                methods = service['methods']
+                for j in range(len(methods)):
+                    method = methods[j]
+                    method_id = method['id']
+                    if (j + 1) != method_id:
+                        print('Check the method id of %s#%s. Expected: %s, found: %s' % (
+                            service['name'], method['name'], (j + 1), method_id))
+                        valid = False
+                    request_params = method['request'].get('params', [])
+                    method_name = service['name'] + "#" + method['name']
+                    if not is_parameters_ordered_and_semantically_correct(method['since'], method_name + '#request',
+                                                                          request_params, protocol_versions):
+                        valid = False
+                    response_params = method['response'].get('params', [])
+                    if not is_parameters_ordered_and_semantically_correct(method['since'], method_name + '#response',
+                                                                          response_params, protocol_versions):
+                        valid = False
+                    events = method.get('events', [])
+                    for event in events:
+                        event_params = event.get('params', [])
+                        if not is_parameters_ordered_and_semantically_correct(event['since'],
+                                                                              method_name + '#' + event['name']
+                                                                              + '#event',
+                                                                              event_params, protocol_versions):
+                            valid = False
     return valid
 
 
-def validate_custom_protocol_definitions(services, schema_path):
+def is_semantically_correct_param(version, protocol_versions):
+    is_semantically_correct = True
+    if version != protocol_versions[0]:
+        # Not 2.0
+        if version % MINOR_VERSION_MULTIPLIER == 0:
+            # Minor version
+            if (version - MINOR_VERSION_MULTIPLIER) not in protocol_versions:
+                # since is set to 2.x but 2.(x-1) is not in the protocol definitions
+                is_semantically_correct = False
+        elif version % PATCH_VERSION_MULTIPLIER == 0:
+            # Patch version
+            if (version - PATCH_VERSION_MULTIPLIER) not in protocol_versions:
+                # since is set to 2.x.y but 2.x.(y-1) is not in the protocol definitions
+                is_semantically_correct = False
+    return is_semantically_correct
+
+
+def is_parameters_ordered_and_semantically_correct(since, name, params, protocol_versions):
+    is_ordered = True
+    is_semantically_correct = True
+    version = get_version_as_number(since)
+
+    if not is_semantically_correct_param(version, protocol_versions):
+        method_or_event_name = name[:name.rindex('#')]
+        print('Check the since value of the "%s"\n'
+              'It is set to version "%s" but this protocol version does '
+              'not semantically follow other protocol versions!' % (method_or_event_name, since))
+        is_semantically_correct = False
+
+    for param in params:
+        param_version = get_version_as_number(param['since'])
+        if not is_semantically_correct_param(param_version, protocol_versions):
+            print('Check the since value of "%s" field of the "%s".\n'
+                  'It is set version "%s" but this protocol version does '
+                  'not semantically follow other protocol versions!' % (param['name'], name, param['since']))
+            is_semantically_correct = False
+
+        if version > param_version:
+            print('Check the since value of "%s" field of the "%s".\n'
+                  'Parameters should be in the increasing order of since values!' % (param['name'], name))
+            is_ordered = False
+
+        version = param_version
+    return is_ordered and is_semantically_correct
+
+
+def validate_custom_protocol_definitions(definition, schema_path, protocol_versions):
     valid = True
     with open(schema_path, 'r') as schema_file:
         schema = json.load(schema_file)
-    for service in services:
-        if not validate_against_schema(service, schema):
+    custom_types = definition[0]
+    if not validate_against_schema(custom_types, schema):
+        return False
+    for custom_type in custom_types['customTypes']:
+        params = custom_type.get('params', [])
+        if not is_parameters_ordered_and_semantically_correct(custom_type['since'],
+                                                              'CustomTypes#' + custom_type['name'],
+                                                              params, protocol_versions):
             valid = False
     return valid
 


### PR DESCRIPTION
This PR adds the ability to add new parameters, methods, custom types and events to the client protocol. 

As discussed within the team, existence (or lack of it) of the new parameters can be checked by the `isXXExists` fields/arguments of the RequestParameters, ResponseParameters, handleYYEvent methods, custom type constructor calls/factory method calls.

Also, for the custom types, the following change is made. If the custom type does not have an initial frame before (no fix sized paramters), and we extend the custom type with new fix sized parameters, those parameters are encoded into the `BEGIN_FRAME` of the custom type since adding a new initial frame would break the old readers. 