### PR TITLE
Add vector search hints [HZAI-52]

### DIFF
--- a/binary/reference_objects.py
+++ b/binary/reference_objects.py
@@ -88,7 +88,10 @@ objects = {
     'VectorSearchOptions': {
         'includeValue': False,
         'includeVectors': False,
-        'limit': 100
+        'limit': 100,
+        'hints':  {
+            STRING: STRING
+        }
     },
     'VectorPair': {
         'type': 0

--- a/java/__init__.py
+++ b/java/__init__.py
@@ -190,7 +190,7 @@ _java_types_decode = {
     "CPMember": "com.hazelcast.cp.internal.CPMemberInfo",
     "MigrationState": "com.hazelcast.internal.partition.MigrationStateImpl",
     "VectorDocument": "com.hazelcast.vector.impl.DataVectorDocument",
-    "VectorSearchOptions": "com.hazelcast.vector.impl.SearchOptionsImpl",
+    "VectorSearchOptions": "com.hazelcast.vector.SearchOptions",
     "VectorIndexConfig": "com.hazelcast.config.vector.VectorIndexConfig",
     "VectorSearchResult": "com.hazelcast.vector.impl.DataSearchResult",
     "VectorPair": "com.hazelcast.client.impl.protocol.codec.holder.VectorPairHolder",

--- a/protocol-definitions/custom/Custom.yaml
+++ b/protocol-definitions/custom/Custom.yaml
@@ -1577,6 +1577,10 @@ customTypes:
         type: List_VectorPair
         nullable: false
         since: 2.8
+      - name: hints
+        type: Map_String_String
+        nullable: true
+        since: 2.8
 
   - name: VectorSearchResult
     returnWithFactory: true


### PR DESCRIPTION
Add ability to pass extra flags, settings, etc. not affecting the meaning of the query but affecting the way how the query is executed or quality of the results.

Hint values are passed as string. Typed API for hints may be provided in clients as needed (see example in [Java API](https://github.com/hazelcast/hazelcast-mono/pull/1356/files#diff-992dd1b3f6a13aeeb32fd501dc680058b2d5ed3087c3f926bdf81ff9846114cbR14)). 