### PR TITLE
Convert c++ parameter name to snake_case, Fix spacing

### DIFF
--- a/cpp/__init__.py
+++ b/cpp/__init__.py
@@ -54,6 +54,23 @@ def is_trivial(type):
     return 1
 
 
+def cpp_param_name(name):
+    """
+    Converts camelCase protocol parameter name to snake_case
+    """
+    result = []
+
+    for i, ch in enumerate(name):
+        if ch.isupper():
+            if i > 0:
+                result.append('_')
+            result.append(ch.lower())
+        else:
+            result.append(ch)
+
+    return ''.join(result)
+
+
 """
 def cpp_escape_keyword(value):
     if value not in cpp_reserved_words:

--- a/cpp/__init__.py
+++ b/cpp/__init__.py
@@ -62,7 +62,7 @@ def cpp_param_name(name):
 
     for i, ch in enumerate(name):
         if ch.isupper():
-            if i > 0:
+            if i > 0 and name[i-1].islower():
                 result.append('_')
             result.append(ch.lower())
         else:

--- a/cpp/codec-template.cpp.j2
+++ b/cpp/codec-template.cpp.j2
@@ -1,19 +1,19 @@
 {% macro encode_var_sized(param, is_final) -%}
     {% if is_var_sized_list(param.type) or is_var_sized_list_contains_nullable(param.type) -%}
-        msg.set{% if is_var_sized_list_contains_nullable(param.type)%}_contains_nullable{% endif %}{% if param.nullable  %}_nullable{% endif %}({{ param.name }}{% if is_final %}, true{% endif %});
+        msg.set{% if is_var_sized_list_contains_nullable(param.type)%}_contains_nullable{% endif %}{% if param.nullable  %}_nullable{% endif %}({{ param_name(param.name) }}{% if is_final %}, true{% endif %});
 {#
     {%- elif is_var_sized_entry_list(param.type) -%}
-        EntryListCodec.encode{% if param.nullable  %}_nullable{% endif %}(clientMessage, {{ param.name }}, {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
+        EntryListCodec.encode{% if param.nullable  %}_nullable{% endif %}(clientMessage, {{ param_name(param.name) }}, {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
     {%- elif is_var_sized_map(param.type) -%}
-        MapCodec.encode{% if param.nullable  %}_nullable{% endif %}(clientMessage, {{ param.name }}, {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
+        MapCodec.encode{% if param.nullable  %}_nullable{% endif %}(clientMessage, {{ param_name(param.name) }}, {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
 #}
     {%- else -%}
-            msg.set{% if param.nullable  %}_nullable{% endif %}({{ param.name }}{% if is_final %}, true{% endif %});
+            msg.set{% if param.nullable  %}_nullable{% endif %}({{ param_name(param.name) }}{% if is_final %}, true{% endif %});
     {% endif %}
 {%- endmacro %}
 {% macro decode_var_sized(param) -%}
     {%- if is_var_sized_list(param.type) or is_var_sized_list_contains_nullable(param.type) -%}
-        auto {{ param.name }} = msg.get{% if is_var_sized_list_contains_nullable(param.type)%}_contains_nullable{% endif %}{% if param.nullable  %}_nullable{% endif %}<{{ lang_types_decode(param.type) }}>();
+        auto {{ param_name(param.name) }} = msg.get{% if is_var_sized_list_contains_nullable(param.type)%}_contains_nullable{% endif %}{% if param.nullable  %}_nullable{% endif %}<{{ lang_types_decode(param.type) }}>();
 {#
     {%- elif is_var_sized_entry_list(param.type) -%}
         EntryListCodec.decode{% if param.nullable  %}_nullable{% endif %}(iterator, {{ key_type(lang_name, param.type) }}Codec::decode, {{ value_type(lang_name, param.type) }}Codec::decode)
@@ -21,14 +21,14 @@
         MapCodec.decode{% if param.nullable  %}_nullable{% endif %}(iterator, {{ key_type(lang_name, param.type) }}Codec::decode, {{ value_type(lang_name, param.type) }}Codec::decode)
 #}
     {%- else -%}
-        auto {{ param.name }} = msg.get{% if param.nullable  %}_nullable{% endif %}<{{ lang_types_decode(param.type) }}>();
+        auto {{ param_name(param.name) }} = msg.get{% if param.nullable  %}_nullable{% endif %}<{{ lang_types_decode(param.type) }}>();
     {%- endif -%}
 {%- endmacro %}
 {% set request_fix_sized_params = fixed_params(method.request.params) %}
 {% set request_var_sized_params = var_size_params(method.request.params) %}
 {% set response_fix_sized_params = fixed_params(method.response.params) %}
 {% set response_var_sized_params = var_size_params(method.response.params) %}
-                ClientMessage {{ service_name.lower() }}_{{ method.name.lower() }}_encode({% for param in method.request.params %}{% if is_trivial(param.type) %}{{ lang_types_encode(param.type) }}{% else %}const {{ lang_types_encode(param.type) }} {% if param.nullable %} *{% else %} &{% endif %}{% endif %} {{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %}) {
+                ClientMessage {{ service_name.lower() }}_{{ method.name.lower() }}_encode({% for param in method.request.params %}{% if is_trivial(param.type) %}{{ lang_types_encode(param.type) }} {% else %}const {{ lang_types_encode(param.type) }} {% if param.nullable %}*{% else %}&{% endif %}{% endif %}{{ param_name(param.name) }}{% if not loop.last %}, {% endif %}{% endfor %}) {
                     size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN {% for param in request_fix_sized_params %} + {{ get_size(param.type) }}{% endfor %};
                     ClientMessage msg(initial_frame_size{% if request_var_sized_params|length == 0 %}, true{% endif %});
                     msg.set_retryable({{ method.request.retryable|lower }});
@@ -38,7 +38,7 @@
                     msg.set_partition_id(-1);
 
                 {% for param in request_fix_sized_params %}
-                    msg.set({{ param.name }});
+                    msg.set({{ param_name(param.name) }});
                 {% endfor %}
                 {% for i in range(0, request_var_sized_params|length ) %}
                     {{ encode_var_sized(request_var_sized_params[i], i == (request_var_sized_params|length - 1) ) }}
@@ -55,7 +55,7 @@
                         {% if fixed_params(event.params)|length > 0 %}
                         auto *initial_frame = reinterpret_cast<ClientMessage::frame_header_t *>({% endif %}{% if fixed_params(event.params)|length == 0 %}                        {% endif %}msg.rd_ptr(ClientMessage::EVENT_HEADER_LEN){% if fixed_params(event.params)|length > 0 %}){% endif %};
                         {% for param in fixed_params(event.params) %}
-                        auto {{ param.name }} = msg.get<{{ lang_types_decode(param.type) }}>();
+                        auto {{ param_name(param.name) }} = msg.get<{{ lang_types_decode(param.type) }}>();
                         {% endfor %}
                         {% if fixed_params(event.params)|length > 0 %}
                         msg.seek(static_cast<int32_t>(initial_frame->frame_len));
@@ -64,7 +64,7 @@
                         {% for param in var_size_params(event.params) %}
                         {{ decode_var_sized(param) }}
                         {% endfor %}
-                        handle_{{ event.name.lower() }}({% for param in event.params %}{{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %});
+                        handle_{{ event.name.lower() }}({% for param in event.params %}{{ param_name(param.name) }}{% if not loop.last %}, {% endif %}{% endfor %});
                         return;
                     }
                 {% endfor %}

--- a/cpp/codec-template.cpp.j2
+++ b/cpp/codec-template.cpp.j2
@@ -29,7 +29,7 @@
 {% set response_fix_sized_params = fixed_params(method.response.params) %}
 {% set response_var_sized_params = var_size_params(method.response.params) %}
                 ClientMessage {{ service_name.lower() }}_{{ method.name.lower() }}_encode({% for param in method.request.params %}{% if is_trivial(param.type) %}{{ lang_types_encode(param.type) }} {% else %}const {{ lang_types_encode(param.type) }} {% if param.nullable %}*{% else %}&{% endif %}{% endif %}{{ param_name(param.name) }}{% if not loop.last %}, {% endif %}{% endfor %}) {
-                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN {% for param in request_fix_sized_params %} + {{ get_size(param.type) }}{% endfor %};
+                    size_t initial_frame_size = ClientMessage::REQUEST_HEADER_LEN{% for param in request_fix_sized_params %} + {{ get_size(param.type) }}{% endfor %};
                     ClientMessage msg(initial_frame_size{% if request_var_sized_params|length == 0 %}, true{% endif %});
                     msg.set_retryable({{ method.request.retryable|lower }});
                     msg.set_operation_name("{{ service_name|lower }}.{{ method.name|lower }}");

--- a/cpp/codec-template.h.j2
+++ b/cpp/codec-template.h.j2
@@ -1,15 +1,15 @@
 {% macro encode_var_sized(param) -%}
     {% if is_var_sized_list(param.type) or is_var_sized_list_contains_nullable(param.type) -%}
-        ListMultiFrameCodec.encode{% if is_var_sized_list_contains_nullable(param.type)%}ContainsNullable{% endif %}{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param.name }}, {{ item_type(lang_name, param.type) }}Codec::encode)
+        ListMultiFrameCodec.encode{% if is_var_sized_list_contains_nullable(param.type)%}ContainsNullable{% endif %}{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param_name(param.name) }}, {{ item_type(lang_name, param.type) }}Codec::encode)
     {%- elif is_var_sized_entry_list(param.type) -%}
-        EntryListCodec.encode{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param.name }}, {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
+        EntryListCodec.encode{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param_name(param.name) }}, {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
     {%- elif is_var_sized_map(param.type) -%}
-        MapCodec.encode{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param.name }}, {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
+        MapCodec.encode{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param_name(param.name) }}, {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
     {%- else -%}
         {%- if param.nullable  -%}
-            CodecUtil.encodeNullable(clientMessage, {{ param.name }}, {{ lang_name(param.type) }}Codec::encode)
+            CodecUtil.encodeNullable(clientMessage, {{ param_name(param.name) }}, {{ lang_name(param.type) }}Codec::encode)
         {%- else -%}
-            {{ lang_name(param.type) }}Codec.encode(clientMessage, {{ param.name }})
+            {{ lang_name(param.type) }}Codec.encode(clientMessage, {{ param_name(param.name) }})
         {%- endif %}
     {% endif %}
 {%- endmacro %}
@@ -37,7 +37,7 @@
                  * {{ line }}
                 {% endfor %}
                  */
-                ClientMessage HAZELCAST_API {{ service_name.lower() }}_{{ method.name.lower() }}_encode({% for param in method.request.params %}{% if is_trivial(param.type) %}{{ lang_types_encode(param.type) }}{% else %}const {{ lang_types_encode(param.type) }} {% if param.nullable %} *{% else %} &{% endif %}{% endif %} {{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %});
+                ClientMessage HAZELCAST_API {{ service_name.lower() }}_{{ method.name.lower() }}_encode({% for param in method.request.params %}{% if is_trivial(param.type) %}{{ lang_types_encode(param.type) }} {% else %}const {{ lang_types_encode(param.type) }} {% if param.nullable %}*{% else %}&{% endif %}{% endif %}{{ param_name(param.name) }}{% if not loop.last %}, {% endif %}{% endfor %});
 
                 {# EVENTS#}
                 {% if method.events|length != 0 %}
@@ -46,17 +46,17 @@
             {% for event in method.events%}
                     /**
                         {% for param in event.params %}
-                     * @param {{ param.name }}
+                     * @param {{ param_name(param.name) }}
                             {%- for line in param.doc.splitlines() %}
                                 {% if loop.first -%}
                     {{ " %s"|format(line) }}
                                 {% else %}
-                     * {{ line|indent(8 + param.name|length, True) }}
+                     * {{ line|indent(8 + param_name(param.name)|length, True) }}
                                 {% endif %}
                             {% endfor %}
                         {% endfor %}
                     */
-                    virtual void handle_{{ event.name.lower() }}({% for param in event.params %}{% if not param.nullable %}{{ lang_types_encode(param.type) }}{% if not is_trivial(param.type) %} const &{% endif %}{% else %}{% if param.type != "UUID" %} const boost::optional<{{ lang_types_decode(param.type) }}> &{% else %} {{ lang_types_decode(param.type) }}{%endif%}{% endif %} {{ param.name }}{% if not loop.last %}, {% endif %}{% endfor %}) = 0;
+                    virtual void handle_{{ event.name.lower() }}({% for param in event.params %}{% if not param.nullable %}{{ lang_types_encode(param.type) }}{% if not is_trivial(param.type) %} const &{% endif %}{% else %}{% if param.type != "UUID" %} const boost::optional<{{ lang_types_decode(param.type) }}> &{% else %} {{ lang_types_decode(param.type) }}{%endif%}{% endif %} {{ param_name(param.name) }}{% if not loop.last %}, {% endif %}{% endfor %}) = 0;
 
             {% endfor %}
                 };

--- a/cpp/codec-template.h.j2
+++ b/cpp/codec-template.h.j2
@@ -56,7 +56,7 @@
                             {% endfor %}
                         {% endfor %}
                     */
-                    virtual void handle_{{ event.name.lower() }}({% for param in event.params %}{% if not param.nullable %}{{ lang_types_encode(param.type) }}{% if not is_trivial(param.type) %} const &{% endif %}{% else %}{% if param.type != "UUID" %} const boost::optional<{{ lang_types_decode(param.type) }}> &{% else %} {{ lang_types_decode(param.type) }}{%endif%}{% endif %} {{ param_name(param.name) }}{% if not loop.last %}, {% endif %}{% endfor %}) = 0;
+                    virtual void handle_{{ event.name.lower() }}({% for param in event.params %}{% if not param.nullable %}{{ lang_types_encode(param.type) }} {% if not is_trivial(param.type) %}const &{% endif %}{% else %}{% if param.type != "UUID" %}const boost::optional<{{ lang_types_decode(param.type) }}> &{% else %}{{ lang_types_decode(param.type) }} {%endif%}{% endif %}{{ param_name(param.name) }}{% if not loop.last %}, {% endif %}{% endfor %}) = 0;
 
             {% endfor %}
                 };

--- a/cpp/custom-codec-template.cpp.j2
+++ b/cpp/custom-codec-template.cpp.j2
@@ -1,14 +1,14 @@
 {% macro encode_var_sized(param, is_final) -%}
     {% if is_var_sized_list(param.type) or is_var_sized_list_contains_nullable(param.type) -%}
-        msg.set{% if is_var_sized_list_contains_nullable(param.type)%}ContainsNullable{% endif %}{% if param.nullable  %}Nullable{% endif %}({{ param.name }}{% if is_final %}, true{% endif %});
+        msg.set{% if is_var_sized_list_contains_nullable(param.type)%}ContainsNullable{% endif %}{% if param.nullable  %}Nullable{% endif %}({{ param_name(param.name) }}{% if is_final %}, true{% endif %});
 {#
     {%- elif is_var_sized_entry_list(param.type) -%}
-        EntryListCodec.encode{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param.name }}, {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
+        EntryListCodec.encode{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param_name(param.name) }}, {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
     {%- elif is_var_sized_map(param.type) -%}
-        MapCodec.encode{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param.name }}, {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
+        MapCodec.encode{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param_name(param.name) }}, {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
 #}
     {%- else -%}
-            msg.set{% if param.nullable  %}Nullable{% endif %}({{ param.name }}{% if is_final %}, true{% endif %});
+            msg.set{% if param.nullable  %}Nullable{% endif %}({{ param_name(param.name) }}{% if is_final %}, true{% endif %});
     {% endif %}
 {%- endmacro %}
 /*
@@ -47,7 +47,7 @@ void hazelcast::client::protocol::codec::{{ codec.name.lower() }}_encode(ClientM
         initial_frame->frame_len = initial_frame_size;
         initial_frame->flags = ClientMessage::DEFAULT_FLAGS;
         {% for param in request_fix_sized_params %}
-        msg.set({{ param.name }});
+        msg.set({{ param_name(param.name) }});
         {% endfor %}
         {% for i in range(0, request_var_sized_params|length ) %}
         {{ encode_var_sized(request_var_sized_params[i], i == (request_var_sized_params|length - 1) ) }}

--- a/util.py
+++ b/util.py
@@ -13,7 +13,14 @@ from jinja2 import Environment, PackageLoader
 from yaml import MarkedYAMLError
 
 from binary import FixedEntryListTypes, FixedLengthTypes, FixedListTypes, FixedMapTypes
-from cpp import cpp_ignore_service_list, cpp_types_decode, cpp_types_encode, get_size, is_trivial
+from cpp import (
+    cpp_ignore_service_list, 
+    cpp_types_decode, 
+    cpp_types_encode, 
+    get_size, 
+    is_trivial, 
+    cpp_param_name
+)
 from cs import cs_escape_keyword, cs_ignore_service_list, cs_types_decode, cs_types_encode
 from java import java_types_decode, java_types_encode
 from md import internal_services
@@ -517,7 +524,7 @@ language_specific_funcs = {
     "param_name": {
         SupportedLanguages.JAVA: param_name,
         SupportedLanguages.CS: param_name,
-        SupportedLanguages.CPP: param_name,
+        SupportedLanguages.CPP: cpp_param_name,
         SupportedLanguages.TS: param_name,
         SupportedLanguages.PY: py_param_name,
         SupportedLanguages.MD: lambda x: x,


### PR DESCRIPTION
The parameter names in the hazelcast-cpp-client repo was converted to snake_case but this change wasn't reflected here. This PR fixes this.

See also https://github.com/hazelcast/hazelcast-cpp-client/pull/950.

Old:
```cpp
ClientMessage HAZELCAST_API client_authentication_encode(const std::string  & clusterName, const std::string  * username, const std::string  * password, boost::uuids::uuid uuid, const std::string  & clientType, byte serializationVersion, const std::string  & clientHazelcastVersion, const std::string  & clientName, const std::vector<std::string>  & labels);
```
New:
```cpp
ClientMessage HAZELCAST_API client_authentication_encode(const std::string &cluster_name, const std::string *username, const std::string *password, boost::uuids::uuid uuid, const std::string &client_type, byte serialization_version, const std::string &client_hazelcast_version, const std::string &client_name, const std::vector<std::string> &labels);
```