### PR TITLE
Change int field for `ExperimentalPipelineSubmitCodec.resourceBundleChecksum` as not nullable

### DIFF
--- a/protocol-definitions/Experimental.yaml
+++ b/protocol-definitions/Experimental.yaml
@@ -29,7 +29,7 @@ methods:
           image with all the resources and project files included, this parameter can be null.'
         - name: resourceBundleChecksum
           type: int
-          nullable: true
+          nullable: false
           since: 2.7
           doc: 'This is the CRC32 checksum over the resource bundle bytes.'
     response:


### PR DESCRIPTION
The int field for `ExperimentalPipelineSubmitCodec.resourceBundleChecksum` should not be nullable.