### PR TITLE
CSharp - Add types for Compact Serialization

### DIFF
--- a/cs/__init__.py
+++ b/cs/__init__.py
@@ -82,9 +82,9 @@ _cs_types_common = {
     "DurationConfig": "NA",
     "MigrationState": "NA",
 
-    "Schema":"NA",
-    "List_Schema":"NA",
-    "FieldDescriptor":"NA",
+    "Schema":"Hazelcast.Serialization.Compact.Schema",
+    "List_Schema":"IEnumerable<Hazelcast.Serialization.Compact.Schema>",
+    "FieldDescriptor":"Hazelcast.Serialization.Compact.SchemaField",
 
     "MergePolicyConfig": "NA",
     "CacheConfigHolder": "NA",


### PR DESCRIPTION
Declares a few types that are required in order to properly generate the Compact Serialization codecs.