### PR TITLE
chore: fixed typo

### DIFF
--- a/protocol-definitions/Client.yaml
+++ b/protocol-definitions/Client.yaml
@@ -71,7 +71,7 @@ methods:
           nullable: false
           since: 2.8
           doc: |
-            Identifies the routing mode of the client. It can be UNISCOKET(0), SMART(1) or SUBSET(2).
+            Identifies the routing mode of the client. It can be UNISOCKET(0), SMART(1) or SUBSET(2).
         - name: cpDirectToLeaderRouting
           type: boolean
           nullable: false


### PR DESCRIPTION
Fixed typo in Client routing mode description: `UNISCOKET`