### PR TITLE
Support updating WAN replication reference of IMap [MC-2640]

### DIFF
--- a/protocol-definitions/MC.yaml
+++ b/protocol-definitions/MC.yaml
@@ -159,6 +159,12 @@ methods:
           since: 2.4
           doc: |
             Global indexes of the map.
+        - name: wanReplicationRef
+          type: WanReplicationRef
+          nullable: true
+          since: 2.7
+          doc: |
+            WanReplicationRef of the map.
   - id: 4
     name: updateMapConfig
     since: 2.0

--- a/protocol-definitions/MC.yaml
+++ b/protocol-definitions/MC.yaml
@@ -164,7 +164,7 @@ methods:
           nullable: true
           since: 2.7
           doc: |
-            WanReplicationRef of the map.
+            WanReplicationRef of the map. WanReplicationRef is WAN replication target of the map.
   - id: 4
     name: updateMapConfig
     since: 2.0


### PR DESCRIPTION
- To support update WAN replication reference from MC, need to get wan reference of a map using getMapConfig task.
- MC Jira ticket => [MC-2640](https://hazelcast.atlassian.net/browse/MC-2640)
- Platform PR => https://github.com/hazelcast/hazelcast-mono/pull/865

[MC-2640]: https://hazelcast.atlassian.net/browse/MC-2640?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ