### PR TITLE
Adds CPMap Service [HZ-3539]

### DIFF
--- a/protocol-definitions/CPMap.yaml
+++ b/protocol-definitions/CPMap.yaml
@@ -1,0 +1,79 @@
+id: 35
+name: CPMap
+methods:
+  - id: 1
+    name: get
+    since: 2.7
+    doc: |
+      Gets the value associated with the key in the specified map.
+    request:
+      retryable: false
+      partitionIdentifier: -1
+      params:
+        - name: groupId
+          type: RaftGroupId
+          nullable: false
+          since: 2.7
+          doc: |
+            CP group ID of this CPMap instance.
+        - name: name
+          type: String
+          nullable: false
+          since: 2.7
+          doc: |
+            Name of this CPMap instance.
+        - name: key
+          type: Data
+          nullable: false
+          since: 2.7
+          doc: |
+            Key of the value to retrieve.
+    response:
+      params:
+        - name: response
+          type: Data
+          nullable: true
+          since: 2.7
+          doc: |
+            The result of the map lookup. 
+  - id: 2
+    name: put
+    since: 2.7
+    doc: |
+      Puts the key-value into the specified map.
+    request:
+      retryable: false
+      partitionIdentifier: -1
+      params:
+        - name: groupId
+          type: RaftGroupId
+          nullable: false
+          since: 2.7
+          doc: |
+            CP group ID of this CPMap instance.
+        - name: name
+          type: String
+          nullable: false
+          since: 2.7
+          doc: |
+            Name of this CPMap instance.
+        - name: key
+          type: Data
+          nullable: false
+          since: 2.7
+          doc: |
+            Key of the value.
+        - name: value
+          type: Data
+          nullable: false
+          since: 2.7
+          doc: |
+            Value to associate with the key.
+    response:
+      params:
+        - name: response
+          type: Data
+          nullable: true
+          since: 2.7
+          doc: |
+            Previous value associated with the key. 

--- a/protocol-definitions/CPMap.yaml
+++ b/protocol-definitions/CPMap.yaml
@@ -77,3 +77,162 @@ methods:
           since: 2.7
           doc: |
             Previous value associated with the key. 
+  - id: 3
+    name: set
+    since: 2.7
+    doc: |
+      Sets the key-value in the specified map.
+    request:
+      retryable: false
+      partitionIdentifier: -1
+      params:
+        - name: groupId
+          type: RaftGroupId
+          nullable: false
+          since: 2.7
+          doc: |
+            CP group ID of this CPMap instance.
+        - name: name
+          type: String
+          nullable: false
+          since: 2.7
+          doc: |
+            Name of this CPMap instance.
+        - name: key
+          type: Data
+          nullable: false
+          since: 2.7
+          doc: |
+            Key of the value.
+        - name: value
+          type: Data
+          nullable: false
+          since: 2.7
+          doc: |
+            Value to associate with the key.
+    response:
+      params:
+        - name: response
+          type: Data
+          nullable: true
+          since: 2.7
+          doc: |
+            Always null, set does not return any previous value.
+  - id: 4
+    name: remove
+    since: 2.7
+    doc: |
+      Removes the value associated with the key in the specified map.
+    request:
+      retryable: false
+      partitionIdentifier: -1
+      params:
+        - name: groupId
+          type: RaftGroupId
+          nullable: false
+          since: 2.7
+          doc: |
+            CP group ID of this CPMap instance.
+        - name: name
+          type: String
+          nullable: false
+          since: 2.7
+          doc: |
+            Name of this CPMap instance.
+        - name: key
+          type: Data
+          nullable: false
+          since: 2.7
+          doc: |
+            Key of the value to remove.
+    response:
+      params:
+        - name: response
+          type: Data
+          nullable: true
+          since: 2.7
+          doc: |
+            The result of the remove. 
+  - id: 5
+    name: delete
+    since: 2.7
+    doc: |
+      Deletes the value associated with the key in the specified map.
+    request:
+      retryable: false
+      partitionIdentifier: -1
+      params:
+        - name: groupId
+          type: RaftGroupId
+          nullable: false
+          since: 2.7
+          doc: |
+            CP group ID of this CPMap instance.
+        - name: name
+          type: String
+          nullable: false
+          since: 2.7
+          doc: |
+            Name of this CPMap instance.
+        - name: key
+          type: Data
+          nullable: false
+          since: 2.7
+          doc: |
+            Key of the value to delete.
+    response:
+      params:
+        - name: response
+          type: Data
+          nullable: true
+          since: 2.7
+          doc: |
+            Always null, delete does not return any value.
+  - id: 6
+    name: compareAndSet
+    since: 2.7
+    doc: |
+      Tests if the value associated with the key is expectedValue and if so associates key with
+      newValue.
+    request:
+      retryable: false
+      partitionIdentifier: -1
+      params:
+        - name: groupId
+          type: RaftGroupId
+          nullable: false
+          since: 2.7
+          doc: |
+            CP group ID of this CPMap instance.
+        - name: name
+          type: String
+          nullable: false
+          since: 2.7
+          doc: |
+            Name of this CPMap instance.
+        - name: key
+          type: Data
+          nullable: false
+          since: 2.7
+          doc: |
+            Key of the data that is subject of the compare and set.
+        - name: expectedValue
+          type: Data
+          nullable: false
+          since: 2.7
+          doc: |
+            The expected value associated with key.
+        - name: newValue
+          type: Data
+          nullable: false
+          since: 2.7
+          doc: |
+            The new value to associate with key.
+    response:
+      params:
+        - name: response
+          type: boolean
+          nullable: false
+          since: 2.7
+          doc: |
+            True if key was associated with newValue, otherwise false.

--- a/protocol-definitions/CPMap.yaml
+++ b/protocol-definitions/CPMap.yaml
@@ -65,7 +65,7 @@ methods:
             Key of the value.
         - name: value
           type: Data
-          nullable: true
+          nullable: false
           since: 2.7
           doc: |
             Value to associate with the key.
@@ -106,7 +106,7 @@ methods:
             Key of the value.
         - name: value
           type: Data
-          nullable: true
+          nullable: false
           since: 2.7
           doc: |
             Value to associate with the key.
@@ -218,13 +218,13 @@ methods:
             Key of the data that is subject of the compare and set.
         - name: expectedValue
           type: Data
-          nullable: true
+          nullable: false
           since: 2.7
           doc: |
             The expected value associated with key.
         - name: newValue
           type: Data
-          nullable: true
+          nullable: false
           since: 2.7
           doc: |
             The new value to associate with key.

--- a/protocol-definitions/CPMap.yaml
+++ b/protocol-definitions/CPMap.yaml
@@ -65,7 +65,7 @@ methods:
             Key of the value.
         - name: value
           type: Data
-          nullable: false
+          nullable: true
           since: 2.7
           doc: |
             Value to associate with the key.
@@ -106,7 +106,7 @@ methods:
             Key of the value.
         - name: value
           type: Data
-          nullable: false
+          nullable: true
           since: 2.7
           doc: |
             Value to associate with the key.
@@ -218,13 +218,13 @@ methods:
             Key of the data that is subject of the compare and set.
         - name: expectedValue
           type: Data
-          nullable: false
+          nullable: true
           since: 2.7
           doc: |
             The expected value associated with key.
         - name: newValue
           type: Data
-          nullable: false
+          nullable: true
           since: 2.7
           doc: |
             The new value to associate with key.


### PR DESCRIPTION
Defines the `CPMap` service for the new `CPMap` feature scheduled for 5.4. The protocol changes facilitate the following, as an example:

```java
HazelcastInstance client = HazelcastClient.newHazelcastClient();
CPMap<String, String> map = client.getCPSubsystem().getMap("mymap");
assert map.put("k", "v") == null;
assert "v".equals(map.get("k"));
```

Enterprise PR: https://github.com/hazelcast/hazelcast-enterprise/pull/6752
OS PR: https://github.com/hazelcast/hazelcast/pull/25877