### PR TITLE
MC-1292 - add globalIndexes to map config operation

### DIFF
--- a/protocol-definitions/MC.yaml
+++ b/protocol-definitions/MC.yaml
@@ -153,6 +153,12 @@ methods:
           since: 2.0
           doc: |
             Classname of the SplitBrainMergePolicy for the map.
+        - name: globalIndexes
+          type: List_IndexConfig
+          nullable: false
+          since: 2.4
+          doc: |
+            Global indexs of the map.
   - id: 4
     name: updateMapConfig
     since: 2.0


### PR DESCRIPTION
Fixes [MC-1292](https://hazelcast.atlassian.net/browse/MC-1292)

Adds `globalIndexes` to the map config operation.
Global indexes are needed for MC SQL Browser.

It's a workaround until dynamic indexes aren't available in the member `Config`
https://hazelcast.slack.com/archives/C031G2V24LR/p1643721320732639
