### PR TITLE
Remove redundant `{`/`}` in annotation usage

### DIFF
--- a/java/codec-template.java.j2
+++ b/java/codec-template.java.j2
@@ -125,7 +125,7 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
 {% set singleRequestValue = method.request.params|length == 1 and request_new_params|length == 0 %}
 {% if not (noRequestValue or singleRequestValue) %}
 
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
     public static class RequestParameters {
     {% for param in method.request.params %}
 
@@ -235,7 +235,7 @@ public final class {{ service_name|capital }}{{ method.name|capital }}Codec {
 {% set singleResponseValue = method.response.params|length == 1 and response_new_params|length == 0 %}
 {% if not (noResponseValue or singleResponseValue) %}
 
-    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings({"URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD"})
+    @edu.umd.cs.findbugs.annotations.SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
     public static class ResponseParameters {
     {% for param in method.response.params %}
 


### PR DESCRIPTION
See https://github.com/hazelcast/hazelcast-mono/compare/master...JackPGreen:consistent-checkstyle-bracketing?expand=1