### PR TITLE
Generalise CPMap.compareAndSet return type to Data [HZ-3590]

### DIFF
--- a/protocol-definitions/CPMap.yaml
+++ b/protocol-definitions/CPMap.yaml
@@ -231,8 +231,8 @@ methods:
     response:
       params:
         - name: response
-          type: boolean
+          type: Data
           nullable: false
           since: 2.7
           doc: |
-            True if key was associated with newValue, otherwise false.
+            Result of the compare and set.


### PR DESCRIPTION
To communicate user facing exceptions on additive operations we need to generalise the return type of `CPMap.compareAndSet` from `boolean` to `Data`.

OS PR: https://github.com/hazelcast/hazelcast/pull/25975