### PR TITLE
Add the cluster meta data to authentication response [API-2171]

### DIFF
--- a/protocol-definitions/Client.yaml
+++ b/protocol-definitions/Client.yaml
@@ -278,25 +278,25 @@ methods:
         - name: memberListVersion
           type: int
           nullable: false
-          since: 2.0
+          since: 2.7
           doc: |
             Incremental member list version
         - name: memberInfos
           type: List_MemberInfo
           nullable: false
-          since: 2.0
+          since: 2.7
           doc: |
             List of member infos  at the cluster associated with the given version
         - name: partitionListVersion
           type: int
           nullable: false
-          since: 2.0
+          since: 2.7
           doc: |
             Incremental state version of the partition table
         - name: partitions
           type: EntryList_UUID_List_Integer
           nullable: false
-          since: 2.0
+          since: 2.7
           doc: |
             The partition table. In each entry, it has uuid of the member and list of partitions belonging to that member
   - id: 3

--- a/protocol-definitions/Client.yaml
+++ b/protocol-definitions/Client.yaml
@@ -130,6 +130,30 @@ methods:
           doc: |
             Returns the token to use while authenticating TPC channels 
             or null if TPC is disabled.
+        - name: memberListVersion
+          type: int
+          nullable: false
+          since: 2.0
+          doc: |
+            Incremental member list version
+        - name: memberInfos
+          type: List_MemberInfo
+          nullable: false
+          since: 2.0
+          doc: |
+            List of member infos  at the cluster associated with the given version
+        - name: partitionListVersion
+          type: int
+          nullable: false
+          since: 2.0
+          doc: |
+            Incremental state version of the partition table
+        - name: partitions
+          type: EntryList_UUID_List_Integer
+          nullable: false
+          since: 2.0
+          doc: |
+            The partition table. In each entry, it has uuid of the member and list of partitions belonging to that member
   - id: 2
     name: authenticationCustom
     since: 2.0
@@ -251,6 +275,30 @@ methods:
           doc: |
             Returns the token to use while authenticating TPC channels 
             or null if TPC is disabled.
+        - name: memberListVersion
+          type: int
+          nullable: false
+          since: 2.0
+          doc: |
+            Incremental member list version
+        - name: memberInfos
+          type: List_MemberInfo
+          nullable: false
+          since: 2.0
+          doc: |
+            List of member infos  at the cluster associated with the given version
+        - name: partitionListVersion
+          type: int
+          nullable: false
+          since: 2.0
+          doc: |
+            Incremental state version of the partition table
+        - name: partitions
+          type: EntryList_UUID_List_Integer
+          nullable: false
+          since: 2.0
+          doc: |
+            The partition table. In each entry, it has uuid of the member and list of partitions belonging to that member
   - id: 3
     name: addClusterViewListener
     since: 2.0

--- a/protocol-definitions/Client.yaml
+++ b/protocol-definitions/Client.yaml
@@ -133,25 +133,25 @@ methods:
         - name: memberListVersion
           type: int
           nullable: false
-          since: 2.0
+          since: 2.7
           doc: |
             Incremental member list version
         - name: memberInfos
           type: List_MemberInfo
           nullable: false
-          since: 2.0
+          since: 2.7
           doc: |
             List of member infos  at the cluster associated with the given version
         - name: partitionListVersion
           type: int
           nullable: false
-          since: 2.0
+          since: 2.7
           doc: |
             Incremental state version of the partition table
         - name: partitions
           type: EntryList_UUID_List_Integer
           nullable: false
-          since: 2.0
+          since: 2.7
           doc: |
             The partition table. In each entry, it has uuid of the member and list of partitions belonging to that member
   - id: 2

--- a/protocol-definitions/Client.yaml
+++ b/protocol-definitions/Client.yaml
@@ -135,7 +135,7 @@ methods:
           nullable: false
           since: 2.7
           doc: |
-            Incremental member list version
+            Incremental member list version. -1 if no member list is available.
         - name: memberInfos
           type: List_MemberInfo
           nullable: false
@@ -147,7 +147,7 @@ methods:
           nullable: false
           since: 2.7
           doc: |
-            Incremental state version of the partition table
+            Incremental state version of the partition table. -1 if no partition table is available.
         - name: partitions
           type: EntryList_UUID_List_Integer
           nullable: false

--- a/protocol-definitions/Client.yaml
+++ b/protocol-definitions/Client.yaml
@@ -283,7 +283,7 @@ methods:
             Incremental member list version
         - name: memberInfos
           type: List_MemberInfo
-          nullable: false
+          nullable: true
           since: 2.7
           doc: |
             List of member infos  at the cluster associated with the given version
@@ -295,7 +295,7 @@ methods:
             Incremental state version of the partition table
         - name: partitions
           type: EntryList_UUID_List_Integer
-          nullable: false
+          nullable: true
           since: 2.7
           doc: |
             The partition table. In each entry, it has uuid of the member and list of partitions belonging to that member


### PR DESCRIPTION
Added the cluster meta data, the member list and partition table information at the client authentication response so that the client does not have to wait the next cluster view event to start or continue the operation.

hazelcast pr: https://github.com/hazelcast/hazelcast-mono/pull/772