### PR TITLE
Add flag in SqlExecute to skip update stats

### DIFF
--- a/protocol-definitions/Sql.yaml
+++ b/protocol-definitions/Sql.yaml
@@ -184,6 +184,12 @@ methods:
           since: 2.2
           doc: |
             Query ID.
+        - name: skipUpdateStatistics
+          type: boolean
+          nullable: false
+          since: 2.3
+          doc: |
+            Flag to skip updating phone home statistics.
     response:
       params:
         - name: rowMetadata


### PR DESCRIPTION
Adds a boolean flag to indicate that the server should skip update statistics for this query

Prerequisite for: https://github.com/hazelcast/hazelcast/pull/19520
Issue: https://github.com/hazelcast/hazelcast/issues/19498