### PR TITLE
Update reference objects

### DIFF
--- a/binary/reference_objects.py
+++ b/binary/reference_objects.py
@@ -54,7 +54,10 @@ objects = {
     },
     'SqlColumnMetadata': {
         'type': 1
-    }
+    },
+    'ListenerConfigHolder': {
+        'listenerType': 1
+    },
 }
 
 map_objects = {


### PR DESCRIPTION
After the recent changes, ListenerConfigHolder does not accept
out-of-range type ids for the listeners. This PR overrides
the value used in the binary files with a valid type id.