### PR TITLE
Remove topic.publish_all() from ignore list. 

### DIFF
--- a/py/__init__.py
+++ b/py/__init__.py
@@ -61,7 +61,6 @@ py_ignore_service_list = {
     "Sql.execute_reserved",
     "Sql.fetch_reserved",
     "Sql.mappingDdl",
-    "Topic.publishAll",
     "TransactionalMap.containsValue",
     "XATransaction",
     "Jet",


### PR DESCRIPTION
This change is required to generate a codec for topic.publish_all() for the Python client.

- https://github.com/hazelcast/hazelcast-python-client/pull/570
- https://github.com/hazelcast/hazelcast-python-client/pull/570#discussion_r978475373