### PR TITLE
C++ codec generation fails

### DIFF
--- a/cpp/__init__.py
+++ b/cpp/__init__.py
@@ -3,6 +3,8 @@ cpp_ignore_service_list = {"Cache", "XATransaction", "ContinuousQuery", "Durable
                            "Client.removePartitionLostListener", "Client.getDistributedObjects",
                            "Client.addDistributedObjectListener", "Client.removeDistributedObjectListener",
                            "Client.deployClasses", "Client.createProxies", "Client.triggerPartitionAssignment",
+                           "Client.addMigrationListener", "Client.removeMigrationListener", "Client.sendSchema",
+                           "Client.fetchSchema", "Client.sendAllSchemas",
                            "Map.addEntryListenerToKeyWithPredicate", "Map.addPartitionLostListener",
                            "Map.removePartitionLostListener", "Map.loadAll", "Map.loadGivenKeys", "Map.fetchKeys",
                            "Map.fetchEntries", "Map.aggregate", "Map.aggregateWithPredicate", "Map.project",

--- a/generator.py
+++ b/generator.py
@@ -169,7 +169,7 @@ if lang != SupportedLanguages.MD:
     print("Generated codecs are at '%s'" % abspath(codec_output_dir))
 
 if custom_protocol_defs:
-    if lang != SupportedLanguages.MD:
+    if lang != SupportedLanguages.MD and lang != SupportedLanguages.CPP:
         custom_codec_template = env.get_template("custom-codec-template.%s.j2" % lang.value)
         relative_custom_codec_output_dir = args.out_dir or custom_codec_output_directories[lang]
         custom_codec_output_dir = join(root_dir, relative_custom_codec_output_dir)
@@ -182,7 +182,7 @@ if custom_protocol_defs:
             env,
         )
         print("Generated custom codecs are at '%s'" % custom_codec_output_dir)
-    else:
+    elif lang == SupportedLanguages.MD:
         documentation_template = env.get_template("documentation-template.j2")
         generate_documentation(
             protocol_defs,


### PR DESCRIPTION
Updated ignore list with the newly added codecs so that the C++ codec generation works again.

Do not generate custom codecs for C++.