### PR TITLE
ProtocolType enum is removed from protocol custom types

### DIFF
--- a/binary/__init__.py
+++ b/binary/__init__.py
@@ -51,7 +51,6 @@ CustomTypes = [
     'AnchorDataListHolder',
     'PagingPredicateHolder',
     'EndpointQualifier',
-    'ProtocolType'
 ]
 
 CustomConfigTypes = [

--- a/binary/reference_objects.py
+++ b/binary/reference_objects.py
@@ -48,6 +48,9 @@ objects = {
     },
     'BitmapIndexOptions': {
         'uniqueKeyTransformation': 1
+    },
+    'EndpointQualifier': {
+        'type': 2
     }
 }
 

--- a/binary/reference_objects.py
+++ b/binary/reference_objects.py
@@ -48,9 +48,6 @@ objects = {
     },
     'BitmapIndexOptions': {
         'uniqueKeyTransformation': 1
-    },
-    'ProtocolType': {
-        'ordinal': 2
     }
 }
 

--- a/java/__init__.py
+++ b/java/__init__.py
@@ -57,7 +57,6 @@ _java_types_common = {
     "CacheSimpleEntryListenerConfig": "com.hazelcast.config.CacheSimpleEntryListenerConfig",
     "ClientBwListEntry": "com.hazelcast.internal.management.dto.ClientBwListEntryDTO",
     "EndpointQualifier": "com.hazelcast.instance.EndpointQualifier",
-    "ProtocolType": "com.hazelcast.instance.ProtocolType",
 
     "Map_String_String": "java.util.Map<java.lang.String, java.lang.String>",
     "Map_EndpointQualifier_Address": "java.util.Map<com.hazelcast.instance.EndpointQualifier, com.hazelcast.cluster.Address>"

--- a/protocol-definitions/custom/Custom.yaml
+++ b/protocol-definitions/custom/Custom.yaml
@@ -789,21 +789,13 @@ customTypes:
     since: 2.1
     params: 
       - name: type
-        type: ProtocolType
+        type: int
         nullable: false
         since: 2.1
       - name: identifier
         type: String
         since: 2.1
         nullable: true
-  - name: ProtocolType
-    returnWithFactory: true
-    since: 2.1
-    params:
-      - name: ordinal
-        type: int
-        since: 2.1
-        nullable: false
   - name: MemberVersion
     since: 2.0
     params:

--- a/schema/custom-codec-schema.json
+++ b/schema/custom-codec-schema.json
@@ -93,7 +93,6 @@
             "Map_String_String",
             "Map_EndpointQualifier_Address",
             "EndpointQualifier",
-            "ProtocolType",
             "MergePolicyConfig",
             "MemberVersion",
             "MemberInfo",


### PR DESCRIPTION
ProtocolType enum is removed from protocol custom types and handled as builtin enum handling (as int)