### PR TITLE
Change Diagnostics Log File Size Type [DEX-410]

### DIFF
--- a/protocol-definitions/MC.yaml
+++ b/protocol-definitions/MC.yaml
@@ -1040,4 +1040,10 @@ methods:
           since: 2.9
           doc: |
             Properties specific to DiagnosticsPlugin implementations
+        - name: autoOffTimerInMinutes
+          type: int
+          nullable: false
+          since: 2.9
+          doc: |
+            The auto time off duration for the service in minutes. The value must be positive. Set -1 only if you want to disable the auto time off feature.
     response: { }

--- a/protocol-definitions/MC.yaml
+++ b/protocol-definitions/MC.yaml
@@ -1011,7 +1011,7 @@ methods:
           doc: |
             Indicates if the epoch time should be included in the 'top' section
         - name: maxRolledFileSizeInMB
-          type: int
+          type: float
           nullable: false
           since: 2.9
           doc: |

--- a/schema/protocol-schema.json
+++ b/schema/protocol-schema.json
@@ -23,6 +23,7 @@
             "byte",
             "int",
             "long",
+            "float",
             "UUID",
             "byteArray",
             "longArray",


### PR DESCRIPTION
The PR changes the file size type on Diagnostics configuration. It is changed from in to float to accept size in KB.

Note: At time of PR created, the feature and protocol is not released yet. So, it doesn't break anything.