### PR TITLE
MC-635 adding operation resetAgeStatistics

### DIFF
--- a/protocol-definitions/MC.yaml
+++ b/protocol-definitions/MC.yaml
@@ -846,7 +846,7 @@ methods:
       partitionIdentifier: -1
     response: {}
   - id: 33
-    name: resetAgeStatistics
+    name: resetQueueAgeStatistics
     since: 2.4
     doc: Resets the max-age, min-age and average-age metrics of the queue
     request:

--- a/protocol-definitions/MC.yaml
+++ b/protocol-definitions/MC.yaml
@@ -845,3 +845,17 @@ methods:
       retryable: false
       partitionIdentifier: -1
     response: {}
+  - id: 33
+    name: resetAgeStatistics
+    since: 2.4
+    doc: Resets the max-age, min-age and average-age metrics of the queue
+    request:
+      retryable: false
+      partitionIdentifier: name
+      params:
+       - name: name
+         type: String
+         nullable: false
+         since: 2.4
+         doc: Name of the Queue for which the age-related statistics should be reset to 0
+    response: {}

--- a/protocol-definitions/Queue.yaml
+++ b/protocol-definitions/Queue.yaml
@@ -577,17 +577,3 @@ methods:
           since: 2.0
           doc: |
             <tt>True</tt> if this collection contains no elements
-  - id: 21
-    name: resetAgeStatistics
-    since: 2.4
-    doc: Resets the max-age, min-age and average-age metrics of the queue
-    request:
-      retryable: false
-      partitionIdentifier: name
-      params:
-       - name: name
-         type: String
-         nullable: false
-         since: 2.4
-         doc: Name of the Queue for which the age-related statistics should be reset to 0
-    response: {}

--- a/protocol-definitions/Queue.yaml
+++ b/protocol-definitions/Queue.yaml
@@ -577,3 +577,17 @@ methods:
           since: 2.0
           doc: |
             <tt>True</tt> if this collection contains no elements
+  - id: 21
+    name: resetAgeStatistics
+    since: 2.4
+    doc: Resets the max-age, min-age and average-age metrics of the queue
+    request:
+      retryable: false
+      partitionIdentifier: name
+      params:
+       - name: name
+         type: String
+         nullable: false
+         since: 2.4
+         doc: Name of the Queue for which the age-related statistics should be reset to 0
+    response: {}


### PR DESCRIPTION
Adds a simple operation for resetting the minAge, maxAge and averageAge metrics of a queue. 

Question to the reviewers: what should be the `since` version of new operations?

Platform-side PR: https://github.com/hazelcast/hazelcast/pull/19625