### PR TITLE
Client Protocol: Improve default implementation of Replace All #19504

### DIFF
--- a/protocol-definitions/Map.yaml
+++ b/protocol-definitions/Map.yaml
@@ -2947,7 +2947,7 @@ methods:
     since: 2.0
     doc: |
       Replaces each entry's value with the result of invoking the given
-      function on that entry until all entries have been processed or the
+      function on that entry until all the entries have been processed or the
       function throws an exception.
     request:
       retryable: true

--- a/protocol-definitions/Map.yaml
+++ b/protocol-definitions/Map.yaml
@@ -2942,3 +2942,27 @@ methods:
           since: 2.0
           doc: |
             old value of the entry
+  - id: 72
+    name: replaceAll
+    since: 2.0
+    doc: |
+      Replaces each entry's value with the result of invoking the given
+      function on that entry until all entries have been processed or the
+      function throws an exception.
+    request:
+      retryable: true
+      partitionIdentifier: -1
+      params:
+        - name: name
+          type: String
+          nullable: false
+          since: 2.0
+          doc: |
+            name of map
+        - name: function
+          type: Data
+          nullable: false
+          since: 2.0
+          doc: |
+            the function to apply to each entry.
+    response: {}

--- a/protocol-definitions/Map.yaml
+++ b/protocol-definitions/Map.yaml
@@ -2942,27 +2942,3 @@ methods:
           since: 2.0
           doc: |
             old value of the entry
-  - id: 72
-    name: replaceAll
-    since: 2.0
-    doc: |
-      Replaces each entry's value with the result of invoking the given
-      function on that entry until all entries have been processed or the
-      function throws an exception.
-    request:
-      retryable: true
-      partitionIdentifier: -1
-      params:
-        - name: name
-          type: String
-          nullable: false
-          since: 2.0
-          doc: |
-            name of map
-        - name: function
-          type: Data
-          nullable: false
-          since: 2.0
-          doc: |
-            the function to apply to each entry.
-    response: {}

--- a/protocol-definitions/Map.yaml
+++ b/protocol-definitions/Map.yaml
@@ -2947,7 +2947,7 @@ methods:
     since: 2.0
     doc: |
       Replaces each entry's value with the result of invoking the given
-      function on that entry until all the entries have been processed or the
+      function on that entry until all entries have been processed or the
       function throws an exception.
     request:
       retryable: true


### PR DESCRIPTION
Issue Description: "In some cases, the default implementations are very inefficient (e.g. Map.replaceAll and forEach fetching all entries and iterating over them locally). This was improved on member-side as the cluster version is available and in some cases we opted for using entry processors instead.

On the client-side, the cluster version is not available which meant it ends up still using the default version. This should be improved by adding full client support for some of the default methods (some are acceptable as-is), which means changing the client protocol, adding codecs, tasks, the works."