### PR TITLE
Move Jet protocol definitions to this repository

### DIFF
--- a/cpp/__init__.py
+++ b/cpp/__init__.py
@@ -1,5 +1,5 @@
 cpp_ignore_service_list = {"Cache", "XATransaction", "ContinuousQuery", "DurableExecutor", "CardinalityEstimator",
-                           "ScheduledExecutor", "DynamicConfig", "MC", "Sql", "CPSubsystem", "Client.addPartitionLostListener",
+                           "ScheduledExecutor", "DynamicConfig", "MC", "Sql", "CPSubsystem", "Jet", "Client.addPartitionLostListener",
                            "Client.removePartitionLostListener", "Client.getDistributedObjects",
                            "Client.addDistributedObjectListener", "Client.removeDistributedObjectListener",
                            "Client.deployClasses", "Client.createProxies", "Client.triggerPartitionAssignment",

--- a/cs/__init__.py
+++ b/cs/__init__.py
@@ -14,7 +14,7 @@ cs_ignore_service_list = {
     # entire services
     "MC", "Sql", "ExecutorService", "Cache", "XATransaction", "ContinuousQuery",
     "DurableExecutor", "CardinalityEstimator", "ScheduledExecutor", "DynamicConfig",
-    "FlakeIdGenerator",
+    "FlakeIdGenerator", "Jet",
     
     "CPSession", "CPSubsystem", "CPMember", "Fenced*", "CountDownLatch", "Semaphore",
     

--- a/java/binary/client-binary-compatibility-template.j2
+++ b/java/binary/client-binary-compatibility-template.j2
@@ -84,6 +84,7 @@ public class ClientCompatibility{% if test_nullable %}Null{% endif %}Test_{{ '_'
     @Test
     public void test_{{ service.name|capital }}{{ method.name|capital }}Codec_decodeResponse() {
         int fileClientMessageIndex = {{ counter.count }};
+        {% set response_new_params = new_params(method.since, method.response.params) %}
         {% set noResponseValue = method.response.params|length == 0 and response_new_params|length == 0 %}
         {% set singleResponseValue = method.response.params|length == 1 and response_new_params|length == 0 %}
         {% if noResponseValue %}

--- a/java/binary/member-binary-compatibility-template.j2
+++ b/java/binary/member-binary-compatibility-template.j2
@@ -74,8 +74,9 @@ public class MemberCompatibility{% if test_nullable %}Null{% endif %}Test_{{ '_'
     @Test
     public void test_{{ service.name|capital}}{{ method.name|capital }}Codec_decodeRequest() {
         int fileClientMessageIndex = {{ counter.count }};
+        {% set request_new_params = new_params(method.since, method.request.params) %}
         {% set noRequestValue = method.request.params|length == 0 and request_new_params|length == 0 %}
-        {% set singleRequestValue = method.request.params|length == 1 and response_new_params|length == 0 %}
+        {% set singleRequestValue = method.request.params|length == 1 and request_new_params|length == 0 %}
         {% if noRequestValue %}
         {% elif singleRequestValue %}
         ClientMessage fromFile = clientMessages.get(fileClientMessageIndex);

--- a/protocol-definitions/Jet.yaml
+++ b/protocol-definitions/Jet.yaml
@@ -1,0 +1,283 @@
+id: 254
+name: Jet
+methods:
+  - id: 1
+    name: submitJob
+    since: 2.0
+    doc: ''
+    request:
+      retryable: false
+      partitionIdentifier: -1
+      params:
+        - name: jobId
+          type: long
+          nullable: false
+          since: 2.0
+          doc: ''
+        - name: dag
+          type: Data
+          nullable: false
+          since: 2.0
+          doc: ''
+        - name: jobConfig
+          type: Data
+          nullable: true
+          since: 2.0
+          doc: ''
+        - name: isLightJob
+          type: boolean
+          nullable: false
+          since: 2.3
+          doc: ''
+    response: {}
+  - id: 2
+    name: terminateJob
+    since: 2.0
+    doc: ''
+    request:
+      retryable: false
+      partitionIdentifier: -1
+      params:
+        - name: jobId
+          type: long
+          nullable: false
+          since: 2.0
+          doc: ''
+        - name: terminateMode
+          type: int
+          nullable: false
+          since: 2.0
+          doc: ''
+        - name: lightJobCoordinator
+          type: UUID
+          nullable: true
+          since: 2.3
+          doc: ''
+    response: {}
+  - id: 3
+    name: getJobStatus
+    since: 2.0
+    doc: ''
+    request:
+      retryable: true
+      partitionIdentifier: -1
+      params:
+        - name: jobId
+          type: long
+          nullable: false
+          since: 2.0
+          doc: ''
+    response:
+      params:
+        - name: response
+          type: int
+          nullable: false
+          since: 2.0
+          doc: ''
+  - id: 4
+    name: getJobIds
+    since: 2.0
+    doc: ''
+    request:
+      retryable: true
+      partitionIdentifier: -1
+      params:
+        - name: onlyName
+          type: String
+          nullable: true
+          since: 2.3
+          doc: ''
+        - name: onlyJobId
+          type: long
+          nullable: false
+          since: 2.3
+          doc: ''
+    response:
+      params:
+        - name: response
+          type: Data
+          nullable: false
+          since: 2.3
+          doc: ''
+  - id: 5
+    name: joinSubmittedJob
+    since: 2.0
+    doc: ''
+    request:
+      retryable: true
+      partitionIdentifier: -1
+      params:
+        - name: jobId
+          type: long
+          nullable: false
+          since: 2.0
+          doc: ''
+        - name: lightJobCoordinator
+          type: UUID
+          nullable: true
+          since: 2.3
+          doc: ''
+    response: {}
+  - id: 7
+    name: getJobSubmissionTime
+    since: 2.0
+    doc: ''
+    request:
+      retryable: true
+      partitionIdentifier: -1
+      params:
+        - name: jobId
+          type: long
+          nullable: false
+          since: 2.0
+          doc: ''
+        - name: lightJobCoordinator
+          type: UUID
+          nullable: true
+          since: 2.3
+          doc: ''
+    response:
+      params:
+        - name: response
+          type: long
+          nullable: false
+          since: 2.0
+          doc: ''
+  - id: 8
+    name: getJobConfig
+    since: 2.0
+    doc: ''
+    request:
+      retryable: true
+      partitionIdentifier: -1
+      params:
+        - name: jobId
+          type: long
+          nullable: false
+          since: 2.0
+          doc: ''
+    response:
+      params:
+        - name: response
+          type: Data
+          nullable: false
+          since: 2.0
+          doc: ''
+  - id: 9
+    name: resumeJob
+    since: 2.0
+    doc: ''
+    request:
+      retryable: false
+      partitionIdentifier: -1
+      params:
+        - name: jobId
+          type: long
+          nullable: false
+          since: 2.0
+          doc: ''
+    response: {}
+  - id: 10
+    name: exportSnapshot
+    since: 2.0
+    doc: ''
+    request:
+      retryable: false
+      partitionIdentifier: -1
+      params:
+        - name: jobId
+          type: long
+          nullable: false
+          since: 2.0
+          doc: ''
+        - name: name
+          type: String
+          nullable: false
+          since: 2.0
+          doc: ''
+        - name: cancelJob
+          type: boolean
+          nullable: false
+          since: 2.0
+          doc: ''
+    response: {}
+  - id: 11
+    name: getJobSummaryList
+    since: 2.0
+    doc: ''
+    request:
+      retryable: true
+      partitionIdentifier: -1
+      params: []
+    response:
+      params:
+        - name: response
+          type: Data
+          nullable: false
+          since: 2.0
+          doc: ''
+  - id: 12
+    name: existsDistributedObject
+    since: 2.0
+    doc: ''
+    request:
+      retryable: true
+      partitionIdentifier: -1
+      params:
+        - name: serviceName
+          type: String
+          nullable: false
+          since: 2.0
+          doc: ''
+        - name: objectName
+          type: String
+          nullable: false
+          since: 2.0
+          doc: ''
+    response:
+      params:
+        - name: response
+          type: boolean
+          nullable: false
+          since: 2.0
+          doc: ''
+  - id: 13
+    name: getJobMetrics
+    since: 2.0
+    doc: ''
+    request:
+      retryable: true
+      partitionIdentifier: -1
+      params:
+        - name: jobId
+          type: long
+          nullable: false
+          since: 2.0
+          doc: ''
+    response:
+      params:
+        - name: response
+          type: Data
+          nullable: false
+          since: 2.0
+          doc: ''
+  - id: 14
+    name: getJobSuspensionCause
+    since: 2.0
+    doc: ''
+    request:
+      retryable: true
+      partitionIdentifier: -1
+      params:
+        - name: jobId
+          type: long
+          nullable: false
+          since: 2.0
+          doc: ''
+    response:
+      params:
+        - name: response
+          type: Data
+          nullable: false
+          since: 2.0
+          doc: ''

--- a/protocol-definitions/Jet.yaml
+++ b/protocol-definitions/Jet.yaml
@@ -76,7 +76,7 @@ methods:
           doc: ''
   - id: 4
     name: getJobIds
-    since: 2.3
+    since: 2.0
     doc: ''
     request:
       retryable: true

--- a/protocol-definitions/Jet.yaml
+++ b/protocol-definitions/Jet.yaml
@@ -76,7 +76,7 @@ methods:
           doc: ''
   - id: 4
     name: getJobIds
-    since: 2.0
+    since: 2.3
     doc: ''
     request:
       retryable: true

--- a/py/__init__.py
+++ b/py/__init__.py
@@ -68,6 +68,7 @@ py_ignore_service_list = {
     "Topic.publishAll",
     "TransactionalMap.containsValue",
     "XATransaction",
+    "Jet",
 }
 
 

--- a/ts/__init__.py
+++ b/ts/__init__.py
@@ -9,7 +9,7 @@ ts_reserved_keywords = {'abstract', 'await', 'boolean', 'break', 'byte', 'case',
 ts_ignore_service_list = {"MC", "ExecutorService", "TransactionalMap", "TransactionalMultiMap",
                           "TransactionalSet", "TransactionalList", "TransactionalQueue", "Cache", "XATransaction",
                           "Transaction", "ContinuousQuery", "DurableExecutor", "CardinalityEstimator",
-                          "ScheduledExecutor", "DynamicConfig", "CPSubsystem"}
+                          "ScheduledExecutor", "DynamicConfig", "CPSubsystem", "Jet"}
 
 
 def ts_types_encode(key):

--- a/util.py
+++ b/util.py
@@ -37,6 +37,8 @@ MAJOR_VERSION_MULTIPLIER = 10000
 MINOR_VERSION_MULTIPLIER = 100
 PATCH_VERSION_MULTIPLIER = 1
 
+ID_VALIDATOR_IGNORE_SET = {"Jet"}
+
 
 def java_name(type_name):
     return "".join([capital(part) for part in type_name.split("_")])
@@ -264,9 +266,9 @@ def validate_services(services, schema_path, no_id_check, protocol_versions):
             if not validate_against_schema(service, schema):
                 return False
 
-            if not no_id_check:
-                # Validate id ordering of services.
+            if not no_id_check and service["name"] not in ID_VALIDATOR_IGNORE_SET:
                 service_id = service["id"]
+                # Validate id ordering of services.
                 if i != service_id:
                     print(
                         "Check the service id of the %s. Expected: %s, found: %s."


### PR DESCRIPTION
Apart from moving the definitions, ignored Jet from id validation
checks.

Jet was once living in its repository and given an id of `254`, which
does not fit into valid id range. We could have changed the id now,
but that means we won't be able to read messages from old Jet clusters,
which we probably don't want.