### PR TITLE
Change client protocol for node.js SQL json support

### DIFF
--- a/ts/__init__.py
+++ b/ts/__init__.py
@@ -17,7 +17,7 @@ ts_ignore_service_list = {"MC", "ExecutorService", "TransactionalMap", "Transact
                           "Map.eventJournalRead", "Map.eventJournalSubscribe", "Map.fetchKeys", "Map.fetchWithQuery",
                           "Map.project", "Map.projectWithPredicate", "Map.removeInterceptor", "Map.removePartitionLostListener",
                           "Map.submitToKey", "ReplicatedMap.addNearCacheEntryListener", "Topic.addMessageListener",
-                          "Topic.publishAll", "Topic.publish", "Topic.removeMessageListener"}
+                          "Topic.publishAll", "Topic.publish", "Topic.removeMessageListener", "Map.replaceAll"}
 
 
 def ts_types_encode(key):
@@ -151,6 +151,8 @@ class PathHolders:
     SqlColumnMetadataCodec = ImportPathHolder('SqlColumnMetadataCodec', 'custom/SqlColumnMetadataCodec', is_custom_codec=True)
     SqlPage = ImportPathHolder('SqlPage', 'sql/SqlPage')
     SqlPageCodec = ImportPathHolder('SqlPageCodec', 'builtin/SqlPageCodec', is_builtin_codec=True)
+    HazelcastJsonValue = ImportPathHolder('HazelcastJsonValue', 'core/HazelcastJsonValue')
+    HazelcastJsonValueCodec = ImportPathHolder('HazelcastJsonValueCodec', 'custom/HazelcastJsonValueCodec', is_custom_codec=True)
 
 import_paths = {
     'CodecUtil': PathHolders.CodecUtil,
@@ -207,8 +209,8 @@ import_paths = {
     'SqlError': [PathHolders.SqlErrorCodec, PathHolders.SqlError],
     'SqlQueryId': [PathHolders.SqlQueryIdCodec, PathHolders.SqlQueryId],
     'List_SqlColumnMetadata': [PathHolders.SqlColumnMetadataCodec, PathHolders.SqlColumnMetadata, PathHolders.ListMultiFrameCodec],
-    'SqlPage': [PathHolders.SqlPage, PathHolders.SqlPageCodec]
-
+    'SqlPage': [PathHolders.SqlPage, PathHolders.SqlPageCodec],
+    'HazelcastJsonValue': [PathHolders.HazelcastJsonValue, PathHolders.HazelcastJsonValueCodec]
 }
 
 _ts_types = {
@@ -266,6 +268,7 @@ _ts_types = {
     "SqlError": "SqlError",
     "SqlColumnMetadata": "SqlColumnMetadataImpl",
     'SqlPage': 'SqlPage',
+    'HazelcastJsonValue': 'HazelcastJsonValue',
     "CPMember": "NA",
     "MigrationState": "NA",
 

--- a/ts/custom-codec-template.ts.j2
+++ b/ts/custom-codec-template.ts.j2
@@ -1,17 +1,24 @@
 {% macro encode_var_sized(param) -%}
     {% if is_var_sized_list(param.type) or is_var_sized_list_contains_nullable(param.type) -%}
-        ListMultiFrameCodec.encode{% if is_var_sized_list_contains_nullable(param.type)%}ContainsNullable{% endif %}{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param_name(codec.name)}}.{{ escape_keyword(param.name) }}, {{ item_type(lang_name, param.type) }}Codec.encode)
+        ListMultiFrameCodec.encode{% if is_var_sized_list_contains_nullable(param.type)%}ContainsNullable{% endif %}{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param_name(codec.name)}}.{{ get_field(param) }}, {{ item_type(lang_name, param.type) }}Codec.encode)
     {%- elif is_var_sized_entry_list(param.type) -%}
-        EntryListCodec.encode{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param_name(codec.name)}}.{{ escape_keyword(param.name) }}, {{ key_type(lang_name, param.type) }}Codec.encode, {{ value_type(lang_name, param.type) }}Codec.encode)
+        EntryListCodec.encode{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param_name(codec.name)}}.{{ get_field(param) }}, {{ key_type(lang_name, param.type) }}Codec.encode, {{ value_type(lang_name, param.type) }}Codec.encode)
     {%- elif is_var_sized_map(param.type) -%}
-        MapCodec.encode{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param_name(codec.name)}}.{{ escape_keyword(param.name) }}, {{ key_type(lang_name, param.type) }}Codec.encode, {{ value_type(lang_name, param.type) }}Codec.encode)
+        MapCodec.encode{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param_name(codec.name)}}.{{ get_field(param) }}, {{ key_type(lang_name, param.type) }}Codec.encode, {{ value_type(lang_name, param.type) }}Codec.encode)
     {%- else -%}
         {%- if param.nullable  -%}
-            CodecUtil.encodeNullable(clientMessage, {{ param_name(codec.name)}}.{{ escape_keyword(param.name) }}, {{ lang_name(param.type) }}Codec.encode)
+            CodecUtil.encodeNullable(clientMessage, {{ param_name(codec.name)}}.{{ get_field(param) }}, {{ lang_name(param.type) }}Codec.encode)
         {%- else -%}
-            {{ lang_name(param.type) }}Codec.encode(clientMessage, {{ param_name(codec.name)}}.{{ escape_keyword(param.name) }})
+            {{ lang_name(param.type) }}Codec.encode(clientMessage, {{ param_name(codec.name)}}.{{ get_field(param) }})
         {%- endif %}
     {% endif %}
+{%- endmacro %}
+{% macro get_field(param) %}
+    {%- if param.getterMethod -%}
+        {{ escape_keyword(param.getterMethod) }}
+    {%- else -%}
+        {{ escape_keyword(param.name) }}
+    {%- endif %}
 {%- endmacro %}
 {% macro decode_var_sized(param) -%}
     {%- if is_var_sized_list(param.type) or is_var_sized_list_contains_nullable(param.type) -%}
@@ -96,7 +103,7 @@ export class {{ codec.name|capital }}Codec {
 
         const initialFrame = Frame.createInitialFrame(INITIAL_FRAME_SIZE, DEFAULT_FLAGS);
         {% endif %}
-        FixSizedTypesCodec.encode{{ param.type|capital }}(initialFrame.content, {{to_upper_snake_case(param.name)}}_OFFSET, {{ param_name(codec.name)}}.{{ escape_keyword(param.name) }});
+        FixSizedTypesCodec.encode{{ param.type|capital }}(initialFrame.content, {{to_upper_snake_case(param.name)}}_OFFSET, {{ param_name(codec.name)}}.{{ get_field(param) }});
         {% if loop.last %}
             {% if not should_add_begin_frame %}
         initialFrame.flags |= BEGIN_DATA_STRUCTURE_FLAG;

--- a/util.py
+++ b/util.py
@@ -194,6 +194,10 @@ def generate_custom_codecs(services, template, output_dir, lang, env):
                         content = cpp_source_template.render(codec=codec)
                         save_file(join(output_dir, source_file_name), content)
                     else:
+                        if lang == SupportedLanguages.TS:
+                            # Add a getter method to HazelcastJsonValue because it is public and only has toString() API.
+                            if codec["name"] == "HazelcastJsonValue":
+                                codec["params"][0]["getterMethod"] = "toString()"
                         codec_file_name = file_name_generators[lang](codec["name"])
                         content = template.render(codec=codec)
                         save_file(join(output_dir, codec_file_name), content)


### PR DESCRIPTION
* Does the same thing in #405 to add cutom getter access for HazelcastJsonValue. (we need to access its string via `toString()` instead of `.value`)
* Ignore map.replaceAll since it is not used in Node.js client
* Add HazelcastJsonValue codec