### PR TITLE
Client Protocol Changes: Improve default implementation of Replace All #19508

### DIFF
--- a/protocol-definitions/Map.yaml
+++ b/protocol-definitions/Map.yaml
@@ -2942,3 +2942,27 @@ methods:
           since: 2.0
           doc: |
             old value of the entry
+  - id: 72
+    name: replaceAll
+    since: 2.0
+    doc: |
+      Replaces each entry's value with the result of invoking the given
+      function on that entry until all entries have been processed or the
+      function throws an exception.
+    request:
+      retryable: true
+      partitionIdentifier: -1
+      params:
+        - name: name
+          type: String
+          nullable: false
+          since: 2.0
+          doc: |
+            name of map
+        - name: function
+          type: Data
+          nullable: false
+          since: 2.0
+          doc: |
+            the function to apply to each entry.
+    response: {}

--- a/protocol-definitions/Map.yaml
+++ b/protocol-definitions/Map.yaml
@@ -2947,8 +2947,8 @@ methods:
     since: 2.4
     doc: |
       Replaces each entry's value with the result of invoking the given
-      function on that entry until all entries have been processed or the
-      function throws an exception in the targetted partition.
+      function on that entry until all entries have been processed in the targetted partition
+      or the function throws an exception.
     request:
       retryable: true
       partitionIdentifier: partitionId

--- a/protocol-definitions/Map.yaml
+++ b/protocol-definitions/Map.yaml
@@ -2944,25 +2944,25 @@ methods:
             old value of the entry
   - id: 72
     name: replaceAll
-    since: 2.0
+    since: 2.4
     doc: |
       Replaces each entry's value with the result of invoking the given
       function on that entry until all entries have been processed or the
-      function throws an exception.
+      function throws an exception in the targetted partition.
     request:
       retryable: true
-      partitionIdentifier: -1
+      partitionIdentifier: partitionId
       params:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: 2.4
           doc: |
             name of map
         - name: function
           type: Data
           nullable: false
-          since: 2.0
+          since: 2.4
           doc: |
             the function to apply to each entry.
     response: {}


### PR DESCRIPTION
Issue Description: "In some cases, the default implementations are very inefficient (e.g. Map.replaceAll and forEach fetching all entries and iterating over them locally). This was improved on member-side as the cluster version is available and in some cases we opted for using entry processors instead.

On the client-side, the cluster version is not available which meant it ends up still using the default version. This should be improved by adding full client support for some of the default methods (some are acceptable as-is), which means changing the client protocol, adding codecs, tasks, the works."