### PR TITLE
MC-1245 Add clusterId to MCGetClusterMetadata endpoint

### DIFF
--- a/protocol-definitions/MC.yaml
+++ b/protocol-definitions/MC.yaml
@@ -416,6 +416,12 @@ methods:
           since: 2.0
           doc: |
             Cluster-wide time in milliseconds.
+        - name: clusterId
+          type: String
+          nullable: false
+          since: 2.5
+          doc: |
+            Cluster ID.
   - id: 15
     name: shutdownCluster
     since: 2.0


### PR DESCRIPTION
Adding clusterId to MCGetClusterMetadata endpoint. This will be used by Management Center to report the values to Phone Home.
Jira ticket -> [MC-1245 ClusterID in the MC Phonehomes](https://hazelcast.atlassian.net/browse/MC-1245)