### PR TITLE
Fix NPE in the SQL client when null column value is passed

### DIFF
--- a/protocol-definitions/Sql.yaml
+++ b/protocol-definitions/Sql.yaml
@@ -49,7 +49,7 @@ methods:
           doc: |
             Row metadata.
         - name: rowPage
-          type: List_List_Data
+          type: List_ListCN_Data
           nullable: true
           since: 2.1
           doc: |
@@ -96,7 +96,7 @@ methods:
     response:
       params:
         - name: rowPage
-          type: List_List_Data
+          type: List_ListCN_Data
           nullable: true
           since: 2.1
           doc: |


### PR DESCRIPTION
This PR changes the SQL row data structure form List_List_Data to List_ListCN_Data to avoid NPE when a null column value is passed to the client (see https://github.com/hazelcast/hazelcast/issues/17608)