### PR TITLE
Update copyright year to 2021

### DIFF
--- a/cpp/custom-codec-template.cpp.j2
+++ b/cpp/custom-codec-template.cpp.j2
@@ -12,7 +12,7 @@
     {% endif %}
 {%- endmacro %}
 /*
- * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/custom-codec-template.h.j2
+++ b/cpp/custom-codec-template.h.j2
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/header_includes.txt
+++ b/cpp/header_includes.txt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cpp/source_header.txt
+++ b/cpp/source_header.txt
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/cs/codec-template.cs.j2
+++ b/cs/codec-template.cs.j2
@@ -28,7 +28,7 @@
         {%- endif -%}
     {%- endif -%}
 {%- endmacro %}
-// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/cs/custom-codec-template.cs.j2
+++ b/cs/custom-codec-template.cs.j2
@@ -28,7 +28,7 @@
         {%- endif -%}
     {%- endif -%}
 {%- endmacro %}
-// Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+// Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/java/binary/client-binary-compatibility-template.j2
+++ b/java/binary/client-binary-compatibility-template.j2
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java/binary/member-binary-compatibility-template.j2
+++ b/java/binary/member-binary-compatibility-template.j2
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java/codec-template.java.j2
+++ b/java/codec-template.java.j2
@@ -35,7 +35,7 @@
 {% set response_var_sized_params = var_size_params(method.response.params) %}
 {% set response_new_params = new_params(method.since, method.response.params) %}
 /*
- * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java/custom-codec-template.java.j2
+++ b/java/custom-codec-template.java.j2
@@ -29,7 +29,7 @@
     {%- endif -%}
 {%- endmacro %}
 /*
- * Copyright (c) 2008-2020, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-2021, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Updated the copyright year used in codec templates for all
languages with 2021.