### PR TITLE
Fix `ScheduledExecutor` Javadoc

### DIFF
--- a/protocol-definitions/ScheduledExecutor.yaml
+++ b/protocol-definitions/ScheduledExecutor.yaml
@@ -478,7 +478,7 @@ methods:
     since: 2.0
     doc: |
       Checks whether a task is done.
-      @see {@link java.util.concurrent.Future#cancel(boolean)}
+      @see java.util.concurrent.Future#cancel(boolean)
     request:
       retryable: true
       partitionIdentifier: taskName
@@ -508,7 +508,7 @@ methods:
     since: 2.0
     doc: |
       Checks whether a task is done.
-      @see {@link java.util.concurrent.Future#cancel(boolean)}
+      @see java.util.concurrent.Future#cancel(boolean)
     request:
       retryable: true
       partitionIdentifier: -1


### PR DESCRIPTION
`@link` is implicit with `@see` and they cannot be combined.