### PR TITLE
Add uuid to Vector Collection optimize request [AI-148]

### DIFF
--- a/protocol-definitions/VectorCollection.yaml
+++ b/protocol-definitions/VectorCollection.yaml
@@ -270,6 +270,12 @@ methods:
           doc: |
             Name of the Index to optimize.
             A null value triggers the optimization of the only index within the collection.
+        - name: uuid
+          type: UUID
+          nullable: true
+          since: 2.9
+          doc: |
+            UUID of this optimization request.
     response: {}
 
   - id: 10


### PR DESCRIPTION
UUID is needed to recognise retried `optimize` invocations that may be still in progress from previous attempt.

Member PR: https://github.com/hazelcast/hazelcast-mono/pull/3428