### PR TITLE
Disable unused codecs for the Python client

### DIFF
--- a/py/__init__.py
+++ b/py/__init__.py
@@ -64,6 +64,7 @@ py_ignore_service_list = {
     "ScheduledExecutor",
     "Sql.execute_reserved",
     "Sql.fetch_reserved",
+    "Sql.mappingDdl",
     "Topic.publishAll",
     "TransactionalMap.containsValue",
     "XATransaction",


### PR DESCRIPTION
Disabled the generation of the Sql#mappingDdl codec as it is being
used by the MC.