### PR TITLE
Add backup counts in VectorCollectionConfig [AI-145]

### DIFF
--- a/protocol-definitions/DynamicConfig.yaml
+++ b/protocol-definitions/DynamicConfig.yaml
@@ -1440,11 +1440,23 @@ methods:
           nullable: false
           since: 2.8
           doc: |
-            vector collection's name
+            vector collection name
         - name: indexConfigs
           type: List_VectorIndexConfig
           nullable: false
           since: 2.8
           doc: |
-            item vector index configurations
+            vector index configurations
+        - name: backupCount
+          type: int
+          nullable: false
+          since: 2.9
+          doc: |
+            number of synchronous backups
+        - name: asyncBackupCount
+          type: int
+          nullable: false
+          since: 2.9
+          doc: |
+            number of asynchronous backups
     response: {}


### PR DESCRIPTION
ADR: https://hazelcast.atlassian.net/wiki/spaces/EN/pages/5212045313/ADR-00028-+Type+1+-Configuration+for+VectorCollection+fault+tolerance
Member PR: https://github.com/hazelcast/hazelcast-mono/pull/3121