### PR TITLE
chore: fix off-by-one error with jinja loop index

### DIFF
--- a/md/documentation-template.j2
+++ b/md/documentation-template.j2
@@ -1267,7 +1267,7 @@ Header only response message, no message body exist.
             {% for event in method.events %}
 
 ##### {{ event.name }}
-**Message Type:** {{ "0x%02x%02x%02x"|format(service.id, method.id, 2 + loop.index) }}
+**Message Type:** {{ "0x%02x%02x%02x"|format(service.id, method.id, 1 + loop.index) }}
 
 | Name | Type | Nullable | Description | Available Since |
 | ---- | ---- | -------- | ----------- | --------------- |


### PR DESCRIPTION
Fixed off-by-one error in Event message_type.   According to the protocol the Least significant bit is set to 0 (Request), 1 (Response) and increments for each Event.

Message Type value for MembersView should end in 02, PartitionsView -> 03, MemberGroupsView -> 04

Instead it is off by 1 since the jinja loop.index starts at 1 not 0