### PR TITLE
Add SQL-related codec support for the Python client

### DIFF
--- a/py/__init__.py
+++ b/py/__init__.py
@@ -162,7 +162,6 @@ import_paths = {
     "List_String": [PathHolders.ListMultiFrameCodec, PathHolders.StringCodec],
     "List_Data": [PathHolders.ListMultiFrameCodec, PathHolders.DataCodec],
     "ListCN_Data": [PathHolders.ListMultiFrameCodec, PathHolders.DataCodec],
-    "List_ListCN_Data": [PathHolders.ListMultiFrameCodec, PathHolders.ListCNDataCodec],
     "List_MemberInfo": [PathHolders.ListMultiFrameCodec, PathHolders.MemberInfoCodec],
     "List_DistributedObjectInfo": [PathHolders.ListMultiFrameCodec, PathHolders.DistributedObjectInfoCodec],
     "List_StackTraceElement": [PathHolders.ListMultiFrameCodec, PathHolders.StackTraceElementCodec],
@@ -237,7 +236,6 @@ _py_types = {
     "List_String",
     "List_StackTraceElement",
     "ListCN_Data",
-    "List_ListCN_Data",
     "List_SqlColumnMetadata",
 
     "EntryList_UUID_Long",

--- a/py/__init__.py
+++ b/py/__init__.py
@@ -4,7 +4,7 @@ import re
 
 def py_types_encode_decode(t):
     if t not in _py_types:
-        raise NotImplementedError("Missing type Mapping")
+        raise NotImplementedError("Missing type Mapping for %s" % t)
 
 
 _pattern1 = re.compile("(.)([A-Z][a-z]+)")
@@ -21,6 +21,15 @@ def py_param_name(type_name):
 
 def py_get_import_path_holders(param_type):
     return import_paths.get(param_type, [])
+
+
+_private_custom_types = ("SqlError", "SqlQueryId")
+
+
+def py_custom_type_name(name):
+    if name in _private_custom_types:
+        return "_" + name
+    return name
 
 
 py_ignore_service_list = {
@@ -54,7 +63,8 @@ py_ignore_service_list = {
     "Queue.drainTo",
     "ReplicatedMap.addNearCacheEntryListener",
     "ScheduledExecutor",
-    "Sql",
+    "Sql.execute_reserved",
+    "Sql.fetch_reserved",
     "Topic.publishAll",
     "TransactionalMap.containsValue",
     "XATransaction",
@@ -96,6 +106,7 @@ class PathHolders:
     ListUUIDCodec = ImportPathHolder("ListUUIDCodec", "protocol.builtin")
     ListDataCodec = ImportPathHolder("ListDataCodec", "protocol.builtin")
     ListMultiFrameCodec = ImportPathHolder("ListMultiFrameCodec", "protocol.builtin")
+    ListCNDataCodec = ImportPathHolder("ListCNDataCodec", "protocol.builtin")
     EntryListCodec = ImportPathHolder("EntryListCodec", "protocol.builtin")
     EntryListLongByteArrayCodec = ImportPathHolder("EntryListLongByteArrayCodec", "protocol.builtin")
     EntryListIntegerUUIDCodec = ImportPathHolder("EntryListIntegerUUIDCodec", "protocol.builtin")
@@ -122,6 +133,13 @@ class PathHolders:
                                               "protocol.codec.custom.endpoint_qualifier_codec")
     RaftGroupId = ImportPathHolder("RaftGroupId", "protocol")
     RaftGroupIdCodec = ImportPathHolder("RaftGroupIdCodec", "protocol.codec.custom.raft_group_id_codec")
+    SqlQueryId = ImportPathHolder("_SqlQueryId", "sql")
+    SqlQueryIdCodec = ImportPathHolder("SqlQueryIdCodec", "protocol.codec.custom.sql_query_id_codec")
+    SqlColumnMetadata = ImportPathHolder("SqlColumnMetadata", "sql")
+    SqlColumnMetadataCodec = ImportPathHolder("SqlColumnMetadataCodec", "protocol.codec.custom.sql_column_metadata_codec")
+    SqlError = ImportPathHolder("_SqlError", "sql")
+    SqlErrorCodec = ImportPathHolder("SqlErrorCodec", "protocol.codec.custom.sql_error_codec")
+    SqlPageCodec = ImportPathHolder("SqlPageCodec", "protocol.builtin")
 
 
 import_paths = {
@@ -144,9 +162,11 @@ import_paths = {
     "List_String": [PathHolders.ListMultiFrameCodec, PathHolders.StringCodec],
     "List_Data": [PathHolders.ListMultiFrameCodec, PathHolders.DataCodec],
     "ListCN_Data": [PathHolders.ListMultiFrameCodec, PathHolders.DataCodec],
+    "List_ListCN_Data": [PathHolders.ListMultiFrameCodec, PathHolders.ListCNDataCodec],
     "List_MemberInfo": [PathHolders.ListMultiFrameCodec, PathHolders.MemberInfoCodec],
     "List_DistributedObjectInfo": [PathHolders.ListMultiFrameCodec, PathHolders.DistributedObjectInfoCodec],
     "List_StackTraceElement": [PathHolders.ListMultiFrameCodec, PathHolders.StackTraceElementCodec],
+    "List_SqlColumnMetadata": [PathHolders.ListMultiFrameCodec, PathHolders.SqlColumnMetadataCodec],
     "EntryList_String_String": [PathHolders.EntryListCodec, PathHolders.StringCodec],
     "EntryList_String_byteArray": [PathHolders.EntryListCodec, PathHolders.StringCodec, PathHolders.ByteArrayCodec],
     "EntryList_Long_byteArray": [PathHolders.EntryListLongByteArrayCodec],
@@ -168,7 +188,11 @@ import_paths = {
     "PagingPredicateHolder": [PathHolders.PagingPredicateHolder, PathHolders.PagingPredicateHolderCodec],
     "EndpointQualifier": [PathHolders.EndpointQualifier, PathHolders.EndpointQualifierCodec],
     "Map_EndpointQualifier_Address": [PathHolders.MapCodec, PathHolders.EndpointQualifierCodec,
-                                      PathHolders.AddressCodec]
+                                      PathHolders.AddressCodec],
+    "SqlQueryId": [PathHolders.SqlQueryId, PathHolders.SqlQueryIdCodec],
+    "SqlColumnMetadata": [PathHolders.SqlColumnMetadata, PathHolders.SqlColumnMetadataCodec],
+    "SqlError": [PathHolders.SqlError, PathHolders.SqlErrorCodec],
+    "SqlPage": [PathHolders.SqlPageCodec],
 }
 
 _py_types = {
@@ -194,6 +218,10 @@ _py_types = {
     "RaftGroupId",
     "AnchorDataListHolder",
     "PagingPredicateHolder",
+    "SqlQueryId",
+    "SqlColumnMetadata",
+    "SqlError",
+    "SqlPage",
 
     "IndexConfig",
     "BitmapIndexOptions",
@@ -209,6 +237,8 @@ _py_types = {
     "List_String",
     "List_StackTraceElement",
     "ListCN_Data",
+    "List_ListCN_Data",
+    "List_SqlColumnMetadata",
 
     "EntryList_UUID_Long",
 

--- a/py/custom-codec-template.py.j2
+++ b/py/custom-codec-template.py.j2
@@ -135,5 +135,5 @@ class {{ codec.name }}Codec(object):
         {% for param in codec.params %}
             {% do ctor_params.append(param) %}
         {% endfor %}
-        return {{ codec.name }}({% for param in ctor_params %}{% if param in new_codec_params %}is_{{ param_name(param.name) }}_exists, {% endif %}{{ param_name(param.name) }}{% if not loop.last %}, {% endif %}{% endfor %})
+        return {{ custom_type_name(codec.name) }}({% for param in ctor_params %}{% if param in new_codec_params %}is_{{ param_name(param.name) }}_exists, {% endif %}{{ param_name(param.name) }}{% if not loop.last %}, {% endif %}{% endfor %})
 


### PR DESCRIPTION
Excluded SQL (apart from the reserved and unused ones) codecs from
the ignorelist and updated the templates with the necessary changes.

Since some classes used in custom codecs are private on the client,
an extra care was needed.