### PR TITLE
Rename External Data Store to Data Link [HZ-2013]

### DIFF
--- a/protocol-definitions/DynamicConfig.yaml
+++ b/protocol-definitions/DynamicConfig.yaml
@@ -1246,11 +1246,11 @@ methods:
             apply to this lock configuration's operations.
     response: {}
   - id: 17
-    name: addExternalDataStoreConfig
-    since: 2.5
+    name: addDataLinkConfig
+    since: 2.6
     doc: |
-      Adds an external data store configuration.
-      If an external data store configuration with the given {@code name} already exists, then
+      Adds a data link configuration.
+      If an data link configuration with the given {@code name} already exists, then
       the new configuration is ignored and the existing one is preserved.
     request:
       retryable: false
@@ -1259,26 +1259,26 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.5
+          since: 2.6
           doc: |
-            Name of this external data store, must be unique.
+            Name of this data link, must be unique.
         - name: className
           type: String
           nullable: false
-          since: 2.5
+          since: 2.6
           doc: |
-            Name for the ExternalDataStoreFactory implementation class.
+            Name for the DataLinkFactory implementation class.
         - name: shared
           type: boolean
           nullable: false
-          since: 2.5
+          since: 2.6
           doc: |
-            {@code true} if an instance of the external data store will be reused. {@code false} when on each usage
-            the data store instance should be created. The default it {@code true}.
+            {@code true} if an instance of the data link will be reused. {@code false} when on each usage
+            the data link instance should be created. The default it {@code true}.
         - name: properties
           type: Map_String_String
           nullable: false
-          since: 2.5
+          since: 2.6
           doc: |
-            Properties of the data store configuration.
+            Properties of the data link configuration.
     response: {}

--- a/protocol-definitions/DynamicConfig.yaml
+++ b/protocol-definitions/DynamicConfig.yaml
@@ -1250,7 +1250,7 @@ methods:
     since: 2.6
     doc: |
       Adds a data link configuration.
-      If an data link configuration with the given {@code name} already exists, then
+      If a data link configuration with the given {@code name} already exists, then
       the new configuration is ignored and the existing one is preserved.
     request:
       retryable: false


### PR DESCRIPTION
In 5.2 we added `addExternalDataStoreConfig` method to client protocol, all APIs were added with `@Beta` annotation so we could break the API.

The feedback is that the name is easily confused with tiered store and map store, so we rename it to data link.

OS PR [#23597](https://github.com/hazelcast/hazelcast/pull/23597)