### PR TITLE
Adds isShutdown property to CPSubsystem.addGroupAvailabilityListener [HZ-3118]

### DIFF
--- a/protocol-definitions/CPSubsystem.yaml
+++ b/protocol-definitions/CPSubsystem.yaml
@@ -108,6 +108,12 @@ methods:
             since: 2.1
             doc: |
               Missing members.
+          - name: isShutdown
+            type: boolean
+            nullable: false
+            since: 2.7
+            doc: |
+              Determines if the availability event is due to an explicit shutdown.
   - id: 4
     name: removeGroupAvailabilityListener
     since: 2.1


### PR DESCRIPTION
This provides support for the `isShutdown` flag that `CPGroupAvailabilityEventImpl` carries.

This was added to distinguish between the current context of this event (`CPAvailabilityEvent` -- just its implementation `CPGroupAvailabilityEventImpl`) of when a member appears to be missing vs. when a member is shutdown, i.e. definitely missing (as it's been explicitly shutdown).

OS PR: https://github.com/hazelcast/hazelcast/pull/25490/