### PR TITLE
Update copyright year for Node.js client

### DIFF
--- a/ts/codec-template.ts.j2
+++ b/ts/codec-template.ts.j2
@@ -62,7 +62,7 @@
     {% endfor %}
 {% endif %}
 /*
- * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/ts/custom-codec-template.ts.j2
+++ b/ts/custom-codec-template.ts.j2
@@ -50,7 +50,7 @@
     {%- endfor -%}
 {%- endmacro %}
 /*
- * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Node.js client counterpart PR: https://github.com/hazelcast/hazelcast-nodejs-client/pull/747