### PR TITLE
[API-1531] Return replicated member UUIDs in the send schema codec

### DIFF
--- a/binary/__init__.py
+++ b/binary/__init__.py
@@ -1,4 +1,4 @@
-FixedLengthTypes = [
+FixSizedTypes = [
     "boolean",
     "byte",
     "int",
@@ -6,7 +6,7 @@ FixedLengthTypes = [
     "UUID",
 ]
 
-VarLengthTypes = [
+VarSizedTypes = [
     'byteArray',
     'longArray',
     'String',
@@ -14,7 +14,7 @@ VarLengthTypes = [
     'SqlPage'
 ]
 
-FixedEntryListTypes = [
+FixSizedEntryListTypes = [
     'EntryList_Integer_UUID',
     'EntryList_UUID_Long',
     'EntryList_Integer_Long',
@@ -24,13 +24,17 @@ FixedEntryListTypes = [
     'EntryList_UUID_List_Integer',
 ]
 
-FixedMapTypes = [
+FixSizedMapTypes = [
 ]
 
-FixedListTypes = [
+FixSizedListTypes = [
     'List_Integer',
     'List_Long',
     'List_UUID'
+]
+
+FixSizedSetTypes = [
+    'Set_UUID',
 ]
 
 CustomTypes = [
@@ -93,7 +97,7 @@ CustomConfigTypes = [
     'TieredStoreConfig',
 ]
 
-VarLengthEntryListTypes = [
+VarSizedEntryListTypes = [
     'EntryList_String_String',
     'EntryList_String_byteArray',
     'EntryList_String_EntryList_Integer_Long',
@@ -101,12 +105,12 @@ VarLengthEntryListTypes = [
     'EntryList_Data_List_Data',
 ]
 
-VarLengthMapTypes = [
+VarSizedMapTypes = [
     'Map_String_String',
     'Map_EndpointQualifier_Address',
 ]
 
-VarLengthListTypes = [
+VarSizedListTypes = [
     'List_byteArray',
     'List_CacheEventData',
     'List_CacheSimpleEntryListenerConfig',
@@ -132,5 +136,7 @@ VarLengthListTypes = [
     'List_FieldDescriptor'
 ]
 
-AllTypes = FixedLengthTypes + VarLengthTypes + FixedEntryListTypes + FixedMapTypes + FixedListTypes \
-           + CustomTypes + CustomConfigTypes + VarLengthEntryListTypes + VarLengthMapTypes + VarLengthListTypes
+AllTypes = FixSizedTypes + VarSizedTypes + FixSizedEntryListTypes \
+           + FixSizedMapTypes + FixSizedListTypes + FixSizedSetTypes \
+           + CustomTypes + CustomConfigTypes + VarSizedEntryListTypes \
+           + VarSizedMapTypes + VarSizedListTypes

--- a/binary/reference_objects.py
+++ b/binary/reference_objects.py
@@ -99,3 +99,7 @@ list_objects = {
     'long': [LONG],
     'UUID': [UUID]
 }
+
+set_objects = {
+    'UUID': [UUID],
+}

--- a/binary/util.py
+++ b/binary/util.py
@@ -142,6 +142,16 @@ class FixSizedParamEncoder:
         client_message.add_frame(Frame(content))
 
     @staticmethod
+    def encode_fix_sized_set_frame(client_message, item_type):
+        obj = reference_objects.set_objects[item_type]
+        content = bytearray(sizes[item_type] * len(obj))
+        offset = 0
+        for item in obj:
+            FixSizedParamEncoder.pack_into(content, offset, item_type, item)
+            offset += sizes[item_type]
+        client_message.add_frame(Frame(content))
+
+    @staticmethod
     def pack_into(buffer, offset, type, value, should_be_null=False):
         if type == 'UUID':
             struct.pack_into(formats['boolean'], buffer, offset, should_be_null)
@@ -236,6 +246,7 @@ class VarSizedParamEncoder:
             'List_Data': partial(self.encode_multi_frame_list, encoder=self.encode_data_frame),
             'List_ScheduledTaskHandler': partial(self.encode_multi_frame_list, encoder=self.encoder.custom_type_encoder
                                                  .encoder_for('ScheduledTaskHandler')),
+            'Set_UUID': partial(FixSizedParamEncoder.encode_fix_sized_set_frame, item_type='UUID'),
             'SqlPage': partial(self.encode_sqlpage),
             'HazelcastJsonValue': partial(self.encode_json)
         }
@@ -453,6 +464,7 @@ reference_objects_dict = {
     'List_MCEvent': 'aListOfMCEvents',
     'List_SqlColumnMetadata': 'aListOfSqlColumnMetadata',
     'List_JobAndSqlSummary': 'aListJobAndSqlSummary',
+    'Set_UUID': 'aSetOfUUIDs',
     'MergePolicyConfig': 'aMergePolicyConfig',
     'CacheConfigHolder': 'aCacheConfigHolder',
     'AnchorDataListHolder': 'anAnchorDataListHolder',

--- a/cpp/__init__.py
+++ b/cpp/__init__.py
@@ -193,6 +193,8 @@ _cpp_types_encode = {
     "EntryList_UUID_List_Integer": "std::vector<std::pair<boost::uuids::uuid, std::vector<int>>>",
     "EntryList_Data_Data": "std::vector<std::pair<serialization::pimpl::data, serialization::pimpl::data>>",
     "EntryList_Data_List_Data": "std::vector<std::pair<serialization::pimpl::data, std::vector<serialization::pimpl::data>>>",
+
+    "Set_UUID": "NA",
 }
 
 _cpp_types_decode = {
@@ -238,7 +240,9 @@ _cpp_types_decode = {
     "EntryList_UUID_Long": "std::vector<std::pair<boost::uuids::uuid, int64_t>>",
     "EntryList_String_EntryList_Integer_Long": "std::vector<std::pair<std::string, std::vector<std::pair<int32_t, int64_t>>>>",
     "EntryList_UUID_List_Integer": "std::vector<std::pair<boost::uuids::uuid, std::vector<int>>>",
-    "EntryList_Data_Data": "std::vector<std::pair<serialization::pimpl::data, serialization::pimpl::data>>"
+    "EntryList_Data_Data": "std::vector<std::pair<serialization::pimpl::data, serialization::pimpl::data>>",
+
+    "Set_UUID": "NA",
 }
 
 _trivial_types = {

--- a/cs/__init__.py
+++ b/cs/__init__.py
@@ -160,7 +160,9 @@ _cs_types_encode = {
     "EntryList_UUID_UUID": "ICollection<KeyValuePair<Guid, Guid>>",
     "EntryList_UUID_List_Integer": "ICollection<KeyValuePair<Guid, IList<int>>>",
     "EntryList_Data_Data": "ICollection<KeyValuePair<IData, IData>>",
-    "EntryList_Data_List_Data": "ICollection<KeyValuePair<IData, ICollection<IData>>>"
+    "EntryList_Data_List_Data": "ICollection<KeyValuePair<IData, ICollection<IData>>>",
+
+    "Set_UUID": "NA",
 }
 
 _cs_types_decode = {
@@ -215,5 +217,7 @@ _cs_types_decode = {
     "EntryList_UUID_UUID": "IList<KeyValuePair<Guid, Guid>>",
     "EntryList_UUID_List_Integer": "IList<KeyValuePair<Guid, IList<int>>>",
     "EntryList_Data_Data": "IList<KeyValuePair<IData, IData>>",
-    "EntryList_Data_List_Data": "IList<KeyValuePair<IData, IList<IData>>>"
+    "EntryList_Data_List_Data": "IList<KeyValuePair<IData, IList<IData>>>",
+
+    "Set_UUID": "NA",
 }

--- a/java/__init__.py
+++ b/java/__init__.py
@@ -118,6 +118,9 @@ _java_types_encode = {
     "List_MCEvent": "java.util.Collection<com.hazelcast.internal.management.dto.MCEventDTO>",
     "List_SqlColumnMetadata": "java.util.List<com.hazelcast.sql.SqlColumnMetadata>",
     "List_JobAndSqlSummary": "java.util.List<com.hazelcast.jet.impl.JobAndSqlSummary>",
+    "List_Schema": "java.util.Collection<com.hazelcast.internal.serialization.impl.compact.Schema>",
+
+    "Set_UUID": "java.util.Collection<java.util.UUID>",
 
     "EntryList_String_String": "java.util.Collection<java.util.Map.Entry<java.lang.String, java.lang.String>>",
     "EntryList_String_byteArray": "java.util.Collection<java.util.Map.Entry<java.lang.String, byte[]>>",
@@ -131,7 +134,6 @@ _java_types_encode = {
     "EntryList_UUID_List_Integer": "java.util.Collection<java.util.Map.Entry<java.util.UUID, java.util.List<java.lang.Integer>>>",
     "EntryList_Data_Data": "java.util.Collection<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>>",
     "EntryList_Data_List_Data": "java.util.Collection<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, java.util.Collection<com.hazelcast.internal.serialization.Data>>>",
-    "List_Schema": "java.util.Collection<com.hazelcast.internal.serialization.impl.compact.Schema>"
 }
 
 _java_types_decode = {
@@ -176,6 +178,9 @@ _java_types_decode = {
     "List_ScheduledTaskHandler": "java.util.Collection<com.hazelcast.scheduledexecutor.ScheduledTaskHandler>",
     "List_SqlColumnMetadata": "java.util.List<com.hazelcast.sql.SqlColumnMetadata>",
     "List_JobAndSqlSummary": "java.util.List<com.hazelcast.jet.impl.JobAndSqlSummary>",
+    "List_Schema": "java.util.List<com.hazelcast.internal.serialization.impl.compact.Schema>",
+
+    "Set_UUID": "java.util.Set<java.util.UUID>",
 
     "EntryList_String_String": "java.util.List<java.util.Map.Entry<java.lang.String, java.lang.String>>",
     "EntryList_String_byteArray": "java.util.List<java.util.Map.Entry<java.lang.String, byte[]>>",
@@ -189,5 +194,4 @@ _java_types_decode = {
     "EntryList_UUID_List_Integer": "java.util.List<java.util.Map.Entry<java.util.UUID, java.util.List<java.lang.Integer>>>",
     "EntryList_Data_Data": "java.util.List<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, com.hazelcast.internal.serialization.Data>>",
     "EntryList_Data_List_Data": "java.util.List<java.util.Map.Entry<com.hazelcast.internal.serialization.Data, java.util.List<com.hazelcast.internal.serialization.Data>>>",
-    "List_Schema": "java.util.List<com.hazelcast.internal.serialization.impl.compact.Schema>"
 }

--- a/protocol-definitions/Client.yaml
+++ b/protocol-definitions/Client.yaml
@@ -888,7 +888,7 @@ methods:
             true if the listener existed and was removed, false otherwise.
   - id: 19
     name: sendSchema
-    since: 2.3
+    since: 2.5
     doc: |
       Sends a schema to cluster
     request:
@@ -898,13 +898,20 @@ methods:
         - name: schema
           type: Schema
           nullable: false
-          since: 2.3
+          since: 2.5
           doc: |
             schema to be send to the cluster
-    response: {}
+    response:
+      params:
+        - name: replicatedMembers
+          type: Set_UUID
+          nullable: false
+          since: 2.5
+          doc: |
+            UUIDs of the members that the schema is replicated
   - id: 20
     name: fetchSchema
-    since: 2.3
+    since: 2.5
     doc: |
       Fetches a schema from the cluster with the given schemaId
     request:
@@ -914,7 +921,7 @@ methods:
         - name: schemaId
           type: long
           nullable: false
-          since: 2.3
+          since: 2.5
           doc: |
             Id of the schema to be fetched
     response:
@@ -922,12 +929,12 @@ methods:
         - name: schema
           type: Schema
           nullable: true
-          since: 2.3
+          since: 2.5
           doc: |
             schema with the given schema id fetched from the cluster
   - id: 21
     name: sendAllSchemas
-    since: 2.3
+    since: 2.5
     doc: |
       Sends all the schemas to the cluster
     request:
@@ -937,7 +944,7 @@ methods:
         - name: schemas
           type: List_Schema
           nullable: false
-          since: 2.3
+          since: 2.5
           doc: |
             list of schemas
     response: {}

--- a/schema/custom-codec-schema.json
+++ b/schema/custom-codec-schema.json
@@ -95,6 +95,7 @@
             "List_MCEvent",
             "List_SqlColumnMetadata",
             "List_JobAndSqlSummary",
+            "Set_UUID",
             "Map_String_String",
             "Map_EndpointQualifier_Address",
             "EndpointQualifier",

--- a/schema/protocol-schema.json
+++ b/schema/protocol-schema.json
@@ -95,6 +95,7 @@
             "List_MCEvent",
             "List_SqlColumnMetadata",
             "List_JobAndSqlSummary",
+            "Set_UUID",
             "Map_String_String",
             "Map_EndpointQualifier_Address",
             "MergePolicyConfig",

--- a/ts/__init__.py
+++ b/ts/__init__.py
@@ -309,5 +309,7 @@ _ts_types = {
     "EntryList_Data_List_Data": "Array<[Data, Data[]]>",
 
     "Map_String_String": "Map<string, string>",
-    "Map_EndpointQualifier_Address": "Map<EndpointQualifier, AddressImpl>"
+    "Map_EndpointQualifier_Address": "Map<EndpointQualifier, AddressImpl>",
+
+    "Set_UUID": "NA",
 }

--- a/util.py
+++ b/util.py
@@ -12,7 +12,7 @@ import yaml
 from jinja2 import Environment, PackageLoader
 from yaml import MarkedYAMLError
 
-from binary import FixedEntryListTypes, FixedLengthTypes, FixedListTypes, FixedMapTypes
+from binary import FixSizedEntryListTypes, FixSizedTypes, FixSizedListTypes, FixSizedMapTypes
 from cpp import (
     cpp_ignore_service_list, 
     cpp_types_decode, 
@@ -68,7 +68,7 @@ def param_name(type_name):
 
 
 def is_fixed_type(param):
-    return param["type"] in FixedLengthTypes
+    return param["type"] in FixSizedTypes
 
 
 def capital(txt):
@@ -237,19 +237,19 @@ def value_type(lang_name, param_type):
 
 
 def is_var_sized_list(param_type):
-    return param_type.startswith("List_") and param_type not in FixedListTypes
+    return param_type.startswith("List_") and param_type not in FixSizedListTypes
 
 
 def is_var_sized_list_contains_nullable(param_type):
-    return param_type.startswith("ListCN_") and param_type not in FixedListTypes
+    return param_type.startswith("ListCN_") and param_type not in FixSizedListTypes
 
 
 def is_var_sized_map(param_type):
-    return param_type.startswith("Map_") and param_type not in FixedMapTypes
+    return param_type.startswith("Map_") and param_type not in FixSizedMapTypes
 
 
 def is_var_sized_entry_list(param_type):
-    return param_type.startswith("EntryList_") and param_type not in FixedEntryListTypes
+    return param_type.startswith("EntryList_") and param_type not in FixSizedEntryListTypes
 
 
 def load_services(protocol_def_dir):


### PR DESCRIPTION
Introduced a new set UUID codec to return the response of the replicated member UUIDs.

Also, updated the since versions of the schema replication related codecs to 2.5 (Hazelcast 5.2).