### PR TITLE
Remove unused codes from codecs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ where
     * `cpp` : C++
     * `cs` : C#
     * `py` : Python
-    * `ts` : Typescript
+    * `ts` : TypeScript
     * `go` : Go
      
 `java` is the default value if no language is specified.

--- a/ts/codec-template.ts.j2
+++ b/ts/codec-template.ts.j2
@@ -76,7 +76,7 @@
  * limitations under the License.
  */
 
-/*tslint:disable:max-line-length*/
+/* eslint-disable max-len */
 import {BitsUtil} from '../BitsUtil';
 {% if request_fix_sized_params|length != 0 or response_fix_sized_params|length != 0 or event_fix_sized_params|length != 0 %}
 import {FixSizedTypesCodec} from './builtin/FixSizedTypesCodec';

--- a/ts/codec-template.ts.j2
+++ b/ts/codec-template.ts.j2
@@ -41,7 +41,7 @@
                     {% endif %}
                 {% endfor %}
             {% endif %}
-            {% if not (is_var_sized_list(param.type) or is_var_sized_list_contains_nullable(param.type) or is_var_sized_entry_list(param.type) or is_var_sized_map(param.type)) and param.nullable and not 'CodecUtil' in imported_paths %}
+            {% if not (is_var_sized_list(param.type) or is_var_sized_list_contains_nullable(param.type) or is_var_sized_entry_list(param.type) or is_var_sized_map(param.type)) and param.nullable and param.type != 'UUID' and not 'CodecUtil' in imported_paths %}
                 {%- do imported_paths.append('CodecUtil') -%}
                 {{ get_import_path_holders('CodecUtil').get_import_statement(False) }}
             {% endif %} 
@@ -86,7 +86,7 @@ import {ClientMessage, Frame, {% if response_fix_sized_params|length != 0 %}RESP
 // hex: {{ '0x%06X'|format(method.request.id) }}
 const REQUEST_MESSAGE_TYPE = {{ method.request.id }};
 // hex: {{ '0x%06X'|format(method.response.id) }}
-const RESPONSE_MESSAGE_TYPE = {{ method.response.id }};
+// RESPONSE_MESSAGE_TYPE = {{ method.response.id }}
 {% for event in method.events%}
 // hex: {{ '0x%06X'|format(event.id) }}
 const EVENT_{{ to_upper_snake_case(event.name)}}_MESSAGE_TYPE = {{ event.id }};

--- a/ts/custom-codec-template.ts.j2
+++ b/ts/custom-codec-template.ts.j2
@@ -62,7 +62,7 @@
  * limitations under the License.
  */
 
-/*tslint:disable:max-line-length*/
+/* eslint-disable max-len */
 {% if fix_sized_params|length != 0 %}
 import {FixSizedTypesCodec} from '../builtin/FixSizedTypesCodec';
 import {BitsUtil} from '../../BitsUtil';


### PR DESCRIPTION
Our eslint config does not allows unused variables, so,
RESPONSE_PARAMS which is there for debugging purposes is converted
into a comment.

Also, since nullable UUIDs are handled inside the FixSizedTypesCodec,
there is no need to import CodecUtil in that case.

depends on #321