### PR TITLE
Use DataCodec directly for handling nullable `Data` [HZG-446]

### DIFF
--- a/java/codec-template.java.j2
+++ b/java/codec-template.java.j2
@@ -7,7 +7,11 @@
         MapCodec.encode{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param.name }}, {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
     {%- else -%}
         {%- if param.nullable  -%}
-            CodecUtil.encodeNullable(clientMessage, {{ param.name }}, {{ lang_name(param.type) }}Codec::encode)
+            {%- if param.type == 'Data' -%}
+                DataCodec.encodeNullable(clientMessage, {{ param.name }})
+            {%- else -%}
+                CodecUtil.encodeNullable(clientMessage, {{ param.name }}, {{ lang_name(param.type) }}Codec::encode)
+            {%- endif -%}
         {%- else -%}
             {{ lang_name(param.type) }}Codec.encode(clientMessage, {{ param.name }})
         {%- endif %}

--- a/java/custom-codec-template.java.j2
+++ b/java/custom-codec-template.java.j2
@@ -7,7 +7,11 @@
         MapCodec.encode{% if param.nullable  %}Nullable{% endif %}(clientMessage, {{ param_name(codec.name)}}.{% if param.type == 'boolean' %}is{% else %}get{% endif %}{{ param.name|capital }}(), {{ key_type(lang_name, param.type) }}Codec::encode, {{ value_type(lang_name, param.type) }}Codec::encode)
     {%- else -%}
         {%- if param.nullable  -%}
-            CodecUtil.encodeNullable(clientMessage, {{ param_name(codec.name)}}.{% if param.type == 'boolean' %}is{% else %}get{% endif %}{{ param.name|capital }}(), {{ lang_name(param.type) }}Codec::encode)
+            {%- if param.type == 'Data' -%}
+                DataCodec.encodeNullable(clientMessage, {{ param_name(codec.name)}}.{% if param.type == 'boolean' %}is{% else %}get{% endif %}{{ param.name|capital }}())
+            {%- else -%}
+                CodecUtil.encodeNullable(clientMessage, {{ param_name(codec.name)}}.{% if param.type == 'boolean' %}is{% else %}get{% endif %}{{ param.name|capital }}(), {{ lang_name(param.type) }}Codec::encode)
+            {%- endif -%}
         {%- else -%}
             {{ lang_name(param.type) }}Codec.encode(clientMessage, {{ param_name(codec.name)}}.{% if param.type == 'boolean' %}is{% else %}get{% endif %}{{ param.name|capital }}())
         {%- endif %}


### PR DESCRIPTION
Using `DataCodec` directly allows special handling of different representations of null for nullable `Data` fields in https://github.com/hazelcast/hazelcast-mono/pull/4629