### PR TITLE
MC-1268 adding returned configUpdateProcessId to updateConfig and reloadConfig

### DIFF
--- a/protocol-definitions/MC.yaml
+++ b/protocol-definitions/MC.yaml
@@ -874,7 +874,7 @@ methods:
       partitionIdentifier: -1
     response:
       params:
-        - name: configUpdateProcessId
+        - name: configReloadProcessId
           type: UUID
           nullable: false
           doc: The unique identifier of the configuration reload process which will be included in all MCEvent instances emitted for MC during the update

--- a/protocol-definitions/MC.yaml
+++ b/protocol-definitions/MC.yaml
@@ -873,7 +873,12 @@ methods:
       retryable: false
       partitionIdentifier: -1
     response:
-      params: []
+      params:
+        - name: configUpdateProcessId
+          type: UUID
+          nullable: false
+          doc: The unique identifier of the configuration reload process which will be included in all MCEvent instances emitted for MC during the update
+          since: 2.4
   - id: 35
     name: updateConfig
     since: 2.4
@@ -888,4 +893,9 @@ methods:
          since: 2.4
          doc: the config patch (XML or YAML string) to be applied to the current configuration
     response:
-      params: []
+      params:
+        - name: configUpdateProcessId
+          type: UUID
+          nullable: false
+          doc: The unique identifier of the configuration update process which will be included in all MCEvent instances emitted for MC during the update
+          since: 2.4


### PR DESCRIPTION
Adds config update process ID as return value to MC `updateConfig` and `reloadConfig` operations.
It is necessary for MC because on the MC-side, we will filter the config update events to be displayed by the MC instance using this process identifier.

### Related PRs:

 * [OS PR](https://github.com/hazelcast/hazelcast/pull/20652)
 * [EE PR](https://github.com/hazelcast/hazelcast-enterprise/pull/4685)