### PR TITLE
Add to_object function to Python codecs when necessary [API-1964]

### DIFF
--- a/binary/util.py
+++ b/binary/util.py
@@ -495,7 +495,7 @@ def create_environment_for_binary_generator(lang):
     env.lstrip_blocks = True
     env.keep_trailing_newline = False
     env.filters['capital'] = capital
-    env.globals['lang_types_encode'] = language_specific_funcs['lang_types_encode'][lang]
+    env.globals['lang_types_encode'] = language_specific_funcs[lang]['lang_types_encode']
     env.globals['reference_objects_dict'] = reference_objects_dict
     env.globals['get_version_as_number'] = get_version_as_number
     env.globals['new_params'] = new_params

--- a/cs/__init__.py
+++ b/cs/__init__.py
@@ -24,9 +24,6 @@ cs_ignore_service_list = {
     "DataPersistenceConfig", "DiskTierConfig", "TieredStoreConfig", "SqlSummary", "JobAndSqlSummary"
 }
 
-def cs_init_env(env):
-    env.globals["cs_sizeof"] = cs_sizeof
-    return env
 
 def cs_types_encode(key):
     try:

--- a/py/__init__.py
+++ b/py/__init__.py
@@ -23,13 +23,28 @@ def py_get_import_path_holders(param_type):
     return import_paths.get(param_type, [])
 
 
-_private_custom_types = ("SqlError", "SqlQueryId")
+_private_custom_types = {"SqlError", "SqlQueryId"}
 
 
 def py_custom_type_name(name):
     if name in _private_custom_types:
         return "_" + name
     return name
+
+
+_decoder_requires_to_object_fn = {"SqlPage"}
+
+
+def py_decoder_requires_to_object_fn(param_type):
+    return param_type in _decoder_requires_to_object_fn
+
+
+def py_to_object_fn_in_decode(params):
+    for param in params:
+        if py_decoder_requires_to_object_fn(param["type"]):
+            return True
+
+    return False
 
 
 py_ignore_service_list = {

--- a/py/codec-template.py.j2
+++ b/py/codec-template.py.j2
@@ -14,6 +14,7 @@
     {% endif %}
 {%- endmacro %}
 {% macro decode_var_sized(param) -%}
+    {% set requires_to_object_fn = decoder_requires_to_object_fn(param.type) %}
     {%- if is_var_sized_list(param.type) or is_var_sized_list_contains_nullable(param.type) -%}
         ListMultiFrameCodec.decode{% if is_var_sized_list_contains_nullable(param.type) %}_contains_nullable{% endif %}{% if param.nullable  %}_nullable{% endif %}(msg, {{ item_type(lang_name, param.type) }}Codec.decode)
     {%- elif is_var_sized_entry_list(param.type) -%}
@@ -22,7 +23,7 @@
         MapCodec.decode{% if param.nullable  %}_nullable{% endif %}(msg, {{ key_type(lang_name, param.type) }}Codec.decode, {{ value_type(lang_name, param.type) }}Codec.decode)
     {%- else -%}
         {%- if param.nullable  -%}
-            CodecUtil.decode_nullable(msg, {{ lang_name(param.type) }}Codec.decode)
+            CodecUtil.decode_nullable(msg, {% if requires_to_object_fn %}lambda m: {% endif %}{{ lang_name(param.type) }}Codec.decode{% if requires_to_object_fn %}(m, to_object_fn){% endif %})
         {%- else -%}
             {{ lang_name(param.type) }}Codec.decode(msg)
         {%- endif -%}
@@ -120,7 +121,7 @@ def encode_request({% for param in method.request.params %}{{ param_name(param.n
 {% if method.response.params|length > 0 %}
 
 
-def decode_response(msg):
+def decode_response(msg{% if to_object_fn_in_decode(method.response.params) %}, to_object_fn{% endif %}):
 {% if response_fix_sized_params|length != 0 %}
     initial_frame = msg.next_frame()
 {% else %}


### PR DESCRIPTION
This change was needed to support efficient eager deserialization of the SQL columns of type OBJECT.

I have also refactored the `language_specific_funcs` so that we don't have to put dummy values even for functions that are needed for a single language.