### PR TITLE
Add capacity policy field to addScheduledExecutorConfig

### DIFF
--- a/protocol-definitions/DynamicConfig.yaml
+++ b/protocol-definitions/DynamicConfig.yaml
@@ -580,7 +580,8 @@ methods:
           nullable: false
           since: 2.0
           doc: |
-            maximum number of tasks that a scheduler can have at any given point in time per partition
+            maximum number of tasks that a scheduler can have at any given point in time per partition or per node
+            according to the capacity policy
         - name: splitBrainProtectionName
           type: String
           nullable: true
@@ -608,6 +609,12 @@ methods:
           since: 2.1
           doc: |
             {@code true} to enable gathering of statistics, otherwise {@code false}
+        - name: capacityPolicy
+          type: byte
+          nullable: false
+          since: 2.5
+          doc: |
+            Capacity policy for the configured capacity value
     response: {}
   - id: 11
     name: addQueueConfig


### PR DESCRIPTION
This PR adds previously missing capacity policy field to
addScheduledExecutorConfig.

OS PR: https://github.com/hazelcast/hazelcast/pull/21870