### PR TITLE
Disabled unused codecs

### DIFF
--- a/cs/__init__.py
+++ b/cs/__init__.py
@@ -16,7 +16,8 @@ cs_ignore_service_list = {
     "DurableExecutor", "CardinalityEstimator", "ScheduledExecutor", "DynamicConfig",
     "Jet",
     "CPSubsystem", "CPMember",  "CountDownLatch", "Semaphore",
-
+    "Map.replaceAll","Sql.mappingDdl",
+    "AtomicLong.apply", "AtomicRef.apply",
     # methods
     "Atomic*.apply", "Atomic*.alter", "MultiMap.putAll", "Client.removeMigrationListener", "SQL*_reserved*"
 }


### PR DESCRIPTION
In order to sync up with up to date codecs in .Net client, disabled unused ones. So, we can generate codecs by using submodule without any conflict on the client side. 

After PR is merged, https://github.com/hazelcast/hazelcast-csharp-client/pull/563 can be merged without any conflict on generated codecs.