### PR TITLE
Add routing mode to client auth [CORE-62]

### DIFF
--- a/protocol-definitions/Client.yaml
+++ b/protocol-definitions/Client.yaml
@@ -66,6 +66,12 @@ methods:
           since: 2.0
           doc: |
             User defined labels of the client instance
+        - name: routingMode
+          type: byte
+          nullable: false
+          since: 2.8
+          doc: |
+            Identifies the routing mode of the client. It can be UNISCOKET(0), SMART(1) or UNISCOKET(2).
     response:
       params:
         - name: status
@@ -217,6 +223,12 @@ methods:
           since: 2.0
           doc: |
             User defined labels of the client instance
+        - name: routingMode
+          type: byte
+          nullable: false
+          since: 2.8
+          doc: |
+            Identifies the routing mode of the client. It can be UNISCOKET(0), SMART(1) or UNISCOKET(2).
     response:
       params:
         - name: status

--- a/protocol-definitions/Client.yaml
+++ b/protocol-definitions/Client.yaml
@@ -71,7 +71,7 @@ methods:
           nullable: false
           since: 2.8
           doc: |
-            Identifies the routing mode of the client. It can be UNISCOKET(0), SMART(1) or UNISCOKET(2).
+            Identifies the routing mode of the client. It can be UNISCOKET(0), SMART(1) or SUBSET(2).
     response:
       params:
         - name: status
@@ -228,7 +228,7 @@ methods:
           nullable: false
           since: 2.8
           doc: |
-            Identifies the routing mode of the client. It can be UNISCOKET(0), SMART(1) or UNISCOKET(2).
+            Identifies the routing mode of the client. It can be UNISCOKET(0), SMART(1) or SUBSET(2).
     response:
       params:
         - name: status


### PR DESCRIPTION
Sends routing mode in client auth for metrics reporting on member side. 

mono repo PR: https://github.com/hazelcast/hazelcast-mono/pull/1966