### PR TITLE
remove the map_remove_all_codec from the py_ignore_service_list

### DIFF
--- a/py/__init__.py
+++ b/py/__init__.py
@@ -49,7 +49,6 @@ py_ignore_service_list = {
     "Map.addPartitionLostListener",
     "Map.eventJournalRead",
     "Map.eventJournalSubscribe",
-    "Map.removeAll",
     "Map.removePartitionLostListener",
     "Map.submitToKey",
     "Map.replaceAll",


### PR DESCRIPTION
The map_remove_all_codec is removed from the list of py_ignore_service_list.