### PR TITLE
Remove useless object inheritance from Python templates

### DIFF
--- a/py/__init__.py
+++ b/py/__init__.py
@@ -52,6 +52,7 @@ py_ignore_service_list = {
     "Map.removeAll",
     "Map.removePartitionLostListener",
     "Map.submitToKey",
+    "Map.replaceAll",
     "MultiMap.delete",
     "MC",
     "Queue.drainTo",

--- a/py/custom-codec-template.py.j2
+++ b/py/custom-codec-template.py.j2
@@ -74,7 +74,7 @@ _INITIAL_FRAME_SIZE = _{{ to_upper_snake_case(param.name) }}_ENCODE_OFFSET + {{ 
     {% endif %}
 {% endfor %}
 
-class {{ codec.name }}Codec(object):
+class {{ codec.name }}Codec:
     @staticmethod
     def encode(buf, {{ param_name(codec.name) }}, is_final=False):
         {% if fix_sized_params|length == 0 %}


### PR DESCRIPTION
Since we have removed the Python 2 support, the object inheritance
is not necessary anymore.

This PR removes that.

Also, it adds not-yet-implemented map#replaceAll to ignore-list,
so that we don't generate a codec for it.