### PR TITLE
Improve description for client statistics

### DIFF
--- a/protocol-definitions/Client.yaml
+++ b/protocol-definitions/Client.yaml
@@ -523,7 +523,7 @@ methods:
       The second parameter, the clientAttribute is a String that is composed of key=value pairs separated by ','. The
       following characters ('=' '.' ',' '\') should be escaped.
 
-      Please note that if any client implementation can not provide the value for a statistics, the corresponding key, value
+      Please note that if any client implementation can not provide the value for statistics, the corresponding key, value
       pair will not be presented in the statistics string. Only the ones, that the client can provide will be added.
 
       The third parameter, metrics is a compressed byte array containing all metrics recorded by the client.
@@ -548,6 +548,8 @@ methods:
       | Size of dictionary blob         |   4 bytes (int)    |
       +---------------------------------+--------------------+
       | ZLIB compressed dictionary blob |   variable size    |
+      +---------------------------------+--------------------+
+      | Number of metrics in the blob   |   4 bytes (int)    |
       +---------------------------------+--------------------+
       | ZLIB compressed metrics blob    |   variable size    |
       +---------------------------------+--------------------+
@@ -613,11 +615,12 @@ methods:
       THE METRIC BLOB
       ===============
 
-      The compressed dictionary blob is followed by the compressed metrics blob
-      with the following layout:
+      The compressed dictionary blob is followed by the number of metrics
+      (int) present in the metrics blob.
 
-      +------------------------------------------------+--------------------+
-      | Number of metrics                              |   4 bytes (int)    |
+      The number of metrics is followed by the compressed metrics blob with
+      the following layout:
+
       +------------------------------------------------+--------------------+
       | Metrics mask                                   |   1 byte           |
       +------------------------------------------------+--------------------+


### PR DESCRIPTION
Number of metrics is not a part of the compressed metrics blob (see [this line](https://github.com/hazelcast/hazelcast/blob/6fa873c3103ff5f2abb10e8cf477e01d4ca777fa/hazelcast/src/main/java/com/hazelcast/internal/metrics/impl/MetricsCompressor.java#L357)). This PR fixes this imperfection in the client statistics documentation.