### PR TITLE
Make Java clients copyright year dynamic

### DIFF
--- a/java/binary/client-binary-compatibility-template.j2
+++ b/java/binary/client-binary-compatibility-template.j2
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-{{ copyright_year }}, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java/binary/member-binary-compatibility-template.j2
+++ b/java/binary/member-binary-compatibility-template.j2
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-{{ copyright_year }}, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java/codec-template.java.j2
+++ b/java/codec-template.java.j2
@@ -35,7 +35,7 @@
 {% set response_var_sized_params = var_size_params(method.response.params) %}
 {% set response_new_params = new_params(method.since, method.response.params) %}
 /*
- * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-{{ copyright_year }}, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/java/custom-codec-template.java.j2
+++ b/java/custom-codec-template.java.j2
@@ -29,7 +29,7 @@
     {%- endif -%}
 {%- endmacro %}
 /*
- * Copyright (c) 2008-2023, Hazelcast, Inc. All Rights Reserved.
+ * Copyright (c) 2008-{{ copyright_year }}, Hazelcast, Inc. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Works in conjunction with https://github.com/hazelcast/hazelcast-mono/pull/324 to enable automated copyright year updates