### PR TITLE
Get rid of ResponseParameters for single response

### DIFF
--- a/java/binary/client-binary-compatibility-template.j2
+++ b/java/binary/client-binary-compatibility-template.j2
@@ -85,6 +85,11 @@ public class ClientCompatibility{% if test_nullable %}Null{% endif %}Test_{{ '_'
     public void test_{{ service.name|capital }}{{ method.name|capital }}Codec_decodeResponse() {
         int fileClientMessageIndex = {{ counter.count }};
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
+        {% set singleResponseValue = method.response.params|length == 1 and response_new_params|length == 0 %}
+        {% if singleResponseValue %}
+        {% set param = method.response.params|last %}
+        assertTrue(isEqual({%if test_nullable and param.nullable %}null{% else %}{{ reference_objects_dict[param.type] }}{% endif %}, {{ service.name|capital }}{{ method.name|capital }}Codec.decodeResponse(fromFile)));
+        {% else %}
         {{ service.name|capital }}{{ method.name|capital }}Codec.ResponseParameters parameters = {{ service.name|capital }}{{ method.name|capital }}Codec.decodeResponse(fromFile);
         {% set new_response_params = new_params(method.since, method.response.params) %}
         {% for param in method.response.params %}
@@ -97,6 +102,7 @@ public class ClientCompatibility{% if test_nullable %}Null{% endif %}Test_{{ '_'
         assertTrue(isEqual({%if test_nullable and param.nullable %}null{% else %}{{ reference_objects_dict[param.type] }}{% endif %}, parameters.{{ param.name }}));
             {% endif %}
         {% endfor %}
+        {% endif %}
     }
     {% set counter.count = counter.count + 1 %}
     {% if method.events|length != 0%}
@@ -170,3 +176,5 @@ public class ClientCompatibility{% if test_nullable %}Null{% endif %}Test_{{ '_'
         }
     }
 }
+
+

--- a/java/binary/client-binary-compatibility-template.j2
+++ b/java/binary/client-binary-compatibility-template.j2
@@ -84,12 +84,15 @@ public class ClientCompatibility{% if test_nullable %}Null{% endif %}Test_{{ '_'
     @Test
     public void test_{{ service.name|capital }}{{ method.name|capital }}Codec_decodeResponse() {
         int fileClientMessageIndex = {{ counter.count }};
-        ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
+        {% set noResponseValue = method.response.params|length == 0 and response_new_params|length == 0 %}
         {% set singleResponseValue = method.response.params|length == 1 and response_new_params|length == 0 %}
-        {% if singleResponseValue %}
+        {% if noResponseValue %}
+        {% elif singleResponseValue %}
+        ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
         {% set param = method.response.params|last %}
         assertTrue(isEqual({%if test_nullable and param.nullable %}null{% else %}{{ reference_objects_dict[param.type] }}{% endif %}, {{ service.name|capital }}{{ method.name|capital }}Codec.decodeResponse(fromFile)));
         {% else %}
+        ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
         {{ service.name|capital }}{{ method.name|capital }}Codec.ResponseParameters parameters = {{ service.name|capital }}{{ method.name|capital }}Codec.decodeResponse(fromFile);
         {% set new_response_params = new_params(method.since, method.response.params) %}
         {% for param in method.response.params %}
@@ -176,5 +179,4 @@ public class ClientCompatibility{% if test_nullable %}Null{% endif %}Test_{{ '_'
         }
     }
 }
-
 

--- a/java/binary/member-binary-compatibility-template.j2
+++ b/java/binary/member-binary-compatibility-template.j2
@@ -74,12 +74,15 @@ public class MemberCompatibility{% if test_nullable %}Null{% endif %}Test_{{ '_'
     @Test
     public void test_{{ service.name|capital}}{{ method.name|capital }}Codec_decodeRequest() {
         int fileClientMessageIndex = {{ counter.count }};
-        ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
+        {% set noRequestValue = method.request.params|length == 0 and request_new_params|length == 0 %}
         {% set singleRequestValue = method.request.params|length == 1 and response_new_params|length == 0 %}
-        {% if singleRequestValue %}
+        {% if noRequestValue %}
+        {% elif singleRequestValue %}
+        ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
         {% set param = method.request.params|last %}
         assertTrue(isEqual({%if test_nullable and param.nullable %}null{% else %}{{ reference_objects_dict[param.type] }}{% endif %}, {{ service.name|capital }}{{ method.name|capital }}Codec.decodeRequest(fromFile)));
         {% else %}
+        ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
         {{ service.name|capital }}{{ method.name|capital }}Codec.RequestParameters parameters = {{ service.name|capital }}{{ method.name|capital }}Codec.decodeRequest(fromFile);
         {% set new_request_params = new_params(method.since, method.request.params) %}
         {% for param in method.request.params %}

--- a/java/binary/member-binary-compatibility-template.j2
+++ b/java/binary/member-binary-compatibility-template.j2
@@ -75,6 +75,11 @@ public class MemberCompatibility{% if test_nullable %}Null{% endif %}Test_{{ '_'
     public void test_{{ service.name|capital}}{{ method.name|capital }}Codec_decodeRequest() {
         int fileClientMessageIndex = {{ counter.count }};
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);
+        {% set singleRequestValue = method.request.params|length == 1 and response_new_params|length == 0 %}
+        {% if singleRequestValue %}
+        {% set param = method.request.params|last %}
+        assertTrue(isEqual({%if test_nullable and param.nullable %}null{% else %}{{ reference_objects_dict[param.type] }}{% endif %}, {{ service.name|capital }}{{ method.name|capital }}Codec.decodeRequest(fromFile)));
+        {% else %}
         {{ service.name|capital }}{{ method.name|capital }}Codec.RequestParameters parameters = {{ service.name|capital }}{{ method.name|capital }}Codec.decodeRequest(fromFile);
         {% set new_request_params = new_params(method.since, method.request.params) %}
         {% for param in method.request.params %}
@@ -87,6 +92,7 @@ public class MemberCompatibility{% if test_nullable %}Null{% endif %}Test_{{ '_'
         assertTrue(isEqual({%if test_nullable and param.nullable %}null{% else %}{{ reference_objects_dict[param.type] }}{% endif %}, parameters.{{ param.name }}));
             {% endif %}
         {% endfor %}
+        {% endif %}
     }
     {% set counter.count = counter.count + 1 %}
 

--- a/java/codec-template.java.j2
+++ b/java/codec-template.java.j2
@@ -198,26 +198,38 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
     }
 
 {#RESPONSE PARAMETERS#}
+{% set singleResponseValue = method.response.params|length == 1 and response_new_params|length == 0 %}
+{% if singleResponseValue %}
+    {% set param = method.response.params|last %}
+    /**
+    {% for line in param.doc.splitlines() %}
+     * {{ line }}
+    {% endfor %}
+     */
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
+    public {% if param.nullable  %}@Nullable {% endif %}{{ lang_types_decode(param.type) }} {{ param.name }};
+{% else %}
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
-{% for param in method.response.params %}
+    {% for param in method.response.params %}
+            /**
+            {% for line in param.doc.splitlines() %}
+             * {{ line }}
+            {% endfor %}
+             */
+            public {% if param.nullable  %}@Nullable {% endif %}{{ lang_types_decode(param.type) }} {{ param.name }};
+    {% endfor %}
+    {% for param in response_new_params %}
 
-        /**
-        {% for line in param.doc.splitlines() %}
-         * {{ line }}
-        {% endfor %}
-         */
-        public {% if param.nullable  %}@Nullable {% endif %}{{ lang_types_decode(param.type) }} {{ param.name }};
-{% endfor %}
-{% for param in response_new_params %}
+            /**
+             * True if the {{ param.name }} is received from the member, false otherwise.
+             * If this is false, {{ param.name }} has the default value for its type.
+            */
+            public boolean is{{ param.name|capital }}Exists;
+    {% endfor %}
 
-        /**
-         * True if the {{ param.name }} is received from the member, false otherwise.
-         * If this is false, {{ param.name }} has the default value for its type.
-        */
-        public boolean is{{ param.name|capital }}Exists;
-{% endfor %}
     }
+{% endif %}
 
 {#RESPONSE ENCODE#}
     public static ClientMessage encodeResponse({% for param in method.response.params %}{% if param.nullable  %}@Nullable {% endif %}{{ lang_types_encode(param.type) }} {{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %}) {
@@ -236,6 +248,24 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
     }
 
 {#RESPONSE DECODE#}
+{% if singleResponseValue %}
+    {% set param = method.response.params|last %}
+    public static {{ lang_types_decode(param.type) }} decodeResponse(ClientMessage clientMessage) {
+        ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
+        {% if response_fix_sized_params|length != 0 %}
+        ClientMessage.Frame initialFrame = iterator.next();
+        {% else %}
+        //empty initial frame
+        iterator.next();
+        {% endif %}
+        {% for param in response_fix_sized_params %}
+        return decode{{ param.type|capital }}(initialFrame.content, RESPONSE_{{ to_upper_snake_case(param.name) }}_FIELD_OFFSET);
+        {% endfor %}
+        {% for param in response_var_sized_params %}
+        return {{ decode_var_sized(param) }};
+        {% endfor %}
+    }
+{% else %}
     public static {{ service_name|capital }}{{ method.name|capital }}Codec.ResponseParameters decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         ResponseParameters response = new ResponseParameters();
@@ -271,6 +301,7 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
     {% endfor %}
         return response;
     }
+{% endif %}
 
 {# EVENTS#}
 {% if method.events|length != 0 %}
@@ -360,4 +391,5 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
     }
 {% endif %}
 }
+
 

--- a/java/codec-template.java.j2
+++ b/java/codec-template.java.j2
@@ -121,8 +121,10 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
     }
 
 {#REQUEST PARAMETERS#}
+{% set noRequestValue = method.request.params|length == 0 and request_new_params|length == 0 %}
 {% set singleRequestValue = method.request.params|length == 1 and request_new_params|length == 0 %}
-{% if singleRequestValue %}
+{% if noRequestValue %}
+{% elif singleRequestValue %}
     {% set param = method.request.params|last %}
     /**
     {% for line in param.doc.splitlines() %}
@@ -173,7 +175,8 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
     }
 
 {#REQUEST_DECODE#}
-{% if singleRequestValue %}
+{% if noRequestValue %}
+{% elif singleRequestValue %}
     {% set param = method.request.params|last %}
     public static {{ lang_types_decode(param.type) }} decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
@@ -229,8 +232,10 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
 {% endif %}
 
 {#RESPONSE PARAMETERS#}
+{% set noResponseValue = method.response.params|length == 0 and response_new_params|length == 0 %}
 {% set singleResponseValue = method.response.params|length == 1 and response_new_params|length == 0 %}
-{% if singleResponseValue %}
+{% if noResponseValue %}
+{% elif singleResponseValue %}
     {% set param = method.response.params|last %}
     /**
     {% for line in param.doc.splitlines() %}
@@ -279,7 +284,8 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
     }
 
 {#RESPONSE DECODE#}
-{% if singleResponseValue %}
+{% if noResponseValue %}
+{% elif singleResponseValue %}
     {% set param = method.response.params|last %}
     public static {{ lang_types_decode(param.type) }} decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
@@ -422,5 +428,4 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
     }
 {% endif %}
 }
-
 

--- a/java/codec-template.java.j2
+++ b/java/codec-template.java.j2
@@ -121,6 +121,17 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
     }
 
 {#REQUEST PARAMETERS#}
+{% set singleRequestValue = method.request.params|length == 1 and request_new_params|length == 0 %}
+{% if singleRequestValue %}
+    {% set param = method.request.params|last %}
+    /**
+    {% for line in param.doc.splitlines() %}
+     * {{ line }}
+    {% endfor %}
+     */
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
+    public {% if param.nullable  %}@Nullable {% endif %}{{ lang_types_decode(param.type) }} {{ param.name }};
+{% else %}
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class RequestParameters {
 {% for param in method.request.params %}
@@ -141,6 +152,7 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
         public boolean is{{ param.name|capital }}Exists;
 {% endfor %}
     }
+{% endif %}
 
 {#REQUEST_ENCODE#}
     public static ClientMessage encodeRequest({% for param in method.request.params %}{% if param.nullable  %}@Nullable {% endif %}{{ lang_types_encode(param.type) }} {{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %}) {
@@ -161,6 +173,24 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
     }
 
 {#REQUEST_DECODE#}
+{% if singleRequestValue %}
+    {% set param = method.request.params|last %}
+    public static {{ lang_types_decode(param.type) }} decodeRequest(ClientMessage clientMessage) {
+        ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
+        {% if request_fix_sized_params|length != 0 %}
+        ClientMessage.Frame initialFrame = iterator.next();
+        {% else %}
+        //empty initial frame
+        iterator.next();
+        {% endif %}
+        {% for param in request_fix_sized_params %}
+        return decode{{ param.type|capital }}(initialFrame.content, REQUEST_{{ to_upper_snake_case(param.name) }}_FIELD_OFFSET);
+        {% endfor %}
+        {% for param in request_var_sized_params %}
+        return {{ decode_var_sized(param) }};
+        {% endfor %}
+    }
+{% else %}
     public static {{ service_name|capital }}{{ method.name|capital }}Codec.RequestParameters decodeRequest(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         RequestParameters request = new RequestParameters();
@@ -196,6 +226,7 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
     {% endfor %}
         return request;
     }
+{% endif %}
 
 {#RESPONSE PARAMETERS#}
 {% set singleResponseValue = method.response.params|length == 1 and response_new_params|length == 0 %}

--- a/java/codec-template.java.j2
+++ b/java/codec-template.java.j2
@@ -236,14 +236,6 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
 {% set singleResponseValue = method.response.params|length == 1 and response_new_params|length == 0 %}
 {% if noResponseValue %}
 {% elif singleResponseValue %}
-    {% set param = method.response.params|last %}
-    /**
-    {% for line in param.doc.splitlines() %}
-     * {{ line }}
-    {% endfor %}
-     */
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"UUF_UNUSED_PUBLIC_OR_PROTECTED_FIELD"})
-    public {% if param.nullable  %}@Nullable {% endif %}{{ lang_types_decode(param.type) }} {{ param.name }};
 {% else %}
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
@@ -263,10 +255,8 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
         */
         public boolean is{{ param.name|capital }}Exists;
     {% endfor %}
-
     }
 {% endif %}
-
 {#RESPONSE ENCODE#}
     public static ClientMessage encodeResponse({% for param in method.response.params %}{% if param.nullable  %}@Nullable {% endif %}{{ lang_types_encode(param.type) }} {{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %}) {
         ClientMessage clientMessage = ClientMessage.createForEncode();
@@ -287,6 +277,11 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
 {% if noResponseValue %}
 {% elif singleResponseValue %}
     {% set param = method.response.params|last %}
+    /**
+    {% for line in param.doc.splitlines() %}
+    * {{ line }}
+    {% endfor %}
+    */
     public static {{ lang_types_decode(param.type) }} decodeResponse(ClientMessage clientMessage) {
         ClientMessage.ForwardFrameIterator iterator = clientMessage.frameIterator();
         {% if response_fix_sized_params|length != 0 %}

--- a/java/codec-template.java.j2
+++ b/java/codec-template.java.j2
@@ -248,20 +248,20 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
     @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
     public static class ResponseParameters {
     {% for param in method.response.params %}
-            /**
-            {% for line in param.doc.splitlines() %}
-             * {{ line }}
-            {% endfor %}
-             */
-            public {% if param.nullable  %}@Nullable {% endif %}{{ lang_types_decode(param.type) }} {{ param.name }};
+        /**
+        {% for line in param.doc.splitlines() %}
+         * {{ line }}
+        {% endfor %}
+         */
+        public {% if param.nullable  %}@Nullable {% endif %}{{ lang_types_decode(param.type) }} {{ param.name }};
     {% endfor %}
     {% for param in response_new_params %}
 
-            /**
-             * True if the {{ param.name }} is received from the member, false otherwise.
-             * If this is false, {{ param.name }} has the default value for its type.
-            */
-            public boolean is{{ param.name|capital }}Exists;
+        /**
+         * True if the {{ param.name }} is received from the member, false otherwise.
+         * If this is false, {{ param.name }} has the default value for its type.
+        */
+        public boolean is{{ param.name|capital }}Exists;
     {% endfor %}
 
     }


### PR DESCRIPTION
ClientCodec returns the parameters on a different object.
This is necessary for a multivariable response but for single
types it is an unnecessary object.

I haven’t touched the requests since it is not common to have
a single type request. And they are not critical ones.

Core pr: https://github.com/hazelcast/hazelcast/pull/17162