### PR TITLE
Add missing fields to DynamicConfigAddMapConfigCodec

### DIFF
--- a/binary/__init__.py
+++ b/binary/__init__.py
@@ -84,6 +84,7 @@ CustomConfigTypes = [
     'MergePolicyConfig',
     'CacheConfigHolder',
     'DataPersistenceConfig',
+    'Capacity',
     'MemoryTierConfig',
     'DiskTierConfig',
     'TieredStoreConfig',

--- a/binary/__init__.py
+++ b/binary/__init__.py
@@ -83,6 +83,10 @@ CustomConfigTypes = [
     'DurationConfig',
     'MergePolicyConfig',
     'CacheConfigHolder',
+    'DataPersistenceConfig',
+    'MemoryTierConfig',
+    'DiskTierConfig',
+    'TieredStoreConfig',
 ]
 
 VarLengthEntryListTypes = [

--- a/binary/reference_objects.py
+++ b/binary/reference_objects.py
@@ -11,6 +11,8 @@ INT = 25
 
 LONG = -50992225
 
+POSITIVE_LONG = 50992225
+
 UUID = UuidHolder(123456789, 987654321)
 
 BYTEARRAY = bytearray([BYTE])
@@ -60,6 +62,10 @@ objects = {
     },
     'HazelcastJsonValue': {
         'value': ''
+    },
+    'MemoryTierConfig': {
+        'capacityValue': POSITIVE_LONG,
+        'capacityMemoryUnitType': 3
     }
 }
 

--- a/binary/reference_objects.py
+++ b/binary/reference_objects.py
@@ -63,9 +63,9 @@ objects = {
     'HazelcastJsonValue': {
         'value': ''
     },
-    'MemoryTierConfig': {
-        'capacityValue': POSITIVE_LONG,
-        'capacityMemoryUnitType': 3
+    'Capacity': {
+        'value': POSITIVE_LONG,
+        'unit': 3
     }
 }
 

--- a/binary/util.py
+++ b/binary/util.py
@@ -459,6 +459,7 @@ reference_objects_dict = {
     'SqlPage': 'aSqlPage',
     'HazelcastJsonValue': 'aHazelcastJsonValue',
     'DataPersistenceConfig': 'aDataPersistenceConfig',
+    'Capacity': 'aCapacity',
     'MemoryTierConfig': 'aMemoryTierConfig',
     'DiskTierConfig': 'aDiskTierConfig',
     'TieredStoreConfig': 'aTieredStoreConfig',

--- a/binary/util.py
+++ b/binary/util.py
@@ -457,7 +457,11 @@ reference_objects_dict = {
     'Schema': 'aSchema',
     'List_Schema': 'aListOfSchemas',
     'SqlPage': 'aSqlPage',
-    'HazelcastJsonValue': 'aHazelcastJsonValue'
+    'HazelcastJsonValue': 'aHazelcastJsonValue',
+    'DataPersistenceConfig': 'aDataPersistenceConfig',
+    'MemoryTierConfig': 'aMemoryTierConfig',
+    'DiskTierConfig': 'aDiskTierConfig',
+    'TieredStoreConfig': 'aTieredStoreConfig',
 }
 
 

--- a/java/__init__.py
+++ b/java/__init__.py
@@ -66,7 +66,11 @@ _java_types_common = {
     "Schema": "com.hazelcast.internal.serialization.impl.compact.Schema",
     "FieldDescriptor": "com.hazelcast.internal.serialization.impl.compact.FieldDescriptor",
     "List_FieldDescriptor": "java.util.List<com.hazelcast.internal.serialization.impl.compact.FieldDescriptor>",
-    "HazelcastJsonValue": "com.hazelcast.core.HazelcastJsonValue"
+    "HazelcastJsonValue": "com.hazelcast.core.HazelcastJsonValue",
+    "DataPersistenceConfig": "com.hazelcast.config.DataPersistenceConfig",
+    "MemoryTierConfig" : "com.hazelcast.config.MemoryTierConfig",
+    "DiskTierConfig" : "com.hazelcast.config.DiskTierConfig",
+    "TieredStoreConfig" : "com.hazelcast.config.TieredStoreConfig"
 }
 
 _java_types_encode = {

--- a/java/__init__.py
+++ b/java/__init__.py
@@ -68,9 +68,9 @@ _java_types_common = {
     "List_FieldDescriptor": "java.util.List<com.hazelcast.internal.serialization.impl.compact.FieldDescriptor>",
     "HazelcastJsonValue": "com.hazelcast.core.HazelcastJsonValue",
     "DataPersistenceConfig": "com.hazelcast.config.DataPersistenceConfig",
-    "MemoryTierConfig" : "com.hazelcast.config.MemoryTierConfig",
-    "DiskTierConfig" : "com.hazelcast.config.DiskTierConfig",
-    "TieredStoreConfig" : "com.hazelcast.config.TieredStoreConfig"
+    "MemoryTierConfig": "com.hazelcast.config.MemoryTierConfig",
+    "DiskTierConfig": "com.hazelcast.config.DiskTierConfig",
+    "TieredStoreConfig": "com.hazelcast.config.TieredStoreConfig"
 }
 
 _java_types_encode = {

--- a/java/__init__.py
+++ b/java/__init__.py
@@ -68,6 +68,7 @@ _java_types_common = {
     "List_FieldDescriptor": "java.util.List<com.hazelcast.internal.serialization.impl.compact.FieldDescriptor>",
     "HazelcastJsonValue": "com.hazelcast.core.HazelcastJsonValue",
     "DataPersistenceConfig": "com.hazelcast.config.DataPersistenceConfig",
+    "Capacity": "com.hazelcast.memory.Capacity",
     "MemoryTierConfig": "com.hazelcast.config.MemoryTierConfig",
     "DiskTierConfig": "com.hazelcast.config.DiskTierConfig",
     "TieredStoreConfig": "com.hazelcast.config.TieredStoreConfig"

--- a/protocol-definitions/DynamicConfig.yaml
+++ b/protocol-definitions/DynamicConfig.yaml
@@ -884,6 +884,18 @@ methods:
           doc: |
             {@code true} to enable entry level statistics for the entries of this map.
              otherwise {@code false}. Default value is {@code false}
+        - name: dataPersistenceConfig
+          type: DataPersistenceConfig
+          nullable: false
+          since: 2.5
+          doc: |
+            Data persistence configuration
+        - name: tieredStoreConfig
+          type: TieredStoreConfig
+          nullable: false
+          since: 2.5
+          doc: |
+            Tiered-Store configuration
     response: {}
   - id: 13
     name: addReliableTopicConfig

--- a/protocol-definitions/custom/Custom.yaml
+++ b/protocol-definitions/custom/Custom.yaml
@@ -996,3 +996,55 @@ customTypes:
         type: String
         nullable: false
         since: 2.4
+  - name: DataPersistenceConfig
+    since: 2.5
+    returnWithFactory: true
+    params:
+      - name: enabled
+        type: boolean
+        nullable: false
+        since: 2.5
+      - name: fsync
+        type: boolean
+        nullable: false
+        since: 2.5
+  - name: MemoryTierConfig
+    since: 2.5
+    returnWithFactory: true
+    params:
+      - name: capacityValue
+        type: long
+        nullable: false
+        since: 2.5
+      - name: capacityMemoryUnitName
+        type: String
+        nullable: false
+        since: 2.5
+  - name: DiskTierConfig
+    since: 2.5
+    returnWithFactory: true
+    params:
+      - name: enabled
+        type: boolean
+        nullable: false
+        since: 2.5
+      - name: deviceName
+        type: String
+        nullable: false
+        since: 2.5
+  - name: TieredStoreConfig
+    since: 2.5
+    returnWithFactory: true
+    params:
+      - name: enabled
+        type: boolean
+        nullable: false
+        since: 2.5
+      - name: memoryTierConfig
+        type: MemoryTierConfig
+        nullable: false
+        since: 2.5
+      - name: diskTierConfig
+        type: DiskTierConfig
+        nullable: false
+        since: 2.5

--- a/protocol-definitions/custom/Custom.yaml
+++ b/protocol-definitions/custom/Custom.yaml
@@ -1016,8 +1016,8 @@ customTypes:
         type: long
         nullable: false
         since: 2.5
-      - name: capacityMemoryUnitName
-        type: String
+      - name: capacityMemoryUnitType
+        type: int
         nullable: false
         since: 2.5
   - name: DiskTierConfig

--- a/protocol-definitions/custom/Custom.yaml
+++ b/protocol-definitions/custom/Custom.yaml
@@ -1008,16 +1008,24 @@ customTypes:
         type: boolean
         nullable: false
         since: 2.5
+  - name: Capacity
+    since: 2.5
+    returnWithFactory: true
+    params:
+      - name: value
+        type: long
+        nullable: false
+        since: 2.5
+      - name: unit
+        type: int
+        nullable: false
+        since: 2.5
   - name: MemoryTierConfig
     since: 2.5
     returnWithFactory: true
     params:
-      - name: capacityValue
-        type: long
-        nullable: false
-        since: 2.5
-      - name: capacityMemoryUnitType
-        type: int
+      - name: capacity
+        type: Capacity
         nullable: false
         since: 2.5
   - name: DiskTierConfig

--- a/schema/custom-codec-schema.json
+++ b/schema/custom-codec-schema.json
@@ -111,7 +111,11 @@
             "FieldDescriptor",
             "List_FieldDescriptor",
             "Schema",
-            "HazelcastJsonValue"
+            "HazelcastJsonValue",
+            "DataPersistenceConfig",
+            "MemoryTierConfig",
+            "DiskTierConfig",
+            "TieredStoreConfig"
           ]
         },
         "nullable": {

--- a/schema/custom-codec-schema.json
+++ b/schema/custom-codec-schema.json
@@ -113,6 +113,7 @@
             "Schema",
             "HazelcastJsonValue",
             "DataPersistenceConfig",
+            "Capacity",
             "MemoryTierConfig",
             "DiskTierConfig",
             "TieredStoreConfig"

--- a/schema/protocol-schema.json
+++ b/schema/protocol-schema.json
@@ -114,6 +114,7 @@
             "SqlPage",
             "HazelcastJsonValue",
             "DataPersistenceConfig",
+            "Capacity",
             "MemoryTierConfig",
             "DiskTierConfig",
             "TieredStoreConfig"

--- a/schema/protocol-schema.json
+++ b/schema/protocol-schema.json
@@ -112,7 +112,11 @@
             "FieldDescriptor",
             "List_FieldDescriptor",
             "SqlPage",
-            "HazelcastJsonValue"
+            "HazelcastJsonValue",
+            "DataPersistenceConfig",
+            "MemoryTierConfig",
+            "DiskTierConfig",
+            "TieredStoreConfig"
           ]
         },
         "nullable": {


### PR DESCRIPTION
This PR adds custom types for `DataPersistenceConfig` and
`TieredStoreConfig` and adds these types of parameters to the
`DynamicConfigAddMapConfigCodec`.

OS PR: https://github.com/hazelcast/hazelcast/pull/21432