### PR TITLE
Disable unused methods of the services for C++ codecs generation, remove the `using namespace` statements 

### DIFF
--- a/cpp/__init__.py
+++ b/cpp/__init__.py
@@ -1,5 +1,19 @@
 cpp_ignore_service_list = {"Cache", "XATransaction", "ContinuousQuery", "DurableExecutor", "CardinalityEstimator",
-                           "ScheduledExecutor", "DynamicConfig", "MC", "Sql", "CPSubsystem"}
+                           "ScheduledExecutor", "DynamicConfig", "MC", "Sql", "CPSubsystem", "Client.addPartitionLostListener",
+                           "Client.removePartitionLostListener", "Client.getDistributedObjects",
+                           "Client.addDistributedObjectListener", "Client.removeDistributedObjectListener",
+                           "Client.deployClasses", "Client.createProxies", "Client.triggerPartitionAssignment",
+                           "Map.addEntryListenerToKeyWithPredicate", "Map.addPartitionLostListener",
+                           "Map.removePartitionLostListener", "Map.loadAll", "Map.loadGivenKeys", "Map.fetchKeys",
+                           "Map.fetchEntries", "Map.aggregate", "Map.aggregateWithPredicate", "Map.project",
+                           "Map.projectWithPredicate", "Map.fetchNearCacheInvalidationMetadata", "Map.fetchWithQuery",
+                           "Map.eventJournalSubscribe", "Map.eventJournalRead", "Map.setTtl", "Map.putWithMaxIdle",
+                           "Map.putTransientWithMaxIdle", "Map.setWithMaxIdle", "Map.putIfAbsentWithMaxIdle",
+                           "MultiMap.delete", "MultiMap.putAll",
+                           "Topic.publishAll",
+                           "List.iterator", "List.listIterator",
+                           "TransactionalMap.getForUpdate", "TransactionalMap.containsValue",
+                           "TransactionalQueue.take",  "TransactionalQueue.peek", }
 
 
 def cpp_types_encode(key):
@@ -67,14 +81,14 @@ _cpp_types_common = {
     "longArray": "std::vector<int64_t>",
     "byteArray": "std::vector<byte>",
     "String": "std::string",
-    "Data": "Data",
+    "Data": "serialization::pimpl::data",
 
-    "Address": "Address",
-    "Member": "Member",
+    "Address": "address",
+    "Member": "member",
     "ErrorHolder": "Hazelcast.Client.Protocol.ErrorHolder",
     "StackTraceElement": "protocol::codec::StackTraceElement",
-    "SimpleEntryView": "map::DataEntryView",
-    "RaftGroupId": "raft_group_id",
+    "SimpleEntryView": "map::data_entry_view",
+    "RaftGroupId": "cp::raft_group_id",
     "WanReplicationRef": "NA",
     "HotRestartConfig": "NA",
     "EventJournalConfig": "NA",
@@ -105,13 +119,14 @@ _cpp_types_common = {
     "Map_String_String": "std::unordered_map<std::string, std::string>",
     "Map_EndpointQualifier_Address": "NA",
 
-    "EntryList_Address_List_Integer": "std::vector<std::pair<Address, std::vector<int32_t>>>",
+    "EntryList_Address_List_Integer": "std::vector<std::pair<address, std::vector<int32_t>>>",
     "MapIndexConfig": "NA",
 
     "SqlQueryId": "NA",
     "SqlError": "NA",
     "SqlColumnMetadata": "NA",
     "CPMember": "NA",
+    "MigrationState": "NA",
 }
 
 _cpp_types_encode = {
@@ -120,21 +135,21 @@ _cpp_types_encode = {
     "ScheduledTaskHandler": "NA",
     "Xid": "NA",
     "ClientBwListEntry": "NA",
-    "MemberInfo": "Member",
+    "MemberInfo": "member",
     "MemberVersion": "Hazelcast.Core.MemberVersion",
     "MCEvent": "NA",
     "AnchorDataListHolder": "codec::holder::anchor_data_list",
     "PagingPredicateHolder": "codec::holder::paging_predicate_holder",
 
     "List_Long": "std::vector<int64_t>",
-    "List_Member": "std::vector<Member>",
+    "List_Member": "std::vector<member>",
     "List_Integer": "std::vector<int32_t>",
     "List_UUID": "std::vector<boost::uuids::uuid>",
     "List_String": "std::vector<std::string>",
     "List_Xid": "NA",
-    "List_Data": "std::vector<Data>",
-    "ListCN_Data": "std::vector<Data>",
-    "List_MemberInfo": "std::vector<Member>",
+    "List_Data": "std::vector<serialization::pimpl::data>",
+    "ListCN_Data": "std::vector<serialization::pimpl::data>",
+    "List_MemberInfo": "std::vector<member>",
     "List_ScheduledTaskHandler": "NA",
     "List_CacheEventData": "NA",
     "List_QueryCacheConfigHolder": "NA",
@@ -157,8 +172,8 @@ _cpp_types_encode = {
     "EntryList_UUID_Long": "std::vector<std::pair<boost::uuids::uuid, int64_t>>",
     "EntryList_String_EntryList_Integer_Long": "std::vector<std::pair<std::string, std::vector<std::pair<int32_t, int64_t>>>>",
     "EntryList_UUID_List_Integer": "std::vector<std::pair<boost::uuids::uuid, std::vector<int>>>",
-    "EntryList_Data_Data": "std::vector<std::pair<Data, Data>>",
-    "EntryList_Data_List_Data": "std::vector<std::pair<Data, std::vector<Data>>>",
+    "EntryList_Data_Data": "std::vector<std::pair<serialization::pimpl::data, serialization::pimpl::data>>",
+    "EntryList_Data_List_Data": "std::vector<std::pair<serialization::pimpl::data, std::vector<serialization::pimpl::data>>>",
 }
 
 _cpp_types_decode = {
@@ -167,7 +182,7 @@ _cpp_types_decode = {
     "ScheduledTaskHandler": "NA",
     "Xid": "NA",
     "ClientBwListEntry": "NA",
-    "MemberInfo": "Member",
+    "MemberInfo": "member",
     "MemberVersion": "Hazelcast.Core.MemberVersion",
     "MCEvent": "NA",
     "AnchorDataListHolder": "codec::holder::anchor_data_list",
@@ -176,12 +191,12 @@ _cpp_types_decode = {
     "List_Long": "std::vector<int64_t>",
     "List_Integer": "std::vector<int>",
     "List_UUID": "std::vector<boost::uuids::uuid>",
-    "List_Member": "std::vector<Member>",
+    "List_Member": "std::vector<member>",
     "List_Xid": "NA",
     "List_String": "std::vector<std::string>",
-    "List_Data": "std::vector<Data>",
-    "ListCN_Data": "std::vector<Data>",
-    "List_MemberInfo": "std::vector<Member>",
+    "List_Data": "std::vector<serialization::pimpl::data>",
+    "ListCN_Data": "std::vector<serialization::pimpl::data>",
+    "List_MemberInfo": "std::vector<member>",
     "List_CacheEventData": "NA",
     "List_QueryCacheConfigHolder": "NA",
     "List_DistributedObjectInfo": "NA",
@@ -204,7 +219,7 @@ _cpp_types_decode = {
     "EntryList_UUID_Long": "std::vector<std::pair<boost::uuids::uuid, int64_t>>",
     "EntryList_String_EntryList_Integer_Long": "std::vector<std::pair<std::string, std::vector<std::pair<int32_t, int64_t>>>>",
     "EntryList_UUID_List_Integer": "std::vector<std::pair<boost::uuids::uuid, std::vector<int>>>",
-    "EntryList_Data_Data": "std::vector<std::pair<Data, Data>>"
+    "EntryList_Data_Data": "std::vector<std::pair<serialization::pimpl::data, serialization::pimpl::data>>"
 }
 
 _trivial_types = {

--- a/cpp/codec-template.cpp.j2
+++ b/cpp/codec-template.cpp.j2
@@ -1,27 +1,27 @@
 {% macro encode_var_sized(param, is_final) -%}
     {% if is_var_sized_list(param.type) or is_var_sized_list_contains_nullable(param.type) -%}
-        msg.set{% if is_var_sized_list_contains_nullable(param.type)%}ContainsNullable{% endif %}{% if param.nullable  %}Nullable{% endif %}({{ param.name }}{% if is_final %}, true{% endif %});
+        msg.set{% if is_var_sized_list_contains_nullable(param.type)%}_contains_nullable{% endif %}{% if param.nullable  %}_nullable{% endif %}({{ param.name }}{% if is_final %}, true{% endif %});
 {#
     {%- elif is_var_sized_entry_list(param.type) -%}
-        EntryListCodec.encode{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param.name }}, {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
+        EntryListCodec.encode{% if param.nullable  %}_nullable{% endif %}(clientMessage, {{ param.name }}, {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
     {%- elif is_var_sized_map(param.type) -%}
-        MapCodec.encode{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param.name }}, {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
+        MapCodec.encode{% if param.nullable  %}_nullable{% endif %}(clientMessage, {{ param.name }}, {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
 #}
     {%- else -%}
-            msg.set{% if param.nullable  %}Nullable{% endif %}({{ param.name }}{% if is_final %}, true{% endif %});
+            msg.set{% if param.nullable  %}_nullable{% endif %}({{ param.name }}{% if is_final %}, true{% endif %});
     {% endif %}
 {%- endmacro %}
 {% macro decode_var_sized(param) -%}
     {%- if is_var_sized_list(param.type) or is_var_sized_list_contains_nullable(param.type) -%}
-        auto {{ param.name }} = msg.get{% if is_var_sized_list_contains_nullable(param.type)%}ContainsNullable{% endif %}{% if param.nullable  %}Nullable{% endif %}<{{ lang_types_decode(param.type) }}>();
+        auto {{ param.name }} = msg.get{% if is_var_sized_list_contains_nullable(param.type)%}_contains_nullable{% endif %}{% if param.nullable  %}_nullable{% endif %}<{{ lang_types_decode(param.type) }}>();
 {#
     {%- elif is_var_sized_entry_list(param.type) -%}
-        EntryListCodec.decode{% if param.nullable  %}Nullable{% endif %}(iterator, {{ key_type(lang_name, param.type) }}Codec::decode, {{ value_type(lang_name, param.type) }}Codec::decode)
+        EntryListCodec.decode{% if param.nullable  %}_nullable{% endif %}(iterator, {{ key_type(lang_name, param.type) }}Codec::decode, {{ value_type(lang_name, param.type) }}Codec::decode)
     {%- elif is_var_sized_map(param.type) -%}
-        MapCodec.decode{% if param.nullable  %}Nullable{% endif %}(iterator, {{ key_type(lang_name, param.type) }}Codec::decode, {{ value_type(lang_name, param.type) }}Codec::decode)
+        MapCodec.decode{% if param.nullable  %}_nullable{% endif %}(iterator, {{ key_type(lang_name, param.type) }}Codec::decode, {{ value_type(lang_name, param.type) }}Codec::decode)
 #}
     {%- else -%}
-        auto {{ param.name }} = msg.get{% if param.nullable  %}Nullable{% endif %}<{{ lang_types_decode(param.type) }}>();
+        auto {{ param.name }} = msg.get{% if param.nullable  %}_nullable{% endif %}<{{ lang_types_decode(param.type) }}>();
     {%- endif -%}
 {%- endmacro %}
 {% set request_fix_sized_params = fixed_params(method.request.params) %}
@@ -31,11 +31,11 @@
                 ClientMessage {{ service_name.lower() }}_{{ method.name.lower() }}_encode({% for param in method.request.params %}{% if is_trivial(param.type) %}{{ lang_types_encode(param.type) }}{% else %}const {{ lang_types_encode(param.type) }} {% if param.nullable %} *{% else %} &{% endif %}{% endif %} {{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %}) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN {% for param in request_fix_sized_params %} + {{ get_size(param.type) }}{% endfor %};
                     ClientMessage msg(initial_frame_size{% if request_var_sized_params|length == 0 %}, true{% endif %});
-                    msg.setRetryable({{ method.request.retryable|lower }});
-                    msg.setOperationName("{{ service_name|capital }}.{{ method.name|capital }}");
+                    msg.set_retryable({{ method.request.retryable|lower }});
+                    msg.set_operation_name("{{ service_name|lower }}.{{ method.name|lower }}");
 
-                    msg.setMessageType(static_cast<int32_t>({{ method.request.id }}));
-                    msg.setPartitionId(-1);
+                    msg.set_message_type(static_cast<int32_t>({{ method.request.id }}));
+                    msg.set_partition_id(-1);
 
                 {% for param in request_fix_sized_params %}
                     msg.set({{ param.name }});
@@ -49,7 +49,7 @@
                 {# EVENTS#}
                 {% if method.events|length != 0 %}
                 void {{ service_name.lower() }}_{{ method.name.lower() }}_handler::handle(ClientMessage &msg) {
-                    auto messageType = msg.getMessageType();
+                    auto messageType = msg.get_message_type();
                 {% for event in method.events%}
                     if (messageType == {{ event.id }}) {
                         {% if fixed_params(event.params)|length > 0 %}
@@ -68,9 +68,9 @@
                         return;
                     }
                 {% endfor %}
-                    getLogger()->warning(
-                          "[{{ service_name.lower() }}_{{ method.name.lower() }}_handler::handle] Unknown message type (",
-                          messageType, ") received on event handler.");
+                    HZ_LOG(*get_logger(), warning, (boost::format(
+                            "[{{ service_name.lower() }}_{{ method.name.lower() }}_handler::handle] Unknown message type (%1%) received on event handler.") %
+                                                    messageType).str());
                 }
 
                 {% endif %}

--- a/cpp/header_includes.txt
+++ b/cpp/header_includes.txt
@@ -20,13 +20,7 @@
 
 #include "hazelcast/client/impl/BaseEventHandler.h"
 #include "hazelcast/client/protocol/ClientMessage.h"
-#include "hazelcast/client/serialization/pimpl/Data.h"
-
-using namespace hazelcast::client;
-using namespace hazelcast::util;
-using namespace hazelcast::client::protocol;
-using namespace hazelcast::client::serialization::pimpl;
-using namespace hazelcast::cp;
+#include "hazelcast/client/serialization/pimpl/data.h"
 
 namespace hazelcast {
     namespace client {

--- a/cpp/source_header.txt
+++ b/cpp/source_header.txt
@@ -15,7 +15,8 @@
  */
 
 #include <boost/uuid/uuid.hpp>
-#include "hazelcast/client/Member.h"
+#include "hazelcast/client/member.h"
+#include "hazelcast/logger.h"
 
 #include "codecs.h"
 


### PR DESCRIPTION
Disable unused methods of the services for C++ codecs generation. Also, removed the `using namespace` statements from codecs.