### PR TITLE
Remove language 'go' from README 

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,7 +111,6 @@ where
     * `cs` : C#
     * `py` : Python
     * `ts` : TypeScript
-    * `go` : Go
     * `md` : Markdown (Documentation)
      
 `java` is the default value if no language is specified.


### PR DESCRIPTION
`./generator.py -l go` doesn't work despite being listed as a language target in `README.md`.

From what I see the README is incorrect as the golang support looks minimal to non-existant. This PR just remove `go` from stated set of language targets.

> You can generate codecs for a specific language by calling,
> 
> ./generator.py [-r ROOT_DIRECTORY] [-l LANGUAGE] [-p PROTOCOL_DEFS_PATH] [-o OUTPUT_DIRECTORY] [-n NAMESPACE] [-b BINARY_OUTPUT_DIR] [-t TEST_OUTPUT_DIR] [--no-binary] [--no-id-check]
> where
> 
> ROOT_DIRECTORY is the root folder for the generated codecs. If left empty, default value is set to ./output/[LANGUAGE].
> 
> LANGUAGE is one of
> 
> java : Java
> cpp : C++
> cs : C#
> py : Python
> ts : TypeScript
> **go** : Go
> md : Markdown (Documentation)

```
./generator.py -l go
usage: generator.py [-h] [-r ROOT_DIRECTORY] [-l LANGUAGE] [-p PROTOCOL_DEFS_PATH] [-o OUTPUT_DIRECTORY] [-n NAMESPACE] [-b BINARY_OUTPUT_DIRECTORY]
                    [-t TEST_OUTPUT_DIRECTORY] [--no-binary] [--no-id-check]
generator.py: error: argument -l/--lang: invalid choice: 'go' (choose from 'java', 'cpp', 'cs', 'py', 'ts', 'md')
```

Fixes: https://github.com/hazelcast/hazelcast-client-protocol/issues/471
