### PR TITLE
Add CPMap.putIfAbsent

### DIFF
--- a/protocol-definitions/CPMap.yaml
+++ b/protocol-definitions/CPMap.yaml
@@ -236,3 +236,44 @@ methods:
           since: 2.7
           doc: |
             True if key was associated with newValue, otherwise false.
+  - id: 7
+    name: putIfAbsent
+    since: 2.7
+    doc: |
+      Puts the key-value into the specified map if the key is not currently associated with a value.
+    request:
+      retryable: false
+      partitionIdentifier: -1
+      params:
+        - name: groupId
+          type: RaftGroupId
+          nullable: false
+          since: 2.7
+          doc: |
+            CP group ID of this CPMap instance.
+        - name: name
+          type: String
+          nullable: false
+          since: 2.7
+          doc: |
+            Name of this CPMap instance.
+        - name: key
+          type: Data
+          nullable: false
+          since: 2.7
+          doc: |
+            Key of the value.
+        - name: value
+          type: Data
+          nullable: false
+          since: 2.7
+          doc: |
+            Value to associate with the key.
+    response:
+      params:
+        - name: response
+          type: Data
+          nullable: true
+          since: 2.7
+          doc: |
+            Previous value associated with the key. 

--- a/protocol-definitions/CPMap.yaml
+++ b/protocol-definitions/CPMap.yaml
@@ -276,4 +276,4 @@ methods:
           nullable: true
           since: 2.7
           doc: |
-            Previous value associated with the key. 
+            Value associated with the key if already present.

--- a/protocol-definitions/CPMap.yaml
+++ b/protocol-definitions/CPMap.yaml
@@ -276,4 +276,4 @@ methods:
           nullable: true
           since: 2.7
           doc: |
-            Value associated with the key if already present.
+            Value associated with the key if already present, otherwise null.


### PR DESCRIPTION
Adds `putIfAbsent` for `CPMap` for parity with `IMap` so one can atomically associate a key with a value if the key does not exist.

Hazelcast Mono PR: https://github.com/hazelcast/hazelcast-mono/pull/495