### PR TITLE
Add split brain protection and merge policy in VectorCollectionConfig [AI-146] [AI-151] [AI-216]

### DIFF
--- a/protocol-definitions/DynamicConfig.yaml
+++ b/protocol-definitions/DynamicConfig.yaml
@@ -1459,4 +1459,25 @@ methods:
           since: 2.9
           doc: |
             number of asynchronous backups
+        - name: splitBrainProtectionName
+          type: String
+          nullable: true
+          since: 2.9
+          doc: |
+            Name of an existing configured split brain protection to be used to determine the minimum number of members
+            required in the cluster for the VectorCollection to remain functional. When {@code null}, split brain protection
+            does not apply to this VectorCollection's operations.
+        - name: mergePolicy
+          type: String
+          nullable: false
+          since: 2.9
+          doc: |
+            Name of a class implementing SplitBrainMergePolicy that handles merging of values for this VectorCollection
+            while recovering from network partitioning.
+        - name: mergeBatchSize
+          type: int
+          nullable: false
+          since: 2.9
+          doc: |
+            Number of entries to be sent in a merge operation.
     response: {}


### PR DESCRIPTION
New configuration elements, introduced in `VectorCollectionConfig` in order to support split-brain protection and merge policies in `VectorCollection`.

Member-side PR: https://github.com/hazelcast/hazelcast-mono/pull/3483