### PR TITLE
Simplify initial frame size calculation for custom codecs

### DIFF
--- a/py/custom-codec-template.py.j2
+++ b/py/custom-codec-template.py.j2
@@ -68,7 +68,8 @@ _{{ to_upper_snake_case(param.name) }}_ENCODE_OFFSET = {% if loop.first %}{% if 
 _{{ to_upper_snake_case(param.name) }}_DECODE_OFFSET = {% if loop.first %}0{% else %}_{{ to_upper_snake_case(loop.previtem.name)}}_DECODE_OFFSET + {{ loop.previtem.type.upper() }}_SIZE_IN_BYTES{% endif %}
 
     {% if loop.last %}
-_INITIAL_FRAME_SIZE = _{{ to_upper_snake_case(param.name) }}_ENCODE_OFFSET + {{ param.type.upper() }}_SIZE_IN_BYTES - {% if should_add_begin_frame %}2 * {% endif %}SIZE_OF_FRAME_LENGTH_AND_FLAGS
+_INITIAL_FRAME_SIZE = _{{ to_upper_snake_case(param.name) }}_ENCODE_OFFSET + {{ param.type.upper() }}_SIZE_IN_BYTES{% if should_add_begin_frame %} - SIZE_OF_FRAME_LENGTH_AND_FLAGS{% endif %}
+
 
     {% endif %}
 {% endfor %}


### PR DESCRIPTION
We now don't add `SIZE_OF_FRAME_LENGTH_AND_FLAGS` to the size while
allocating the buffer of the begin frame + initial frame for custom
codecs. Hence, we need to extract one less `SIZE_OF_FRAME_LENGTH_AND_FLAGS`
while calculating the initial frame size.