### PR TITLE
Introduce `getDiagnosticsConfig` for MC

### DIFF
--- a/protocol-definitions/MC.yaml
+++ b/protocol-definitions/MC.yaml
@@ -1040,7 +1040,7 @@ methods:
           since: 2.9
           doc: |
             Properties specific to DiagnosticsPlugin implementations
-        - name: autoOffTimerInMinutes
+        - name: autoOffDurationInMinutes
           type: int
           nullable: false
           since: 2.9
@@ -1105,13 +1105,13 @@ methods:
           since: 2.9
           doc: |
             Properties specific to DiagnosticsPlugin implementations
-        - name: autoOffTimerInMinutes
+        - name: autoOffDurationInMinutes
           type: int
           nullable: false
           since: 2.9
           doc: |
             The auto time off duration for the service in minutes. The value must be positive. Set -1 only if you want to disable the auto time off feature.
-        - name: canConfiguredDynamically
+        - name: canBeConfiguredDynamically
           type: boolean
           nullable: false
           since: 2.9

--- a/protocol-definitions/MC.yaml
+++ b/protocol-definitions/MC.yaml
@@ -1047,3 +1047,73 @@ methods:
           doc: |
             The auto time off duration for the service in minutes. The value must be positive. Set -1 only if you want to disable the auto time off feature.
     response: { }
+  - id: 40
+    name: getDiagnosticsConfig
+    since: 2.9
+    doc: |
+      Gets the diagnostics configuration from the member.
+    request:
+      retryable: true
+      partitionIdentifier: -1      
+    response: 
+      params:
+        - name: enabled
+          type: boolean
+          nullable: false
+          since: 2.9
+          doc: |
+            Indicates whether diagnostics service is enabled or not
+        - name: outputType
+          type: String
+          nullable: false
+          since: 2.9
+          doc: |
+            The output type for the diagnostics
+        - name: includeEpochTime
+          type: boolean
+          nullable: false
+          since: 2.9
+          doc: |
+            Indicates if the epoch time should be included in the 'top' section
+        - name: maxRolledFileSizeInMB
+          type: float
+          nullable: false
+          since: 2.9
+          doc: |
+            The maximum size in MB for a single file
+        - name: maxRolledFileCount
+          type: int
+          nullable: false
+          since: 2.9
+          doc: |
+            The maximum number of rolling files to keep on disk
+        - name: logDirectory
+          type: String
+          nullable: false
+          since: 2.9
+          doc: |
+            The path of output directory for the diagnostics log files. It can be a relative path to the working directory or an absolute path
+        - name: fileNamePrefix
+          type: String
+          nullable: true
+          since: 2.9
+          doc: |
+            The prefix for the diagnostics file
+        - name: properties
+          type: Map_String_String
+          nullable: true
+          since: 2.9
+          doc: |
+            Properties specific to DiagnosticsPlugin implementations
+        - name: autoOffTimerInMinutes
+          type: int
+          nullable: false
+          since: 2.9
+          doc: |
+            The auto time off duration for the service in minutes. The value must be positive. Set -1 only if you want to disable the auto time off feature.
+        - name: canConfiguredDynamically
+          type: boolean
+          nullable: false
+          since: 2.9
+          doc: |
+            Indicates whether the diagnostics service can be configured dynamically or not


### PR DESCRIPTION
A message added to MC codecs to read the `DiagnosticsConfig` from a member. It is handy for MC and Operator when they need to read the diagnostics config arbitrarily. Since `DiagnosticsConfig` removed from public API https://github.com/hazelcast/hazelcast-mono/pull/4451, this requirement emerged. 