### PR TITLE
Update `updateMapConfig` task with new parameter [HZ-4221]

### DIFF
--- a/protocol-definitions/MC.yaml
+++ b/protocol-definitions/MC.yaml
@@ -224,19 +224,12 @@ methods:
             7 - USED_NATIVE_MEMORY_PERCENTAGE
             8 - FREE_NATIVE_MEMORY_SIZE
             9 - FREE_NATIVE_MEMORY_PERCENTAGE
-        - name: applyWanReplicationRef
-          type: boolean
-          nullable: false
-          since: 2.7
-          doc: |
-            Determines whether the supplied WanReplicationRef should be applied.
-            This is for backwards compatible versioning, as supplying a null WanReplicationRef is valid.
         - name: wanReplicationRef
           type: WanReplicationRef
           nullable: true
           since: 2.7
           doc: |
-            The new WanReplicationRef to apply, if applyWanReplicationRef is true.
+            The new WanReplicationRef to apply.
     response: {}
   - id: 5
     name: getMemberConfig

--- a/protocol-definitions/MC.yaml
+++ b/protocol-definitions/MC.yaml
@@ -224,6 +224,19 @@ methods:
             7 - USED_NATIVE_MEMORY_PERCENTAGE
             8 - FREE_NATIVE_MEMORY_SIZE
             9 - FREE_NATIVE_MEMORY_PERCENTAGE
+        - name: applyWanReplicationRef
+          type: boolean
+          nullable: false
+          since: 2.7
+          doc: |
+            Determines whether the supplied WanReplicationRef should be applied.
+            This is for backwards compatible versioning, as supplying a null WanReplicationRef is valid.
+        - name: wanReplicationRef
+          type: WanReplicationRef
+          nullable: true
+          since: 2.7
+          doc: |
+            The new WanReplicationRef to apply, if applyWanReplicationRef is true.
     response: {}
   - id: 5
     name: getMemberConfig


### PR DESCRIPTION
We are expanding the `UpdateMapConfigOperation` to include the `WanReplicationRef` parameter.

Mono PR: https://github.com/hazelcast/hazelcast-mono/pull/544