### PR TITLE
Suppress warnings of unused imports in Java

### DIFF
--- a/java/binary/client-binary-compatibility-template.j2
+++ b/java/binary/client-binary-compatibility-template.j2
@@ -44,6 +44,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
+@SuppressWarnings("unused")
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class ClientCompatibility{% if test_nullable %}Null{% endif %}Test_{{ '_'.join(protocol_version.split('.')) }} {

--- a/java/binary/member-binary-compatibility-template.j2
+++ b/java/binary/member-binary-compatibility-template.j2
@@ -43,6 +43,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
+@SuppressWarnings("unused")
 @RunWith(HazelcastParallelClassRunner.class)
 @Category({QuickTest.class, ParallelJVMTest.class})
 public class MemberCompatibility{% if test_nullable %}Null{% endif %}Test_{{ '_'.join(protocol_version.split('.')) }} {

--- a/java/codec-template.java.j2
+++ b/java/codec-template.java.j2
@@ -81,6 +81,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
  * {{ line }}
 {% endfor %}
  */
+@SuppressWarnings("unused")
 @Generated("!codec_hash!")
 public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
     //hex: {{ '0x%06X'|format(method.request.id) }}

--- a/java/custom-codec-template.java.j2
+++ b/java/custom-codec-template.java.j2
@@ -63,6 +63,7 @@ import static com.hazelcast.client.impl.protocol.codec.builtin.FixedSizeTypesCod
 {% set new_codec_params = new_params(codec.since, codec.params) %}
 {% set fix_sized_new_params = new_params(codec.since, fix_sized_params) %}
 {% set should_add_begin_frame = (fix_sized_params|length > fix_sized_new_params|length) or fix_sized_params|length == 0 %}
+@SuppressWarnings("unused")
 @Generated("!codec_hash!")
 public final class {{ codec.name|capital }}Codec {
     {% for param in fix_sized_params %}


### PR DESCRIPTION
The imports are statically defined in the templates, but the templates then dynamically decide what content should be included - and in some situations, the content isn't included the imports are required for.

I don't think it's possible to easily address the root cause of this problem, but as they are generated classes, it doesn't make sense for an IDE to be flagging issues when they are being included in another project as there's no scope to modify them there.

As such, I've added `@SuppressWarnings("unused")` to the Java templates.

Fixes https://github.com/hazelcast/hazelcast-client-protocol/issues/482