### PR TITLE
Add a `resourceUrl` parameter to `ResourceDefinition` [HZ-4022]

### DIFF
--- a/protocol-definitions/custom/Custom.yaml
+++ b/protocol-definitions/custom/Custom.yaml
@@ -1462,4 +1462,8 @@ customTypes:
       - name: payload
         type: byteArray
         since: 2.7
-        nullable: false
+        nullable: true
+      - name: resourceUrl
+        type: String
+        since: 2.7
+        nullable: true


### PR DESCRIPTION
This is needed to support Operator/Viridian use-cases of User Code Namespaces.

Relates to: https://github.com/hazelcast/hazelcast-mono/pull/283