### PR TITLE
Update cpp log statement

### DIFF
--- a/cpp/codec-template.cpp.j2
+++ b/cpp/codec-template.cpp.j2
@@ -68,9 +68,11 @@
                         return;
                     }
                 {% endfor %}
-                    getLogger()->warning(
-                          "[{{ service_name.lower() }}_{{ method.name.lower() }}_handler::handle] Unknown message type (",
-                          messageType, ") received on event handler.");
+                    HZ_LOG(*getLogger(), warning,
+                        boost::str(boost::format("[{{ service_name.lower() }}_{{ method.name.lower() }}_handler::handle] "
+                                                 "Unknown message type (%1%) received on event handler.")
+                                                 % messageType)
+                    );
                 }
 
                 {% endif %}


### PR DESCRIPTION
The logging interface in the C++ client was changed with https://github.com/hazelcast/hazelcast-cpp-client/pull/638. This PR updates the logging statement in the template file.