### PR TITLE
changing since tag of addressMap and EndpointQualifier to 2.0.1

### DIFF
--- a/protocol-definitions/custom/Custom.yaml
+++ b/protocol-definitions/custom/Custom.yaml
@@ -783,18 +783,18 @@ customTypes:
       - name: addressMap
         type: Map_EndpointQualifier_Address
         nullable: false
-        since: 2.1
+        since: 2.0.1
   - name: EndpointQualifier
     returnWithFactory: true
-    since: 2.1
+    since: 2.0.1
     params: 
       - name: type
         type: int
         nullable: false
-        since: 2.1
+        since: 2.0.1
       - name: identifier
         type: String
-        since: 2.1
+        since: 2.0.1
         nullable: true
   - name: MemberVersion
     since: 2.0


### PR DESCRIPTION
Requested in the backport PR: https://github.com/hazelcast/hazelcast-client-protocol/pull/323

comment: https://github.com/hazelcast/hazelcast-client-protocol/pull/323\#pullrequestreview-418294722