### PR TITLE
Mark Node.js codecs with internal tag

### DIFF
--- a/ts/__init__.py
+++ b/ts/__init__.py
@@ -70,7 +70,7 @@ class PathHolders:
     DataCodec = ImportPathHolder('DataCodec', 'builtin/DataCodec', is_builtin_codec=True)
     ByteArrayCodec = ImportPathHolder('ByteArrayCodec', 'builtin/ByteArrayCodec', is_builtin_codec=True)
     LongArrayCodec = ImportPathHolder('LongArrayCodec', 'builtin/LongArrayCodec', is_builtin_codec=True)
-    Address = ImportPathHolder('Address', 'Address')
+    Address = ImportPathHolder('AddressImpl', 'Address')
     AddressCodec = ImportPathHolder('AddressCodec', 'custom/AddressCodec', is_custom_codec=True)
     ErrorHolder = ImportPathHolder('ErrorHolder', 'protocol/ErrorHolder')
     ErrorHolderCodec = ImportPathHolder('ErrorHolderCodec', 'custom/ErrorHolderCodec', is_custom_codec=True)
@@ -183,7 +183,7 @@ _ts_types = {
     "byteArray": "Buffer",
     "String": "string",
     "Data": "Data",
-    "Address": "Address",
+    "Address": "AddressImpl",
     "ErrorHolder": "ErrorHolder",
     "StackTraceElement": "StackTraceElement",
     "SimpleEntryView": "SimpleEntryView<Data, Data>",

--- a/ts/codec-template.ts.j2
+++ b/ts/codec-template.ts.j2
@@ -112,6 +112,7 @@ const EVENT_{{ to_upper_snake_case(event.name)}}_{{to_upper_snake_case(param.nam
 {% endfor %}
 {% if method.response.params|length > 0 %}
 
+/** @internal */
 export interface {{ service_name|capital }}{{ method.name|capital }}ResponseParams {
 {% for param in method.response.params %}
     {{ param.name }}: {{ lang_types_encode(param.type) }};
@@ -122,6 +123,7 @@ export interface {{ service_name|capital }}{{ method.name|capital }}ResponsePara
 }
 {% endif %}
 
+/** @internal */
 export class {{ service_name|capital }}{{ method.name|capital }}Codec {
 {#REQUEST_ENCODE#}
     static encodeRequest({% for param in method.request.params %}{{ param.name }}: {{ lang_types_encode(param.type) }}{% if not loop.last %}, {% endif %}{% endfor %}): ClientMessage {

--- a/ts/custom-codec-template.ts.j2
+++ b/ts/custom-codec-template.ts.j2
@@ -85,6 +85,7 @@ const INITIAL_FRAME_SIZE = {{to_upper_snake_case(param.name)}}_OFFSET + BitsUtil
 
     {% endif %}
 {% endfor %}
+/** @internal */
 export class {{ codec.name|capital }}Codec {
     static encode(clientMessage: ClientMessage, {{ param_name(codec.name) }}: {{ lang_types_encode(codec.name) }}): void {
         {% if should_add_begin_frame %}


### PR DESCRIPTION
Also changes some class names

Node.js client counterpart PR: https://github.com/hazelcast/hazelcast-nodejs-client/pull/568