### PR TITLE
Encode since tag as string in yaml definition files

### DIFF
--- a/protocol-definitions/AtomicLong.yaml
+++ b/protocol-definitions/AtomicLong.yaml
@@ -3,7 +3,7 @@ name: AtomicLong
 methods:
   - id: 1
     name: apply
-    since: 2.0
+    since: "2.0"
     doc: |
       Applies a function on the value, the actual stored value will not change
     request:
@@ -13,19 +13,19 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this IAtomicLong instance.
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of this IAtomicLong instance.
         - name: function
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The function applied to the value and the value is not
             changed.
@@ -34,12 +34,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The result of the function application.
   - id: 2
     name: alter
-    since: 2.0
+    since: "2.0"
     doc: |
       Alters the currently stored value by applying a function on it.
     request:
@@ -49,25 +49,25 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this IAtomicLong instance.
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of this IAtomicLong instance.
         - name: function
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The function applied to the currently stored value.
         - name: returnValueType
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             0 returns the old value, 1 returns the new value
     response:
@@ -75,12 +75,12 @@ methods:
         - name: response
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The old or the new value depending on the returnValueType parameter.
   - id: 3
     name: addAndGet
-    since: 2.0
+    since: "2.0"
     doc: |
       Atomically adds the given value to the current value.
     request:
@@ -90,19 +90,19 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this IAtomicLong instance.
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of this IAtomicLong instance.
         - name: delta
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The value to add to the current value
     response:
@@ -110,12 +110,12 @@ methods:
         - name: response
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the updated value, the given value added to the current value
   - id: 4
     name: compareAndSet
-    since: 2.0
+    since: "2.0"
     doc: |
       Atomically sets the value to the given updated value only if the current
       value the expected value.
@@ -126,25 +126,25 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this IAtomicLong instance.
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of this IAtomicLong instance.
         - name: expected
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The expected value
         - name: updated
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The new value
     response:
@@ -152,13 +152,13 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if successful; or false if the actual value
             was not equal to the expected value.
   - id: 5
     name: get
-    since: 2.0
+    since: "2.0"
     doc: |
       Gets the current value.
     request:
@@ -168,13 +168,13 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this IAtomicLong instance.
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of this IAtomicLong instance.
     response:
@@ -182,12 +182,12 @@ methods:
         - name: response
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The current value
   - id: 6
     name: getAndAdd
-    since: 2.0
+    since: "2.0"
     doc: |
       Atomically adds the given value to the current value.
     request:
@@ -197,19 +197,19 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this IAtomicLong instance.
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of this IAtomicLong instance.
         - name: delta
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The value to add to the current value
     response:
@@ -217,12 +217,12 @@ methods:
         - name: response
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the old value before the add
   - id: 7
     name: getAndSet
-    since: 2.0
+    since: "2.0"
     doc: |
       Atomically sets the given value and returns the old value.
     request:
@@ -232,19 +232,19 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this IAtomicLong instance.
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of this IAtomicLong instance.
         - name: newValue
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The new value
     response:
@@ -252,6 +252,6 @@ methods:
         - name: response
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the old value

--- a/protocol-definitions/AtomicRef.yaml
+++ b/protocol-definitions/AtomicRef.yaml
@@ -3,7 +3,7 @@ name: AtomicRef
 methods:
   - id: 1
     name: apply
-    since: 2.0
+    since: "2.0"
     doc: |
       Applies a function on the value
     request:
@@ -13,32 +13,32 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this IAtomicReference instance.
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of this IAtomicReference instance.
         - name: function
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The function applied to the value.
         - name: returnValueType
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             0 returns no value, 1 returns the old value,
             2 returns the new value
         - name: alter
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Denotes whether result of the function will be
             set to the IAtomicRefInstance
@@ -47,12 +47,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The result of the function application.
   - id: 2
     name: compareAndSet
-    since: 2.0
+    since: "2.0"
     doc: |
       Alters the currently stored value by applying a function on it.
     request:
@@ -62,25 +62,25 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this IAtomicReference instance.
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of this IAtomicReference instance.
         - name: oldValue
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The expected value
         - name: newValue
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The new value
     response:
@@ -88,13 +88,13 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if successful; or false if the actual value
             was not equal to the expected value.
   - id: 3
     name: contains
-    since: 2.0
+    since: "2.0"
     doc: |
       Checks if the reference contains the value.
     request:
@@ -104,19 +104,19 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this IAtomicReference instance.
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of this IAtomicReference instance.
         - name: value
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The value to check (is allowed to be null).
     response:
@@ -124,12 +124,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if the value is found, false otherwise.
   - id: 4
     name: get
-    since: 2.0
+    since: "2.0"
     doc: |
       Gets the current value.
     request:
@@ -139,13 +139,13 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this IAtomicReference instance.
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of this IAtomicReference instance.
     response:
@@ -153,12 +153,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The current value
   - id: 5
     name: set
-    since: 2.0
+    since: "2.0"
     doc: |
       Atomically sets the given value
     request:
@@ -168,25 +168,25 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this IAtomicReference instance.
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of this IAtomicReference instance.
         - name: newValue
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The value to set
         - name: returnOldValue
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Denotes whether the old value is returned or not
     response:
@@ -194,7 +194,7 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             the old value or null, depending on
             the {

--- a/protocol-definitions/CPGroup.yaml
+++ b/protocol-definitions/CPGroup.yaml
@@ -3,7 +3,7 @@ name: CPGroup
 methods:
   - id: 1
     name: createCPGroup
-    since: 2.0
+    since: "2.0"
     doc: |
       Creates a new CP group with the given name
     request:
@@ -13,7 +13,7 @@ methods:
         - name: proxyName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The proxy name of this data structure instance
     response:
@@ -21,12 +21,12 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the CP group that contains the CP object
   - id: 2
     name: destroyCPObject
-    since: 2.0
+    since: "2.0"
     doc: |
       Destroys the distributed object with the given name on the requested
       CP group
@@ -37,19 +37,19 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this distributed object
         - name: serviceName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The service of this distributed object
         - name: objectName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of this distributed object
     response: {}

--- a/protocol-definitions/CPMap.yaml
+++ b/protocol-definitions/CPMap.yaml
@@ -3,7 +3,7 @@ name: CPMap
 methods:
   - id: 1
     name: get
-    since: 2.7
+    since: "2.7"
     doc: |
       Gets the value associated with the key in the specified map.
     request:
@@ -13,19 +13,19 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             CP group ID of this CPMap instance.
         - name: name
           type: String
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Name of this CPMap instance.
         - name: key
           type: Data
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Key of the value to retrieve.
     response:
@@ -33,12 +33,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             The result of the map lookup. 
   - id: 2
     name: put
-    since: 2.7
+    since: "2.7"
     doc: |
       Puts the key-value into the specified map.
     request:
@@ -48,25 +48,25 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             CP group ID of this CPMap instance.
         - name: name
           type: String
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Name of this CPMap instance.
         - name: key
           type: Data
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Key of the value.
         - name: value
           type: Data
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Value to associate with the key.
     response:
@@ -74,12 +74,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             Previous value associated with the key. 
   - id: 3
     name: set
-    since: 2.7
+    since: "2.7"
     doc: |
       Sets the key-value in the specified map.
     request:
@@ -89,25 +89,25 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             CP group ID of this CPMap instance.
         - name: name
           type: String
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Name of this CPMap instance.
         - name: key
           type: Data
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Key of the value.
         - name: value
           type: Data
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Value to associate with the key.
     response:
@@ -115,12 +115,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             Always null, set does not return any previous value.
   - id: 4
     name: remove
-    since: 2.7
+    since: "2.7"
     doc: |
       Removes the value associated with the key in the specified map.
     request:
@@ -130,19 +130,19 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             CP group ID of this CPMap instance.
         - name: name
           type: String
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Name of this CPMap instance.
         - name: key
           type: Data
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Key of the value to remove.
     response:
@@ -150,12 +150,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             The result of the remove. 
   - id: 5
     name: delete
-    since: 2.7
+    since: "2.7"
     doc: |
       Deletes the value associated with the key in the specified map.
     request:
@@ -165,19 +165,19 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             CP group ID of this CPMap instance.
         - name: name
           type: String
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Name of this CPMap instance.
         - name: key
           type: Data
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Key of the value to delete.
     response:
@@ -185,12 +185,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             Always null, delete does not return any value.
   - id: 6
     name: compareAndSet
-    since: 2.7
+    since: "2.7"
     doc: |
       Tests if the value associated with the key is expectedValue and if so associates key with
       newValue.
@@ -201,31 +201,31 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             CP group ID of this CPMap instance.
         - name: name
           type: String
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Name of this CPMap instance.
         - name: key
           type: Data
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Key of the data that is subject of the compare and set.
         - name: expectedValue
           type: Data
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             The expected value associated with key.
         - name: newValue
           type: Data
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             The new value to associate with key.
     response:
@@ -233,12 +233,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             True if key was associated with newValue, otherwise false.
   - id: 7
     name: putIfAbsent
-    since: 2.7
+    since: "2.7"
     doc: |
       Puts the key-value into the specified map if the key is not currently associated with a value.
     request:
@@ -248,25 +248,25 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             CP group ID of this CPMap instance.
         - name: name
           type: String
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Name of this CPMap instance.
         - name: key
           type: Data
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Key of the value.
         - name: value
           type: Data
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Value to associate with the key.
     response:
@@ -274,6 +274,6 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             Value associated with the key if already present, otherwise null.

--- a/protocol-definitions/CPSession.yaml
+++ b/protocol-definitions/CPSession.yaml
@@ -3,7 +3,7 @@ name: CPSession
 methods:
   - id: 1
     name: createSession
-    since: 2.0
+    since: "2.0"
     doc: |
       Creates a session for the caller on the given CP group.
     request:
@@ -13,13 +13,13 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the CP group
         - name: endpointName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the caller HazelcastInstance
     response:
@@ -27,24 +27,24 @@ methods:
         - name: sessionId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Id of the session.
         - name: ttlMillis
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Time to live value in milliseconds that must be respected by the caller.
         - name: heartbeatMillis
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Time between heartbeats in milliseconds that must be respected by the caller.
   - id: 2
     name: closeSession
-    since: 2.0
+    since: "2.0"
     doc: |
       Closes the given session on the given CP group
     request:
@@ -54,13 +54,13 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the CP group
         - name: sessionId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the session
     response:
@@ -68,13 +68,13 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if the session is found & closed,
             false otherwise.
   - id: 3
     name: heartbeatSession
-    since: 2.0
+    since: "2.0"
     doc: |
       Commits a heartbeat for the given session on the given cP group and
       extends its session expiration time.
@@ -85,19 +85,19 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the CP group
         - name: sessionId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the session
     response: {}
   - id: 4
     name: generateThreadId
-    since: 2.0
+    since: "2.0"
     doc: |
       Generates a new ID for the caller thread. The ID is unique in the given
       CP group.
@@ -108,7 +108,7 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the CP group
     response:
@@ -116,6 +116,6 @@ methods:
         - name: response
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             A unique ID for the caller thread

--- a/protocol-definitions/CPSubsystem.yaml
+++ b/protocol-definitions/CPSubsystem.yaml
@@ -3,7 +3,7 @@ name: CPSubsystem
 methods:
   - id: 1
     name: addMembershipListener
-    since: 2.1
+    since: "2.1"
     doc: |
       Registers a new CP membership listener.
     request:
@@ -13,7 +13,7 @@ methods:
         - name: local
           type: boolean
           nullable: false
-          since: 2.1
+          since: "2.1"
           doc: |
             Denotes whether register a local listener or not.
     response:
@@ -21,28 +21,28 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.1
+          since: "2.1"
           doc: |
             Registration id for the listener.
     events:
       - name: MembershipEvent
-        since: 2.1
+        since: "2.1"
         params:
           - name: member
             type: CPMember
             nullable: false
-            since: 2.1
+            since: "2.1"
             doc: |
               Member which is added or removed.
           - name: type
             type: byte
             nullable: false
-            since: 2.1
+            since: "2.1"
             doc: |
               Type of the event. It is either ADDED(1) or REMOVED(2).
   - id: 2
     name: removeMembershipListener
-    since: 2.1
+    since: "2.1"
     doc: |
       Deregisters CP membership listener.
     request:
@@ -52,7 +52,7 @@ methods:
         - name: registrationId
           type: UUID
           nullable: false
-          since: 2.1
+          since: "2.1"
           doc: |
             The id of the listener which was provided during registration.
     response:
@@ -60,12 +60,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.1
+          since: "2.1"
           doc: |
             True if unregistered, false otherwise.
   - id: 3
     name: addGroupAvailabilityListener
-    since: 2.1
+    since: "2.1"
     doc: |
       Registers a new CP group availability listener.
     request:
@@ -75,7 +75,7 @@ methods:
         - name: local
           type: boolean
           nullable: false
-          since: 2.1
+          since: "2.1"
           doc: |
             Denotes whether register a local listener or not.
     response:
@@ -83,40 +83,40 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.1
+          since: "2.1"
           doc: |
             Registration id for the listener.
     events:
       - name: GroupAvailabilityEvent
-        since: 2.1
+        since: "2.1"
         params:
           - name: groupId
             type: RaftGroupId
             nullable: false
-            since: 2.1
+            since: "2.1"
             doc: |
               Group id whose availability is reported.
           - name: members
             type: List_CPMember
             nullable: false
-            since: 2.1
+            since: "2.1"
             doc: |
               All members.
           - name: unavailableMembers
             type: List_CPMember
             nullable: false
-            since: 2.1
+            since: "2.1"
             doc: |
               Missing members.
           - name: isShutdown
             type: boolean
             nullable: false
-            since: 2.7
+            since: "2.7"
             doc: |
               Determines if the availability event is due to an explicit shutdown.
   - id: 4
     name: removeGroupAvailabilityListener
-    since: 2.1
+    since: "2.1"
     doc: |
       Deregisters CP availability listener.
     request:
@@ -126,7 +126,7 @@ methods:
         - name: registrationId
           type: UUID
           nullable: false
-          since: 2.1
+          since: "2.1"
           doc: |
             The id of the listener which was provided during registration.
     response:
@@ -134,12 +134,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.1
+          since: "2.1"
           doc: |
             True if unregistered, false otherwise.
   - id: 5
     name: getCPGroupIds
-    since: 2.7
+    since: "2.7"
     doc: |
       Returns all the active CP group ids in the cluster. This is mainly used by a client side CPSubsystem because it does not 
       have a RaftService.
@@ -151,12 +151,12 @@ methods:
         - name: response
           type: List_RaftGroupId
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             List of active CP group ids.
   - id: 6
     name: getCPObjectInfos
-    since: 2.7
+    since: "2.7"
     doc: |
       Returns all active CP structures that belong to the group with the provided CPGroupId and service name.
       A snapshot is used to retrieve the result.
@@ -167,19 +167,19 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Defines the cp group to return cp structures from
         - name: serviceName
           type: String
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             The service name of the cp structures to return
         - name: tombstone
           type: boolean
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Whether to return cp tombstones. If true, only tombstones will be returned. If false, 
             only non-tombstone cp structures will be returned.
@@ -188,6 +188,6 @@ methods:
         - name: response
           type: List_String
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             List of names of CP structures that belong to the specified cp group and service.

--- a/protocol-definitions/Cache.yaml
+++ b/protocol-definitions/Cache.yaml
@@ -3,7 +3,7 @@ name: Cache
 methods:
   - id: 1
     name: addEntryListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds an entry listener for this cache. For the types of events that the listener
       will be notified for, see the documentation of the type field of the Cache event below.
@@ -14,13 +14,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache.
         - name: localOnly
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             If true fires events that originated from this node only, otherwise fires all events
     response:
@@ -28,17 +28,17 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Registration id for the registered listener.
     events:
       - name: Cache
-        since: 2.0
+        since: "2.0"
         params:
           - name: type
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               The type of the event. Possible values for the event are:
               CREATED(1): An event type indicating that the cache entry was created.
@@ -53,19 +53,19 @@ methods:
           - name: keys
             type: List_CacheEventData
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               The keys of the entries in the cache.
           - name: completionId
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               User generated id which shall be received as a field of the cache event upon completion of the
               request in the cluster.
   - id: 2
     name: clear
-    since: 2.0
+    since: "2.0"
     doc: |
       Clears the contents of the cache, without notifying listeners or CacheWriters.
     request:
@@ -75,13 +75,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache.
     response: {}
   - id: 3
     name: removeAllKeys
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes entries for the specified keys. The order in which the individual entries are removed is undefined.
       For every entry in the key set, the following are called: any registered CacheEntryRemovedListeners if the cache
@@ -93,26 +93,26 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache.
         - name: keys
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The keys to remove.
         - name: completionId
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             User generated id which shall be received as a field of the cache event upon completion of
             the request in the cluster.
     response: {}
   - id: 4
     name: removeAll
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes all of the mappings from this cache. The order that the individual entries are removed is undefined.
       For every mapping that exists the following are called: any registered CacheEntryRemovedListener if the cache is
@@ -125,20 +125,20 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache.
         - name: completionId
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             User generated id which shall be received as a field of the cache event upon completion of
             the request in the cluster.
     response: {}
   - id: 5
     name: containsKey
-    since: 2.0
+    since: "2.0"
     doc: |
       Determines if the Cache contains an entry for the specified key. More formally, returns true if and only if this
       cache contains a mapping for a key k such that key.equals(k). (There can be at most one such mapping.)
@@ -149,13 +149,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The key whose presence in this cache is to be tested.
     response:
@@ -163,12 +163,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Returns true if cache value for the key exists, false otherwise.
   - id: 6
     name: createConfig
-    since: 2.0
+    since: "2.0"
     doc: |
       Creates the given cache configuration on Hazelcast members.
     request:
@@ -178,13 +178,13 @@ methods:
         - name: cacheConfig
           type: CacheConfigHolder
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The cache configuration.
         - name: createAlsoOnOthers
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if the configuration shall be created on all members, false otherwise.
     response:
@@ -192,12 +192,12 @@ methods:
         - name: response
           type: CacheConfigHolder
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The created configuration object.
   - id: 7
     name: destroy
-    since: 2.0
+    since: "2.0"
     doc: |
       Closes the cache. Clears the internal content and releases any resource.
     request:
@@ -207,13 +207,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache.
     response: {}
   - id: 8
     name: entryProcessor
-    since: 2.0
+    since: "2.0"
     doc: |
       Applies the user defined EntryProcessor to entry mapped by the key.
       Returns the result of the processing, if any, defined by the implementation.
@@ -224,32 +224,32 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the key to the entry
         - name: entryProcessor
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Entry processor to invoke. Byte-array which is serialized from an object implementing
             javax.cache.processor.EntryProcessor.
         - name: arguments
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             additional arguments to pass to the EntryProcessor
         - name: completionId
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             User generated id which shall be received as a field of the cache event upon completion of
             the request in the cluster.
@@ -258,12 +258,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             the result of the processing, if any, defined by the EntryProcessor implementation
   - id: 9
     name: getAll
-    since: 2.0
+    since: "2.0"
     doc: |
       Gets a collection of entries from the cache with custom expiry policy, returning them as Map of the values
       associated with the set of keys requested. If the cache is configured for read-through operation mode, the underlying
@@ -276,19 +276,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache.
         - name: keys
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The keys whose associated values are to be returned.
         - name: expiryPolicy
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Expiry policy for the entry. Byte-array which is serialized from an object implementing
             javax.cache.expiry.ExpiryPolicy interface.
@@ -297,13 +297,13 @@ methods:
         - name: response
           type: EntryList_Data_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             A map of entries that were found for the given keys. Keys not found
             in the cache are not in the returned map.
   - id: 10
     name: getAndRemove
-    since: 2.0
+    since: "2.0"
     doc: |
       Atomically removes the entry for a key only if currently mapped to some value.
     request:
@@ -313,19 +313,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             key with which the specified value is associated
         - name: completionId
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             User generated id which shall be received as a field of the cache event upon completion of
             the request in the cluster.
@@ -334,12 +334,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             the value if one existed or null if no mapping existed for this key
   - id: 11
     name: getAndReplace
-    since: 2.0
+    since: "2.0"
     doc: |
       Atomically replaces the assigned value of the given key by the specified value using a custom
       javax.cache.expiry.ExpiryPolicy and returns the previously assigned value. If the cache is configured for
@@ -352,32 +352,32 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The key whose value is replaced.
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The new value to be associated with the specified key.
         - name: expiryPolicy
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Expiry policy for the entry. Byte-array which is serialized from an object implementing
             javax.cache.expiry.ExpiryPolicy interface.
         - name: completionId
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             User generated id which shall be received as a field of the cache event upon completion of
             the request in the cluster.
@@ -386,12 +386,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The old value previously assigned to the given key.
   - id: 12
     name: getConfig
-    since: 2.0
+    since: "2.0"
     doc: |
       Gets the cache configuration with the given name from members.
     request:
@@ -401,13 +401,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache with prefix.
         - name: simpleName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache without prefix.
     response:
@@ -415,12 +415,12 @@ methods:
         - name: response
           type: CacheConfigHolder
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The cache configuration.
   - id: 13
     name: get
-    since: 2.0
+    since: "2.0"
     doc: |
       Retrieves the mapped value of the given key using a custom javax.cache.expiry.ExpiryPolicy. If no mapping exists
       null is returned. If the cache is configured for read-through operation mode, the underlying configured
@@ -432,19 +432,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The key whose mapped value is to be returned.
         - name: expiryPolicy
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Expiry policy for the entry. Byte-array which is serialized from an object implementing
             javax.cache.expiry.ExpiryPolicy interface.
@@ -453,12 +453,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The value assigned to the given key, or null if not assigned.
   - id: 14
     name: iterate
-    since: 2.0
+    since: "2.0"
     doc: |
       The ordering of iteration over entries is undefined. During iteration, any entries that are a). read will have
       their appropriate CacheEntryReadListeners notified and b). removed will have their appropriate
@@ -471,19 +471,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache.
         - name: iterationPointers
           type: EntryList_Integer_Integer
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The index-size pairs that define the state of iteration
         - name: batch
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The number of items to be batched
     response:
@@ -491,18 +491,18 @@ methods:
         - name: iterationPointers
           type: EntryList_Integer_Integer
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The index-size pairs that define the state of iteration
         - name: keys
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The keys fetched from the cache.
   - id: 15
     name: listenerRegistration
-    since: 2.0
+    since: "2.0"
     doc: |
       Tries to register the listener configuration for the cache specified by its name
       to the given member.
@@ -513,32 +513,32 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache.
         - name: listenerConfig
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The listener configuration. Byte-array which is serialized from an object implementing
             javax.cache.configuration.CacheEntryListenerConfiguration
         - name: shouldRegister
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if the listener is being registered, false if the listener is being unregistered.
         - name: uuid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The UUID of the member server for which the listener is being registered for.
     response: {}
   - id: 16
     name: loadAll
-    since: 2.0
+    since: "2.0"
     doc: |
       Loads all the keys into the CacheRecordStore in batch.
     request:
@@ -548,26 +548,26 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache.
         - name: keys
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the keys to load
         - name: replaceExistingValues
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             when true existing values in the Cache will
             be replaced by those loaded from a CacheLoader
     response: {}
   - id: 17
     name: managementConfig
-    since: 2.0
+    since: "2.0"
     doc: |
       Enables or disables the statistics or the management support for the
       cache with the given name on a member with the given address.
@@ -578,31 +578,31 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache.
         - name: isStat
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if enabling statistics, false if enabling management.
         - name: enabled
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if enabled, false to disable.
         - name: uuid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the UUID of the host to enable.
     response: {}
   - id: 18
     name: putIfAbsent
-    since: 2.0
+    since: "2.0"
     doc: |
       Associates the specified key with the given value if and only if there is not yet a mapping defined for the
       specified key. If the cache is configured for write-through operation mode, the underlying configured
@@ -614,32 +614,32 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The key that is associated with the specified value.
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The value that has the specified key associated with it.
         - name: expiryPolicy
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The custom expiry policy for this operation.
             A null value is equivalent to put(Object, Object).
         - name: completionId
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             User generated id which shall be received as a field of the cache event upon completion of
             the request in the cluster.
@@ -648,12 +648,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if a value was set, false otherwise.
   - id: 19
     name: put
-    since: 2.0
+    since: "2.0"
     doc: |
       Puts the entry with the given key, value and the expiry policy to the cache.
     request:
@@ -663,38 +663,38 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The key that has the specified value associated with it.
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The value to be associated with the key.
         - name: expiryPolicy
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Expiry policy for the entry. Byte-array which is serialized from an object implementing
             javax.cache.expiry.ExpiryPolicy interface.
         - name: get
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             boolean flag indicating if the previous value should be retrieved.
         - name: completionId
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             User generated id which shall be received as a field of the cache event upon completion of
             the request in the cluster.
@@ -703,12 +703,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The value previously assigned to the given key, or null if not assigned.
   - id: 20
     name: removeEntryListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes the specified entry listener. If there is no such listener added before, this call does no change in the
       cluster and returns false.
@@ -719,13 +719,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache.
         - name: registrationId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id assigned during the registration for the listener which shall be removed.
     response:
@@ -733,12 +733,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if the listener is de-registered, false otherwise
   - id: 21
     name: removeInvalidationListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes the specified invalidation listener. If there is no such listener added before, this call does no change
       in the cluster and returns false.
@@ -749,13 +749,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache.
         - name: registrationId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id assigned during the registration for the listener which shall be removed.
     response:
@@ -763,12 +763,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if the listener is de-registered, false otherwise
   - id: 22
     name: remove
-    since: 2.0
+    since: "2.0"
     doc: |
       Atomically removes the mapping for a key only if currently mapped to the given value.
     request:
@@ -778,25 +778,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             key whose mapping is to be removed from the cache
         - name: currentValue
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             value expected to be associated with the specified key.
         - name: completionId
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             User generated id which shall be received as a field of the cache event upon completion of
             the request in the cluster.
@@ -805,12 +805,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             returns false if there was no matching key
   - id: 23
     name: replace
-    since: 2.0
+    since: "2.0"
     doc: |
       Atomically replaces the currently assigned value for the given key with the specified newValue if and only if the
       currently assigned value equals the value of oldValue using a custom javax.cache.expiry.ExpiryPolicy
@@ -823,38 +823,38 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The key whose value is replaced.
         - name: oldValue
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Old value to match if exists before removing. Null means "don't try to remove"
         - name: newValue
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The new value to be associated with the specified key.
         - name: expiryPolicy
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Expiry policy for the entry. Byte-array which is serialized from an object implementing
             javax.cache.expiry.ExpiryPolicy interface.
         - name: completionId
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             User generated id which shall be received as a field of the cache event upon completion of
             the request in the cluster.
@@ -863,12 +863,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The replaced value.
   - id: 24
     name: size
-    since: 2.0
+    since: "2.0"
     doc: |
       Total entry count
     request:
@@ -878,7 +878,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache.
     response:
@@ -886,12 +886,12 @@ methods:
         - name: response
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             total entry count
   - id: 25
     name: addPartitionLostListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a CachePartitionLostListener. The addPartitionLostListener returns a registration ID. This ID is needed to remove the
       CachePartitionLostListener using the #removePartitionLostListener(UUID) method. There is no check for duplicate
@@ -904,13 +904,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache
         - name: localOnly
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             if true only node that has the partition sends the request, if false
             sends all partition lost events.
@@ -919,28 +919,28 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             returns the registration id for the CachePartitionLostListener.
     events:
       - name: CachePartitionLost
-        since: 2.0
+        since: "2.0"
         params:
           - name: partitionId
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Id of the lost partition.
           - name: uuid
             type: UUID
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               UUID of the member that owns the lost partition.
   - id: 26
     name: removePartitionLostListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes the specified cache partition lost listener. If there is no such listener added before, this call does no
       change in the cluster and returns false.
@@ -951,13 +951,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Cache
         - name: registrationId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of registered listener.
     response:
@@ -965,12 +965,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if registration is removed, false otherwise.
   - id: 27
     name: putAll
-    since: 2.0
+    since: "2.0"
     doc: |
       Copies all the mappings from the specified map to this cache with the given expiry policy.
     request:
@@ -980,33 +980,33 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of the cache
         - name: entries
           type: EntryList_Data_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             entries to be put as batch
         - name: expiryPolicy
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             expiry policy for the entry. Byte-array which is serialized from an object implementing
             {@link javax.cache.expiry.ExpiryPolicy} interface.
         - name: completionId
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             user generated id which shall be received as a field of the cache event upon completion of
             the request in the cluster.
     response: {}
   - id: 28
     name: iterateEntries
-    since: 2.0
+    since: "2.0"
     doc: |
       Fetches specified number of entries from the specified partition starting from specified table index.
     request:
@@ -1016,19 +1016,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache.
         - name: iterationPointers
           type: EntryList_Integer_Integer
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The index-size pairs that define the state of iteration
         - name: batch
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The number of items to be batched
     response:
@@ -1036,18 +1036,18 @@ methods:
         - name: iterationPointers
           type: EntryList_Integer_Integer
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The index-size pairs that define the state of iteration
         - name: entries
           type: EntryList_Data_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The entries fetched from the cache.
   - id: 29
     name: addNearCacheInvalidationListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds listener to cache. This listener will be used to listen near cache invalidation events.
     request:
@@ -1057,13 +1057,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache.
         - name: localOnly
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
@@ -1071,79 +1071,79 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Registration id for the registered listener.
     events:
       - name: CacheInvalidation
-        since: 2.0
+        since: "2.0"
         params:
           - name: name
             type: String
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Name of the cache.
           - name: key
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               The key of the invalidated entry.
           - name: sourceUuid
             type: UUID
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               UUID of the member who fired this event.
           - name: partitionUuid
             type: UUID
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               UUID of the source partition that invalidated entry belongs to.
           - name: sequence
             type: long
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Sequence number of the invalidation event.
       - name: CacheBatchInvalidation
-        since: 2.0
+        since: "2.0"
         params:
           - name: name
             type: String
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Name of the cache.
           - name: keys
             type: List_Data
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               List of the keys of the invalidated entries.
           - name: sourceUuids
             type: List_UUID
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               List of UUIDs of the members who fired these events.
           - name: partitionUuids
             type: List_UUID
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               List of UUIDs of the source partitions that invalidated entries belong to.
           - name: sequences
             type: List_Long
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               List of sequence numbers of the invalidation events.
   - id: 30
     name: fetchNearCacheInvalidationMetadata
-    since: 2.0
+    since: "2.0"
     doc: |
       Fetches invalidation metadata from partitions of map.
     request:
@@ -1153,13 +1153,13 @@ methods:
         - name: names
           type: List_String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             names of the caches
         - name: uuid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Address of the member.
     response:
@@ -1167,18 +1167,18 @@ methods:
         - name: namePartitionSequenceList
           type: EntryList_String_EntryList_Integer_Long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Map of partition ids and sequence number of invalidations mapped by the cache name.
         - name: partitionUuidList
           type: EntryList_Integer_UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Map of member UUIDs mapped by the partition ids of invalidations.
   - id: 31
     name: eventJournalSubscribe
-    since: 2.0
+    since: "2.0"
     doc: |
       Performs the initial subscription to the cache event journal.
       This includes retrieving the event journal sequences of the
@@ -1190,7 +1190,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of the cache
     response:
@@ -1198,18 +1198,18 @@ methods:
         - name: oldestSequence
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Sequence id of the oldest event in the event journal.
         - name: newestSequence
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Sequence id of the newest event in the event journal.
   - id: 32
     name: eventJournalRead
-    since: 2.0
+    since: "2.0"
     doc: |
       Reads from the cache event journal in batches. You may specify the start sequence,
       the minimum required number of items in the response, the maximum number of items
@@ -1226,37 +1226,37 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of the cache
         - name: startSequence
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the startSequence of the first item to read
         - name: minSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the minimum number of items to read.
         - name: maxSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the maximum number of items to read.
         - name: predicate
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             the predicate to apply before processing events
         - name: projection
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             the projection to apply to journal events
     response:
@@ -1264,30 +1264,30 @@ methods:
         - name: readCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Number of items that have been read.
         - name: items
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             List of items that have been read.
         - name: itemSeqs
           type: longArray
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Sequence numbers of items in the event journal.
         - name: nextSeq
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Sequence number of the item following the last read item.
   - id: 33
     name: setExpiryPolicy
-    since: 2.0
+    since: "2.0"
     doc: |
       Associates the specified key with the given {@link javax.cache.expiry.ExpiryPolicy}.
       {@code expiryPolicy} takes precedence for these particular {@code keys} against any cache wide expiry policy.
@@ -1299,19 +1299,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of the cache
         - name: keys
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The keys that are associated with the specified expiry policy.
         - name: expiryPolicy
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             custom expiry policy for this operation
     response:
@@ -1319,6 +1319,6 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             {

--- a/protocol-definitions/CardinalityEstimator.yaml
+++ b/protocol-definitions/CardinalityEstimator.yaml
@@ -3,7 +3,7 @@ name: CardinalityEstimator
 methods:
   - id: 1
     name: add
-    since: 2.0
+    since: "2.0"
     doc: |
       Add a new hash in the estimation set. This is the method you want to
       use to feed hash values into the estimator.
@@ -14,13 +14,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of CardinalityEstimator
         - name: hash
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             64bit hash code value to add
 
@@ -28,7 +28,7 @@ methods:
     response: {}
   - id: 2
     name: estimate
-    since: 2.0
+    since: "2.0"
     doc: |
       Estimates the cardinality of the aggregation so far.
       If it was previously estimated and never invalidated, then the cached version is used.
@@ -39,7 +39,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of CardinalityEstimator
     response:
@@ -47,6 +47,6 @@ methods:
         - name: response
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the previous cached estimation or the newly computed one.

--- a/protocol-definitions/Client.yaml
+++ b/protocol-definitions/Client.yaml
@@ -3,7 +3,7 @@ name: Client
 methods:
   - id: 1
     name: authentication
-    since: 2.0
+    since: "2.0"
     doc: |
       Makes an authentication request to the cluster.
     request:
@@ -13,69 +13,69 @@ methods:
         - name: clusterName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Cluster name that client will connect to.
         - name: username
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the user for authentication.
             Used in case Client Identity Config, otherwise it should be passed null.
         - name: password
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Password for the user.
             Used in case Client Identity Config, otherwise it should be passed null.
         - name: uuid
           type: UUID
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Unique string identifying the connected client uniquely.
         - name: clientType
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The type of the client. E.g. JAVA, CPP, CSHARP, etc.
         - name: serializationVersion
           type: byte
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             client side supported version to inform server side
         - name: clientHazelcastVersion
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The Hazelcast version of the client. (e.g. 3.7.2)
         - name: clientName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the name of the client instance
         - name: labels
           type: List_String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             User defined labels of the client instance
         - name: routingMode
           type: byte
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             Identifies the routing mode of the client. It can be UNISOCKET(0), SMART(1) or SUBSET(2).
         - name: cpDirectToLeaderRouting
           type: boolean
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             The client's CP direct-to-leader routing setting (enabled or disabled)
     response:
@@ -83,98 +83,98 @@ methods:
         - name: status
           type: byte
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             A byte that represents the authentication status. It can be AUTHENTICATED(0), CREDENTIALS_FAILED(1),
             SERIALIZATION_VERSION_MISMATCH(2) or NOT_ALLOWED_IN_CLUSTER(3).
         - name: address
           type: Address
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Address of the Hazelcast member which sends the authentication response.
         - name: memberUuid
           type: UUID
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             UUID of the Hazelcast member which sends the authentication response.
         - name: serializationVersion
           type: byte
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             client side supported version to inform server side
         - name: serverHazelcastVersion
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Version of the Hazelcast member which sends the authentication response.
         - name: partitionCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Partition count of the cluster.
         - name: clusterId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             UUID of the cluster that the client authenticated.
         - name: failoverSupported
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Returns true if server supports clients with failover feature.
         - name: tpcPorts
           type: List_Integer
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             Returns the list of TPC ports or null if TPC is disabled.
         - name: tpcToken
           type: byteArray
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             Returns the token to use while authenticating TPC channels 
             or null if TPC is disabled.
         - name: memberListVersion
           type: int
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Incremental member list version. -1 if no member list is available.
         - name: memberInfos
           type: List_MemberInfo
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             List of member infos  at the cluster associated with the given version
         - name: partitionListVersion
           type: int
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Incremental state version of the partition table. -1 if no partition table is available.
         - name: partitions
           type: EntryList_UUID_List_Integer
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             The partition table. In each entry, it has uuid of the member and list of partitions belonging to that member
         - name: keyValuePairs
           type: Map_String_String
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             Server/Member metadata represented as in key value pairs
   - id: 2
     name: authenticationCustom
-    since: 2.0
+    since: "2.0"
     doc: |
       Makes an authentication request to the cluster using custom credentials.
     request:
@@ -184,61 +184,61 @@ methods:
         - name: clusterName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Cluster name that client will connect to.
         - name: credentials
           type: byteArray
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Secret byte array for authentication.
         - name: uuid
           type: UUID
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Unique string identifying the connected client uniquely.
         - name: clientType
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The type of the client. E.g. JAVA, CPP, CSHARP, etc.
         - name: serializationVersion
           type: byte
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             client side supported version to inform server side
         - name: clientHazelcastVersion
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The Hazelcast version of the client. (e.g. 3.7.2)
         - name: clientName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the name of the client instance
         - name: labels
           type: List_String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             User defined labels of the client instance
         - name: routingMode
           type: byte
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             Identifies the routing mode of the client. It can be UNISCOKET(0), SMART(1) or SUBSET(2).
         - name: cpDirectToLeaderRouting
           type: boolean
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             The client's CP direct-to-leader routing setting (enabled or disabled)
     response:
@@ -246,98 +246,98 @@ methods:
         - name: status
           type: byte
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             A byte that represents the authentication status. It can be AUTHENTICATED(0), CREDENTIALS_FAILED(1),
             SERIALIZATION_VERSION_MISMATCH(2) or NOT_ALLOWED_IN_CLUSTER(3).
         - name: address
           type: Address
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Address of the Hazelcast member which sends the authentication response.
         - name: memberUuid
           type: UUID
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             UUID of the Hazelcast member which sends the authentication response.
         - name: serializationVersion
           type: byte
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             client side supported version to inform server side
         - name: serverHazelcastVersion
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Version of the Hazelcast member which sends the authentication response.
         - name: partitionCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Partition count of the cluster.
         - name: clusterId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The cluster id of the cluster.
         - name: failoverSupported
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Returns true if server supports clients with failover feature.
         - name: tpcPorts
           type: List_Integer
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             Returns the list of TPC ports or null if TPC is disabled.
         - name: tpcToken
           type: byteArray
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             Returns the token to use while authenticating TPC channels 
             or null if TPC is disabled.
         - name: memberListVersion
           type: int
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Incremental member list version
         - name: memberInfos
           type: List_MemberInfo
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             List of member infos  at the cluster associated with the given version
         - name: partitionListVersion
           type: int
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Incremental state version of the partition table
         - name: partitions
           type: EntryList_UUID_List_Integer
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             The partition table. In each entry, it has uuid of the member and list of partitions belonging to that member
         - name: keyValuePairs
           type: Map_String_String
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             Server/Member metadata represented as in key value pairs
   - id: 3
     name: addClusterViewListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a cluster view listener to a connection.
     request:
@@ -346,63 +346,63 @@ methods:
     response: {}
     events:
       - name: MembersView
-        since: 2.0
+        since: "2.0"
         params:
           - name: version
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Incremental member list version
           - name: memberInfos
             type: List_MemberInfo
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               List of member infos  at the cluster associated with the given version
               params:
       - name: PartitionsView
-        since: 2.0
+        since: "2.0"
         params:
           - name: version
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Incremental state version of the partition table
           - name: partitions
             type: EntryList_UUID_List_Integer
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               The partition table. In each entry, it has uuid of the member and list of partitions belonging to that member
       - name: MemberGroupsView
-        since: 2.8
+        since: "2.8"
         params:
           - name: version
             type: int
             nullable: false
-            since: 2.8
+            since: "2.8"
             doc: |
               Holds the state of member-groups and member-list-version
           - name: memberGroups
             type: List_List_UUID
             nullable: false
-            since: 2.8
+            since: "2.8"
             doc: |
               Grouped members by their UUID. Grouping is done based on RoutingStrategy.
       - name: ClusterVersion
-        since: 2.8
+        since: "2.8"
         params:
           - name: version
             type: Version
             nullable: false
-            since: 2.8
+            since: "2.8"
             doc: |
               The cluster version.
   - id: 4
     name: createProxy
-    since: 2.0
+    since: "2.0"
     doc: |
       Creates a cluster-wide proxy with the given name and service.
     request:
@@ -412,13 +412,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The distributed object name for which the proxy is being created for.
         - name: serviceName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the service. Possible service names are:
             "hz:impl:listService"
@@ -439,7 +439,7 @@ methods:
     response: {}
   - id: 5
     name: destroyProxy
-    since: 2.0
+    since: "2.0"
     doc: |
       Destroys the proxy given by its name cluster-wide. Also, clears and releases all resources of this proxy.
     request:
@@ -449,13 +449,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The distributed object name for which the proxy is being destroyed for.
         - name: serviceName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the service. Possible service names are:
             "hz:impl:listService"
@@ -476,7 +476,7 @@ methods:
     response: {}
   - id: 6
     name: addPartitionLostListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a partition lost listener to the cluster.
     request:
@@ -486,7 +486,7 @@ methods:
         - name: localOnly
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             if true only node that has the partition sends the request, if false
             sends all partition lost events.
@@ -495,34 +495,34 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The listener registration id.
     events:
       - name: PartitionLost
-        since: 2.0
+        since: "2.0"
         params:
           - name: partitionId
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Id of the lost partition.
           - name: lostBackupCount
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               The number of lost backups for the partition. 0: the owner, 1: first backup, 2: second backup...
           - name: source
             type: UUID
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               UUID of the node that dispatches the event
   - id: 7
     name: removePartitionLostListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes the specified partition lost listener. If there is no such listener added before, this call does no change
       in the cluster and returns false.
@@ -533,7 +533,7 @@ methods:
         - name: registrationId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id assigned during the listener registration.
     response:
@@ -541,12 +541,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if the listener existed and removed, false otherwise.
   - id: 8
     name: getDistributedObjects
-    since: 2.0
+    since: "2.0"
     doc: |
       Gets the list of distributed objects in the cluster.
     request:
@@ -557,12 +557,12 @@ methods:
         - name: response
           type: List_DistributedObjectInfo
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             An array of distributed object info in the cluster.
   - id: 9
     name: addDistributedObjectListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a distributed object listener to the cluster. This listener will be notified
       when a distributed object is created or destroyed.
@@ -573,7 +573,7 @@ methods:
         - name: localOnly
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             If set to true, the server adds the listener only to itself, otherwise the listener is is added for all
             members in the cluster.
@@ -582,40 +582,40 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The registration id for the distributed object listener.
     events:
       - name: DistributedObject
-        since: 2.0
+        since: "2.0"
         params:
           - name: name
             type: String
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Name of the distributed object.
           - name: serviceName
             type: String
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Service name of the distributed object.
           - name: eventType
             type: String
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Type of the event. It is either CREATED or DESTROYED.
           - name: source
             type: UUID
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               The UUID (client or member) of the source of this proxy event.
   - id: 10
     name: removeDistributedObjectListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes the specified distributed object listener. If there is no such listener added before, this call does no
       change in the cluster and returns false.
@@ -626,7 +626,7 @@ methods:
         - name: registrationId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id assigned during the registration.
     response:
@@ -634,12 +634,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if the listener existed and removed, false otherwise.
   - id: 11
     name: ping
-    since: 2.0
+    since: "2.0"
     doc: |
       Sends a ping to the given connection.
     request:
@@ -648,7 +648,7 @@ methods:
     response: {}
   - id: 12
     name: statistics
-    since: 2.0
+    since: "2.0"
     doc: |
       The statistics is composed of three parameters.
 
@@ -818,25 +818,25 @@ methods:
         - name: timestamp
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The timestamp taken during statistics collection.
         - name: clientAttributes
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The key=value pairs separated by the ',' character.
         - name: metricsBlob
           type: byteArray
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Compressed byte array containing all metrics collected by the client.
     response: {}
   - id: 13
     name: deployClasses
-    since: 2.0
+    since: "2.0"
     doc: |
       Deploys the list of classes to cluster
       Each item is a Map.Entry<String, byte[]> in the list.
@@ -848,13 +848,13 @@ methods:
         - name: classDefinitions
           type: EntryList_String_byteArray
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             list of class definitions
     response: {}
   - id: 14
     name: createProxies
-    since: 2.0
+    since: "2.0"
     doc: |
       Proxies will be created on all cluster members.
       If the member is  a lite member, a replicated map will not be created.
@@ -868,7 +868,7 @@ methods:
         - name: proxies
           type: EntryList_String_String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             proxies that will be created
             Each entry's key is distributed object name.
@@ -877,7 +877,7 @@ methods:
     response: {}
   - id: 15
     name: localBackupListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds listener for backup acks
     request:
@@ -888,22 +888,22 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Returns the registration id for the listener.
     events:
       - name: backup
-        since: 2.0
+        since: "2.0"
         params:
           - name: sourceInvocationCorrelationId
             type: long
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               correlation id of the invocation that backup acks belong to
   - id: 16
     name: triggerPartitionAssignment
-    since: 2.0
+    since: "2.0"
     doc: |
       Triggers partition assignment manually on the cluster.
       Note that Partition based operations triggers this automatically
@@ -914,7 +914,7 @@ methods:
       {}
   - id: 17
     name: addMigrationListener
-    since: 2.2
+    since: "2.2"
     doc: |
       Adds a migration listener to the cluster.
     request:
@@ -924,7 +924,7 @@ methods:
         - name: localOnly
           type: boolean
           nullable: false
-          since: 2.2
+          since: "2.2"
           doc: |
             If set to true, the server adds the listener only to itself, otherwise
             the listener is added for all members in the cluster.
@@ -933,73 +933,73 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.2
+          since: "2.2"
           doc: |
             The listener registration id.
     events:
       - name: Migration
-        since: 2.2
+        since: "2.2"
         params:
           - name: migrationState
             type: MigrationState
             nullable: false
-            since: 2.2
+            since: "2.2"
             doc: |
               Migration state.
           - name: type
             type: int
             nullable: false
-            since: 2.2
+            since: "2.2"
             doc: |
               Type of the event. It is either MIGRATION_STARTED(0) or MIGRATION_FINISHED(1).
       - name: ReplicaMigration
-        since: 2.2
+        since: "2.2"
         params:
           - name: migrationState
             type: MigrationState
             nullable: false
-            since: 2.2
+            since: "2.2"
             doc: |
               The progress information of the overall migration.
           - name: partitionId
             type: int
             nullable: false
-            since: 2.2
+            since: "2.2"
             doc: |
               The partition ID that the event is dispatched for.
           - name: replicaIndex
             type: int
             nullable: false
-            since: 2.2
+            since: "2.2"
             doc: |
               The index of the partition replica.
           - name: sourceUuid
             type: UUID
             nullable: true
-            since: 2.2
+            since: "2.2"
             doc: |
               The id of old owner of the migrating partition replica.
           - name: destUuid
             type: UUID
             nullable: true
-            since: 2.2
+            since: "2.2"
             doc: |
               The id of new owner of the migrating partition replica.
           - name: success
             type: boolean
             nullable: false
-            since: 2.2
+            since: "2.2"
             doc: |
               The result of the migration: completed or failed.
           - name: elapsedTime
             type: long
             nullable: false
-            since: 2.2
+            since: "2.2"
             doc: |
               The elapsed the time of this migration in milliseconds.
   - id: 18
     name: removeMigrationListener
-    since: 2.2
+    since: "2.2"
     doc: |
       Removes the specified migration listener.
     request:
@@ -1009,7 +1009,7 @@ methods:
         - name: registrationId
           type: UUID
           nullable: false
-          since: 2.2
+          since: "2.2"
           doc: |
             The id assigned during the listener registration.
     response:
@@ -1017,12 +1017,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.2
+          since: "2.2"
           doc: |
             true if the listener existed and was removed, false otherwise.
   - id: 19
     name: sendSchema
-    since: 2.5
+    since: "2.5"
     doc: |
       Sends a schema to cluster
     request:
@@ -1032,7 +1032,7 @@ methods:
         - name: schema
           type: Schema
           nullable: false
-          since: 2.5
+          since: "2.5"
           doc: |
             schema to be send to the cluster
     response:
@@ -1040,12 +1040,12 @@ methods:
         - name: replicatedMembers
           type: Set_UUID
           nullable: false
-          since: 2.5
+          since: "2.5"
           doc: |
             UUIDs of the members that the schema is replicated
   - id: 20
     name: fetchSchema
-    since: 2.5
+    since: "2.5"
     doc: |
       Fetches a schema from the cluster with the given schemaId
     request:
@@ -1055,7 +1055,7 @@ methods:
         - name: schemaId
           type: long
           nullable: false
-          since: 2.5
+          since: "2.5"
           doc: |
             Id of the schema to be fetched
     response:
@@ -1063,12 +1063,12 @@ methods:
         - name: schema
           type: Schema
           nullable: true
-          since: 2.5
+          since: "2.5"
           doc: |
             schema with the given schema id fetched from the cluster
   - id: 21
     name: sendAllSchemas
-    since: 2.5
+    since: "2.5"
     doc: |
       Sends all the schemas to the cluster
     request:
@@ -1078,13 +1078,13 @@ methods:
         - name: schemas
           type: List_Schema
           nullable: false
-          since: 2.5
+          since: "2.5"
           doc: |
             list of schemas
     response: {}
   - id: 22
     name: tpcAuthentication
-    since: 2.7
+    since: "2.7"
     doc: |
       Makes an authentication request to TPC channels.
     request:
@@ -1094,19 +1094,19 @@ methods:
         - name: uuid
           type: UUID
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             UUID of the client.
         - name: token
           type: byteArray
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Authentication token bytes for the TPC channels
     response: {}
   - id: 23
     name: addCPGroupViewListener
-    since: 2.8
+    since: "2.8"
     doc: |
       Adds a CP Group view listener to a connection.
     request:
@@ -1115,23 +1115,23 @@ methods:
     response: {}
     events:
       - name: GroupsView
-        since: 2.8
+        since: "2.8"
         params:
           - name: version
             type: long
             nullable: false
-            since: 2.8
+            since: "2.8"
             doc: |
               The version number for this group view
           - name: groupsInfo
             type: List_RaftGroupInfo # GroupID -> RaftGroupInfo
             nullable: false
-            since: 2.8
+            since: "2.8"
             doc: |
               List of RaftGroupInfo objects containing group IDs, leader, and follower information
           - name: cpToApUuids
             type: EntryList_UUID_UUID # CP UUID --> AP UUID
             nullable: false
-            since: 2.8
+            since: "2.8"
             doc: |
               Mapping of CP UUIDs to AP UUIDs, for use on the client

--- a/protocol-definitions/ContinuousQuery.yaml
+++ b/protocol-definitions/ContinuousQuery.yaml
@@ -3,7 +3,7 @@ name: ContinuousQuery
 methods:
   - id: 1
     name: publisherCreateWithValue
-    since: 2.0
+    since: "2.0"
     doc: |
       Creates a publisher that includes value for the cache events it sends.
     request:
@@ -13,49 +13,49 @@ methods:
         - name: mapName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: cacheName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the cache for query cache.
         - name: predicate
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The predicate to filter events which will be applied to the QueryCache.
         - name: batchSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The size of batch. After reaching this minimum size, node immediately sends buffered events to QueryCache.
         - name: bufferSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Maximum number of events which can be stored in a buffer of partition.
         - name: delaySeconds
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The minimum number of delay seconds which an event waits in the buffer of node.
         - name: populate
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Flag to enable/disable initial population of the QueryCache.
         - name: coalesce
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Flag to enable/disable coalescing. If true, then only the last updated value for a key is placed in the
             batch, otherwise all changed values are included in the update.
@@ -64,12 +64,12 @@ methods:
         - name: response
           type: EntryList_Data_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Array of key-value pairs.
   - id: 2
     name: publisherCreate
-    since: 2.0
+    since: "2.0"
     doc: |
       Creates a publisher that does not include value for the cache events it sends.
     request:
@@ -79,49 +79,49 @@ methods:
         - name: mapName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: cacheName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of query cache.
         - name: predicate
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The predicate to filter events which will be applied to the QueryCache.
         - name: batchSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The size of batch. After reaching this minimum size, node immediately sends buffered events to QueryCache.
         - name: bufferSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Maximum number of events which can be stored in a buffer of partition.
         - name: delaySeconds
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The minimum number of delay seconds which an event waits in the buffer of node.
         - name: populate
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Flag to enable/disable initial population of the QueryCache.
         - name: coalesce
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Flag to enable/disable coalescing. If true, then only the last updated value for a key is placed in the
             batch, otherwise all changed values are included in the update.
@@ -130,12 +130,12 @@ methods:
         - name: response
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Array of keys.
   - id: 3
     name: madePublishable
-    since: 2.0
+    since: "2.0"
     doc: |
       Makes the query cache with the given name for a specific map publishable.
     request:
@@ -145,13 +145,13 @@ methods:
         - name: mapName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: cacheName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of query cache.
     response:
@@ -159,12 +159,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if successfully set as publishable, false otherwise.
   - id: 4
     name: addListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a listener to be notified for the events fired on the underlying map on all nodes.
     request:
@@ -174,13 +174,13 @@ methods:
         - name: listenerName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the MapListener which will be used to listen this QueryCache
         - name: localOnly
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
@@ -188,44 +188,44 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Registration id for the listener.
     events:
       - name: QueryCacheSingle
-        since: 2.0
+        since: "2.0"
         params:
           - name: data
             type: QueryCacheEventData
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Data that holds the details of the event such as key, value, old value, new value and creation time.
       - name: QueryCacheBatch
-        since: 2.0
+        since: "2.0"
         params:
           - name: events
             type: List_QueryCacheEventData
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               List of events in the form of data that holds the details of the event such as key, value, old value,
               new value and creation time.
           - name: source
             type: String
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Source that dispatches this batch event.
           - name: partitionId
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Id of the partition that holds the keys of the batch event.
   - id: 5
     name: setReadCursor
-    since: 2.0
+    since: "2.0"
     doc: |
       This method can be used to recover from a possible event loss situation.
       This method tries to make consistent the data in this `QueryCache` with the data in the underlying `IMap`
@@ -240,19 +240,19 @@ methods:
         - name: mapName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: cacheName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of query cache.
         - name: sequence
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The cursor position of the accumulator to be set.
     response:
@@ -260,12 +260,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if the cursor position could be set, false otherwise.
   - id: 6
     name: destroyCache
-    since: 2.0
+    since: "2.0"
     doc: |
       Destroys the query cache with the given name for a specific map.
     request:
@@ -275,13 +275,13 @@ methods:
         - name: mapName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: cacheName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of query cache.
     response:
@@ -289,6 +289,6 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if all cache is destroyed, false otherwise.

--- a/protocol-definitions/CountDownLatch.yaml
+++ b/protocol-definitions/CountDownLatch.yaml
@@ -3,7 +3,7 @@ name: CountDownLatch
 methods:
   - id: 1
     name: trySetCount
-    since: 2.0
+    since: "2.0"
     doc: |
       Sets the count to the given value if the current count is zero.
       If the count is not zero, then this method does nothing
@@ -15,19 +15,19 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this CountDownLatch instance
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the CountDownLatch instance
         - name: count
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The number of times countDown must be invoked before
             threads can pass through await
@@ -36,13 +36,13 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if the new count was set,
             false if the current count is not zero.
   - id: 2
     name: await
-    since: 2.0
+    since: "2.0"
     doc: |
       Causes the current thread to wait until the latch has counted down
       to zero, or an exception is thrown, or the specified waiting time
@@ -67,25 +67,25 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this CountDownLatch instance
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of this CountDownLatch instance
         - name: invocationUid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             UID of this invocation
         - name: timeoutMs
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The maximum time in milliseconds to wait
     response:
@@ -93,13 +93,13 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if the count reached zero, false if
             the waiting time elapsed before the count reached 0
   - id: 3
     name: countDown
-    since: 2.0
+    since: "2.0"
     doc: |
       Decrements the count of the latch, releasing all waiting threads if
       the count reaches zero. If the current count is greater than zero, then
@@ -113,31 +113,31 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this CountDownLatch instance
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the CountDownLatch instance
         - name: invocationUid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             UID of this invocation
         - name: expectedRound
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The round this invocation will be performed on
     response: {}
   - id: 4
     name: getCount
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the current count.
     request:
@@ -147,13 +147,13 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this CountDownLatch instance
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the CountDownLatch instance
     response:
@@ -161,12 +161,12 @@ methods:
         - name: response
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The current count of this CountDownLatch instance
   - id: 5
     name: getRound
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the current round. A round completes when the count value
       reaches to 0 and a new round starts afterwards.
@@ -177,13 +177,13 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this CountDownLatch instance
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the CountDownLatch instance
     response:
@@ -191,6 +191,6 @@ methods:
         - name: response
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The current round of this CountDownLatch instance

--- a/protocol-definitions/DurableExecutor.yaml
+++ b/protocol-definitions/DurableExecutor.yaml
@@ -3,7 +3,7 @@ name: DurableExecutor
 methods:
   - id: 1
     name: shutdown
-    since: 2.0
+    since: "2.0"
     doc: |
       Initiates an orderly shutdown in which previously submitted tasks are executed, but no new tasks will be accepted.
       Invocation has no additional effect if already shut down.
@@ -14,13 +14,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the executor.
     response: {}
   - id: 2
     name: isShutdown
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns true if this executor has been shut down.
     request:
@@ -30,7 +30,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the executor.
     response:
@@ -38,12 +38,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if this executor has been shut down
   - id: 3
     name: submitToPartition
-    since: 2.0
+    since: "2.0"
     doc: |
       Submits the task to partition for execution
     request:
@@ -53,13 +53,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the executor.
         - name: callable
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The callable object to be executed.
     response:
@@ -67,12 +67,12 @@ methods:
         - name: response
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the sequence for the submitted execution.
   - id: 4
     name: retrieveResult
-    since: 2.0
+    since: "2.0"
     doc: |
       Retrieves the result of the execution with the given sequence
     request:
@@ -82,13 +82,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the executor.
         - name: sequence
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Sequence of the execution.
     response:
@@ -96,12 +96,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The result of the callable execution with the given sequence.
   - id: 5
     name: disposeResult
-    since: 2.0
+    since: "2.0"
     doc: |
       Disposes the result of the execution with the given sequence
     request:
@@ -111,19 +111,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the executor.
         - name: sequence
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Sequence of the execution.
     response: {}
   - id: 6
     name: retrieveAndDisposeResult
-    since: 2.0
+    since: "2.0"
     doc: |
       Retrieves and disposes the result of the execution with the given sequence
     request:
@@ -133,13 +133,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the executor.
         - name: sequence
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Sequence of the execution.
     response:
@@ -147,6 +147,6 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The result of the callable execution with the given sequence.

--- a/protocol-definitions/DynamicConfig.yaml
+++ b/protocol-definitions/DynamicConfig.yaml
@@ -3,7 +3,7 @@ name: DynamicConfig
 methods:
   - id: 1
     name: addMultiMapConfig
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a new multimap config to a running cluster.
       If a multimap configuration with the given {@code name} already exists, then
@@ -15,50 +15,50 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             multimap configuration name
         - name: collectionType
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             value collection type. Valid values are SET and LIST.
         - name: listenerConfigs
           type: List_ListenerConfigHolder
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             entry listener configurations
         - name: binary
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             {@code true} to store values in {@code BINARY} format or {@code false} to store
             values in {@code OBJECT} format.
         - name: backupCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             number of synchronous backups
         - name: asyncBackupCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             number of asynchronous backups
         - name: statisticsEnabled
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             set to {@code true} to enable statistics on this multimap configuration
         - name: splitBrainProtectionName
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             name of an existing configured split brain protection to be used to determine the minimum number of members
             required in the cluster for the lock to remain functional. When {@code null}, split brain protection does not
@@ -66,26 +66,26 @@ methods:
         - name: mergePolicy
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of a class implementing SplitBrainMergePolicy that handles merging of values for this cache
             while recovering from network partitioning.
         - name: mergeBatchSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Number of entries to be sent in a merge operation.
         - name: userCodeNamespace
           type: String
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             Name of the User Code Namespace applied to this instance.
     response: {}
   - id: 2
     name: addRingbufferConfig
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a new ringbuffer configuration to a running cluster.
       If a ringbuffer configuration with the given {@code name} already exists, then
@@ -97,50 +97,50 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ringbuffer configuration name
         - name: capacity
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             capacity of the ringbuffer
         - name: backupCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             number of synchronous backups
         - name: asyncBackupCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             number of asynchronous backups
         - name: timeToLiveSeconds
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             maximum number of seconds for each entry to stay in the ringbuffer
         - name: inMemoryFormat
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             in memory format of items in the ringbuffer. Valid options are {@code BINARY}
             and {@code OBJECT}
         - name: ringbufferStoreConfig
           type: RingbufferStoreConfigHolder
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             backing ringbuffer store configuration
         - name: splitBrainProtectionName
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             name of an existing configured split brain protection to be used to determine the minimum number of members
             required in the cluster for the lock to remain functional. When {@code null}, split brain protection does not
@@ -148,26 +148,26 @@ methods:
         - name: mergePolicy
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of a class implementing SplitBrainMergePolicy that handles merging of values for this cache
             while recovering from network partitioning.
         - name: mergeBatchSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Number of entries to be sent in a merge operation.
         - name: userCodeNamespace
           type: String
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             Name of the User Code Namespace applied to this instance.
     response: {}
   - id: 3
     name: addCardinalityEstimatorConfig
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a new cardinality estimator configuration to a running cluster.
       If a cardinality estimator configuration with the given {@code name} already exists, then
@@ -179,25 +179,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of the cardinality estimator configuration
         - name: backupCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             number of synchronous backups
         - name: asyncBackupCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             number of asynchronous backups
         - name: splitBrainProtectionName
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             name of an existing configured split brain protection to be used to determine the minimum number of members
             required in the cluster for the lock to remain functional. When {@code null}, split brain protection does not
@@ -205,20 +205,20 @@ methods:
         - name: mergePolicy
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of a class implementing SplitBrainMergePolicy that handles merging of values for this cache
             while recovering from network partitioning.
         - name: mergeBatchSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Number of entries to be sent in a merge operation.
     response: {}
   - id: 4
     name: addListConfig
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a new list configuration to a running cluster.
       If a list configuration with the given {@code name} already exists, then
@@ -230,43 +230,43 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             list's name
         - name: listenerConfigs
           type: List_ListenerConfigHolder
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             item listener configurations
         - name: backupCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             number of synchronous backups
         - name: asyncBackupCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             number of asynchronous backups
         - name: maxSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             maximum size of the list
         - name: statisticsEnabled
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             {@code true} to enable gathering of statistics on the list, otherwise {@code false}
         - name: splitBrainProtectionName
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             name of an existing configured split brain protection to be used to determine the minimum number of members
             required in the cluster for the lock to remain functional. When {@code null}, split brain protection does not
@@ -274,26 +274,26 @@ methods:
         - name: mergePolicy
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of a class implementing SplitBrainMergePolicy that handles merging of values for this cache
             while recovering from network partitioning.
         - name: mergeBatchSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Number of entries to be sent in a merge operation.
         - name: userCodeNamespace
           type: String
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             Name of the User Code Namespace applied to this instance.
     response: {}
   - id: 5
     name: addSetConfig
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a new set configuration to a running cluster.
       If a set configuration with the given {@code name} already exists, then
@@ -305,43 +305,43 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             set's name
         - name: listenerConfigs
           type: List_ListenerConfigHolder
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             item listener configurations
         - name: backupCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             number of synchronous backups
         - name: asyncBackupCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             number of asynchronous backups
         - name: maxSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             maximum size of the set
         - name: statisticsEnabled
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             {@code true} to enable gathering of statistics on the list, otherwise {@code false}
         - name: splitBrainProtectionName
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             name of an existing configured split brain protection to be used to determine the minimum number of members
             required in the cluster for the lock to remain functional. When {@code null}, split brain protection does not
@@ -349,26 +349,26 @@ methods:
         - name: mergePolicy
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of a class implementing SplitBrainMergePolicy that handles merging of values for this cache
             while recovering from network partitioning.
         - name: mergeBatchSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Number of entries to be sent in a merge operation.
         - name: userCodeNamespace
           type: String
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             Name of the User Code Namespace applied to this instance.
     response: {}
   - id: 6
     name: addReplicatedMapConfig
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a new replicated map configuration to a running cluster.
       If a replicated map configuration with the given {@code name} already exists, then
@@ -380,33 +380,33 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of the replicated map configuration
         - name: inMemoryFormat
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             data type used to store entries. Valid values are {@code "BINARY"}, {@code "OBJECT"}
             and {@code "NATIVE"}.
         - name: asyncFillup
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             {@code true} to make the replicated map available for reads before initial replication
             is completed, {@code false} otherwise.
         - name: statisticsEnabled
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             {@code true} to enable gathering of statistics, otherwise {@code false}
         - name: mergePolicy
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             class name of a class implementing
             SplitBrainMergePolicy to merge entries
@@ -414,13 +414,13 @@ methods:
         - name: listenerConfigs
           type: List_ListenerConfigHolder
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             entry listener configurations
         - name: splitBrainProtectionName
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             name of an existing configured split brain protection to be used to determine the minimum number of members
             required in the cluster for the lock to remain functional. When {@code null}, split brain protection does not
@@ -428,19 +428,19 @@ methods:
         - name: mergeBatchSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Number of entries to be sent in a merge operation.
         - name: userCodeNamespace
           type: String
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             Name of the User Code Namespace applied to this instance.
     response: {}
   - id: 7
     name: addTopicConfig
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a new topic configuration to a running cluster.
       If a topic configuration with the given {@code name} already exists, then
@@ -452,45 +452,45 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             topic's name
         - name: globalOrderingEnabled
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             when {@code true} all nodes listening to the same topic get their messages in
             the same order
         - name: statisticsEnabled
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             {@code true} to enable gathering of statistics, otherwise {@code false}
         - name: multiThreadingEnabled
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             {@code true} to enable multi-threaded processing of incoming messages, otherwise
             a single thread will handle all topic messages
         - name: listenerConfigs
           type: List_ListenerConfigHolder
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             message listener configurations
         - name: userCodeNamespace
           type: String
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             Name of the User Code Namespace applied to this instance.
     response: {}
   - id: 8
     name: addExecutorConfig
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a new executor configuration to a running cluster.
       If an executor configuration with the given {@code name} already exists, then
@@ -502,31 +502,31 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             executor's name
         - name: poolSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             executor thread pool size
         - name: queueCapacity
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             capacity of executor queue. A value of {@code 0} implies {@link Integer#MAX_VALUE}
         - name: statisticsEnabled
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             {@code true} to enable gathering of statistics, otherwise {@code false}
         - name: splitBrainProtectionName
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             name of an existing configured split brain protection to be used to determine the minimum number of members
             required in the cluster for the lock to remain functional. When {@code null}, split brain protection does not
@@ -534,13 +534,13 @@ methods:
         - name: userCodeNamespace
           type: String
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             Name of the User Code Namespace applied to this instance.
     response: {}
   - id: 9
     name: addDurableExecutorConfig
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a new durable executor configuration to a running cluster.
       If a durable executor configuration with the given {@code name} already exists, then
@@ -552,31 +552,31 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             durable executor name
         - name: poolSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             executor thread pool size
         - name: durability
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             executor's durability
         - name: capacity
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             capacity of executor tasks per partition
         - name: splitBrainProtectionName
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             name of an existing configured split brain protection to be used to determine the minimum number of members
             required in the cluster for the lock to remain functional. When {@code null}, split brain protection does not
@@ -584,19 +584,19 @@ methods:
         - name: statisticsEnabled
           type: boolean
           nullable: false
-          since: 2.1
+          since: "2.1"
           doc: |
             {@code true} to enable gathering of statistics, otherwise {@code false}
         - name: userCodeNamespace
           type: String
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             Name of the User Code Namespace applied to this instance.
     response: {}
   - id: 10
     name: addScheduledExecutorConfig
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a new scheduled executor configuration to a running cluster.
       If a scheduled executor configuration with the given {@code name} already exists, then
@@ -608,32 +608,32 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of scheduled executor
         - name: poolSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             number of executor threads per member for the executor
         - name: durability
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             durability of the scheduled executor
         - name: capacity
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             maximum number of tasks that a scheduler can have at any given point in time per partition or per node
             according to the capacity policy
         - name: splitBrainProtectionName
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             name of an existing configured split brain protection to be used to determine the minimum number of members
             required in the cluster for the lock to remain functional. When {@code null}, split brain protection does not
@@ -641,38 +641,38 @@ methods:
         - name: mergePolicy
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of a class implementing SplitBrainMergePolicy that handles merging of values for this cache
             while recovering from network partitioning.
         - name: mergeBatchSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Number of entries to be sent in a merge operation.
         - name: statisticsEnabled
           type: boolean
           nullable: false
-          since: 2.1
+          since: "2.1"
           doc: |
             {@code true} to enable gathering of statistics, otherwise {@code false}
         - name: capacityPolicy
           type: byte
           nullable: false
-          since: 2.5
+          since: "2.5"
           doc: |
             Capacity policy for the configured capacity value
         - name: userCodeNamespace
           type: String
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             Name of the User Code Namespace applied to this instance.
     response: {}
   - id: 11
     name: addQueueConfig
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a new queue configuration to a running cluster.
       If a queue configuration with the given {@code name} already exists, then
@@ -684,49 +684,49 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             queue name
         - name: listenerConfigs
           type: List_ListenerConfigHolder
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             item listeners configuration
         - name: backupCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             number of synchronous backups
         - name: asyncBackupCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             number of asynchronous backups
         - name: maxSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             maximum number of items in the queue
         - name: emptyQueueTtl
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             queue time-to-live in seconds: queue will be destroyed if it stays empty or unused for that time
         - name: statisticsEnabled
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             {@code true} to enable gathering of statistics, otherwise {@code false}
         - name: splitBrainProtectionName
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             name of an existing configured split brain protection to be used to determine the minimum number of members
             required in the cluster for the queue to remain functional. When {@code null}, split brain protection does not
@@ -734,37 +734,37 @@ methods:
         - name: queueStoreConfig
           type: QueueStoreConfigHolder
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             backing queue store configuration
         - name: mergePolicy
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Classname of the merge policy.
         - name: mergeBatchSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Number of entries to be sent in a merge operation.
         - name: priorityComparatorClassName
           type: String
           nullable: true
-          since: 2.1
+          since: "2.1"
           doc: |
             Class name of the configured {@link java.util.Comparator} implementation.
         - name: userCodeNamespace
           type: String
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             Name of the User Code Namespace applied to this instance.
     response: {}
   - id: 12
     name: addMapConfig
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a new map configuration to a running cluster.
       If a map configuration with the given {@code name} already exists, then
@@ -776,49 +776,49 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of the map
         - name: backupCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             number of synchronous backups
         - name: asyncBackupCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             number of asynchronous backups
         - name: timeToLiveSeconds
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             maximum number of seconds for each entry to stay in the map.
         - name: maxIdleSeconds
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             maximum number of seconds for each entry to stay idle in the map
         - name: evictionConfig
           type: EvictionConfigHolder
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             map eviction configuration
         - name: readBackupData
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             {@code true} to enable reading local backup entries, {@code false} otherwise
         - name: cacheDeserializedValues
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             control caching of de-serialized values. Valid values are {@code NEVER}
             (Never cache de-serialized object), {@code INDEX_ONLY} (Cache values only
@@ -827,45 +827,45 @@ methods:
         - name: mergePolicy
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of a class implementing SplitBrainMergePolicy that handles merging of values for this cache
             while recovering from network partitioning.
         - name: mergeBatchSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Number of entries to be sent in a merge operation
         - name: inMemoryFormat
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             data type used to store entries. Valid values are {@code BINARY},
             {@code OBJECT} and {@code NATIVE}.
         - name: listenerConfigs
           type: List_ListenerConfigHolder
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             entry listener configurations
         - name: partitionLostListenerConfigs
           type: List_ListenerConfigHolder
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             partition lost listener configurations
         - name: statisticsEnabled
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             {@code true} to enable gathering of statistics, otherwise {@code false}
         - name: splitBrainProtectionName
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             name of an existing configured split brain protection to be used to determine the minimum
             number of members required in the cluster for the map to remain functional.
@@ -873,112 +873,112 @@ methods:
         - name: mapStoreConfig
           type: MapStoreConfigHolder
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             configuration of backing map store or {@code null} for none
         - name: nearCacheConfig
           type: NearCacheConfigHolder
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             configuration of near cache or {@code null} for none
         - name: wanReplicationRef
           type: WanReplicationRef
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             reference to an existing WAN replication configuration
         - name: indexConfigs
           type: List_IndexConfig
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             index configurations
         - name: attributeConfigs
           type: List_AttributeConfig
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             map attributes
         - name: queryCacheConfigs
           type: List_QueryCacheConfigHolder
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             configurations for query caches on this map
         - name: partitioningStrategyClassName
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             name of class implementing {@code com.hazelcast.core.PartitioningStrategy}
             or {@code null}
         - name: partitioningStrategyImplementation
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             a serialized instance of a partitioning strategy
         - name: hotRestartConfig
           type: HotRestartConfig
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             hot restart configuration
         - name: eventJournalConfig
           type: EventJournalConfig
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             event journal configuration
         - name: merkleTreeConfig
           type: MerkleTreeConfig
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             merkle tree configuration
         - name: metadataPolicy
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             metadata policy configuration for the supported data types. Valid values
             are {@code CREATE_ON_UPDATE} and {@code OFF}
         - name: perEntryStatsEnabled
           type: boolean
           nullable: false
-          since: 2.2
+          since: "2.2"
           doc: |
             {@code true} to enable entry level statistics for the entries of this map.
              otherwise {@code false}. Default value is {@code false}
         - name: dataPersistenceConfig
           type: DataPersistenceConfig
           nullable: false
-          since: 2.5
+          since: "2.5"
           doc: |
             Data persistence configuration
         - name: tieredStoreConfig
           type: TieredStoreConfig
           nullable: false
-          since: 2.5
+          since: "2.5"
           doc: |
             Tiered-Store configuration
         - name: partitioningAttributeConfigs
           type: List_PartitioningAttributeConfig
           nullable: true
-          since: 2.6
+          since: "2.6"
           doc: |
             List of attributes used for creating AttributePartitioningStrategy.
         - name: userCodeNamespace
           type: String
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             Name of the User Code Namespace applied to this instance.
     response: {}
   - id: 13
     name: addReliableTopicConfig
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a new reliable topic configuration to a running cluster.
       If a reliable topic configuration with the given {@code name} already exists, then
@@ -990,51 +990,51 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of reliable topic
         - name: listenerConfigs
           type: List_ListenerConfigHolder
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             message listener configurations
         - name: readBatchSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             maximum number of items to read in a batch.
         - name: statisticsEnabled
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             {@code true} to enable gathering of statistics, otherwise {@code false}
         - name: topicOverloadPolicy
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             policy to handle an overloaded topic. Available values are {@code DISCARD_OLDEST},
             {@code DISCARD_NEWEST}, {@code BLOCK} and {@code ERROR}.
         - name: executor
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             a serialized {@link java.util.concurrent.Executor} instance to use for executing
             message listeners or {@code null}
         - name: userCodeNamespace
           type: String
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             Name of the User Code Namespace applied to this instance.
     response: {}
   - id: 14
     name: addCacheConfig
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a new cache configuration to a running cluster.
       If a cache configuration with the given {@code name} already exists, then
@@ -1046,92 +1046,92 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             cache name
         - name: keyType
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             class name of key type
         - name: valueType
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             class name of value type
         - name: statisticsEnabled
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             {@code true} to enable gathering of statistics, otherwise {@code false}
         - name: managementEnabled
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             {@code true} to enable management interface on this cache or {@code false}
         - name: readThrough
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             {@code true} to enable read through from a {@code CacheLoader}
         - name: writeThrough
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             {@code true} to enable write through to a {@code CacheWriter}
         - name: cacheLoaderFactory
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             name of cache loader factory class, if one is configured
         - name: cacheWriterFactory
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             name of cache writer factory class, if one is configured
         - name: cacheLoader
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Factory name of cache loader factory class, if one is configured
         - name: cacheWriter
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Factory name of cache writer factory class, if one is configured
         - name: backupCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             number of synchronous backups
         - name: asyncBackupCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             number of asynchronous backups
         - name: inMemoryFormat
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             data type used to store entries. Valid values are {@code BINARY},
             {@code OBJECT} and {@code NATIVE}.
         - name: splitBrainProtectionName
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             name of an existing configured split brain protection to be used to determine the minimum
             number of members required in the cluster for the cache to remain functional.
@@ -1139,7 +1139,7 @@ methods:
         - name: mergePolicy
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             name of a class implementing SplitBrainMergePolicy
             that handles merging of values for this cache while recovering from
@@ -1147,87 +1147,87 @@ methods:
         - name: mergeBatchSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             number of entries to be sent in a merge operation
         - name: disablePerEntryInvalidationEvents
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             when {@code true} disables invalidation events for per entry but
             full-flush invalidation events are still enabled.
         - name: partitionLostListenerConfigs
           type: List_ListenerConfigHolder
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             partition lost listener configurations
         - name: expiryPolicyFactoryClassName
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             expiry policy factory class name. When configuring an expiry policy,
             either this or {@ode timedExpiryPolicyFactoryConfig} should be configured.
         - name: timedExpiryPolicyFactoryConfig
           type: TimedExpiryPolicyFactoryConfig
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             expiry policy factory with duration configuration
         - name: cacheEntryListeners
           type: List_CacheSimpleEntryListenerConfig
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             cache entry listeners configuration
         - name: evictionConfig
           type: EvictionConfigHolder
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             cache eviction configuration
         - name: wanReplicationRef
           type: WanReplicationRef
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             reference to an existing WAN replication configuration
         - name: eventJournalConfig
           type: EventJournalConfig
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Event Journal configuration
         - name: hotRestartConfig
           type: HotRestartConfig
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             hot restart configuration
         - name: merkleTreeConfig
           type: MerkleTreeConfig
           nullable: true
-          since: 2.3
+          since: "2.3"
           doc: |
             merkle tree configuration
         - name: dataPersistenceConfig
           type: DataPersistenceConfig
           nullable: false
-          since: 2.5
+          since: "2.5"
           doc: |
             Data persistence configuration
         - name: userCodeNamespace
           type: String
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             Name of the User Code Namespace applied to this instance.
     response: {}
   - id: 15
     name: addFlakeIdGeneratorConfig
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a new flake ID generator configuration to a running cluster.
       If a flake ID generator configuration for the same name already exists, then
@@ -1239,61 +1239,61 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of {@code FlakeIdGenerator}
         - name: prefetchCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             how many IDs are pre-fetched on the background when one call to {@code newId()} is made
         - name: prefetchValidity
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             for how long the pre-fetched IDs can be used
         - name: statisticsEnabled
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             {@code true} to enable gathering of statistics, otherwise {@code false}
         - name: nodeIdOffset
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Offset that will be added to the node id assigned to the cluster members for this generator.
         - name: epochStart
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             offset of timestamp component in milliseconds 
         - name: bitsSequence
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             bit length of sequence component 
         - name: bitsNodeId
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             bit length of node id component
         - name: allowedFutureMillis
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             how far to the future is it allowed to go to generate IDs
     response: {}
   - id: 16
     name: addPNCounterConfig
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a new CRDT PN counter configuration to a running cluster.
       If a PN counter configuration with the given {@code name} already exists, then
@@ -1305,25 +1305,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of the CRDT PN counter configuration
         - name: replicaCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             number of replicas on which the CRDT state is kept
         - name: statisticsEnabled
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             set to {@code true} to enable statistics on this multimap configuration
         - name: splitBrainProtectionName
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             name of an existing configured split brain protection to be used to determine the minimum number of members
             required in the cluster for the lock to remain functional. When {@code null}, split brain protection does not
@@ -1331,7 +1331,7 @@ methods:
     response: {}
   - id: 17
     name: addDataConnectionConfig
-    since: 2.6
+    since: "2.6"
     doc: |
       Adds a data connection configuration.
       If a data connection configuration with the given {@code name} already exists, then
@@ -1343,19 +1343,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.6
+          since: "2.6"
           doc: |
             Name of this data connection, must be unique.
         - name: type
           type: String
           nullable: false
-          since: 2.6
+          since: "2.6"
           doc: |
             Type of the data connection as specified in the DataConnectionRegistration.
         - name: shared
           type: boolean
           nullable: false
-          since: 2.6
+          since: "2.6"
           doc: |
             {@code true} if an instance of the data connection will be shared. 
             Depending on the implementation of the data connection the shared instance may be 
@@ -1366,13 +1366,13 @@ methods:
         - name: properties
           type: Map_String_String
           nullable: false
-          since: 2.6
+          since: "2.6"
           doc: |
             Properties of the data connection configuration.
     response: {}
   - id: 18
     name: addWanReplicationConfig
-    since: 2.7
+    since: "2.7"
     doc: |
       Adds a WAN replication configuration.
     request:
@@ -1382,31 +1382,31 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             WAN replication configuration name.
         - name: consumerConfig
           type: WanConsumerConfigHolder
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             The WAN consumer configuration.
         - name: customPublisherConfigs
           type: List_WanCustomPublisherConfigHolder
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             The WAN custom publisher configurations.
         - name: batchPublisherConfigs
           type: List_WanBatchPublisherConfigHolder
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             The WAN batch publisher configurations.
     response: {}
   - id: 19
     name: addUserCodeNamespaceConfig
-    since: 2.7
+    since: "2.7"
     doc: |
       Adds a user code namespace configuration.
     request:
@@ -1416,19 +1416,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Namespace configuration name.
         - name: resources
           type: List_ResourceDefinition
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             List of resource definitions.
     response: {}
   - id: 20
     name: addVectorCollectionConfig
-    since: 2.8
+    since: "2.8"
     doc: |
       Adds a new vector collection configuration to a running cluster.
     request:
@@ -1438,31 +1438,31 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             vector collection name
         - name: indexConfigs
           type: List_VectorIndexConfig
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             vector index configurations
         - name: backupCount
           type: int
           nullable: false
-          since: 2.9
+          since: "2.9"
           doc: |
             number of synchronous backups
         - name: asyncBackupCount
           type: int
           nullable: false
-          since: 2.9
+          since: "2.9"
           doc: |
             number of asynchronous backups
         - name: splitBrainProtectionName
           type: String
           nullable: true
-          since: 2.9
+          since: "2.9"
           doc: |
             Name of an existing configured split brain protection to be used to determine the minimum number of members
             required in the cluster for the VectorCollection to remain functional. When {@code null}, split brain protection
@@ -1470,20 +1470,20 @@ methods:
         - name: mergePolicy
           type: String
           nullable: false
-          since: 2.9
+          since: "2.9"
           doc: |
             Name of a class implementing SplitBrainMergePolicy that handles merging of values for this VectorCollection
             while recovering from network partitioning.
         - name: mergeBatchSize
           type: int
           nullable: false
-          since: 2.9
+          since: "2.9"
           doc: |
             Number of entries to be sent in a merge operation.
         - name: userCodeNamespace
           type: String
           nullable: true
-          since: 2.9
+          since: "2.9"
           doc: |
             Name of the User Code Namespace applied to this instance.
     response: {}

--- a/protocol-definitions/ExecutorService.yaml
+++ b/protocol-definitions/ExecutorService.yaml
@@ -3,7 +3,7 @@ name: ExecutorService
 methods:
   - id: 1
     name: shutdown
-    since: 2.0
+    since: "2.0"
     doc: |
       Initiates an orderly shutdown in which previously submitted tasks are executed, but no new tasks will be accepted.
       Invocation has no additional effect if already shut down.
@@ -14,13 +14,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the executor.
     response: {}
   - id: 2
     name: isShutdown
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns true if this executor has been shut down.
     request:
@@ -30,7 +30,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the executor.
     response:
@@ -38,12 +38,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if this executor has been shut down
   - id: 3
     name: cancelOnPartition
-    since: 2.0
+    since: "2.0"
     doc: |
       Cancels the task running on the member that owns the partition with the given id.
     request:
@@ -53,13 +53,13 @@ methods:
         - name: uuid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Unique id for the execution.
         - name: interrupt
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             If true, then the thread interrupt call can be used to cancel the thread, otherwise interrupt can not be used.
     response:
@@ -67,12 +67,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if cancelled successfully, false otherwise.
   - id: 4
     name: cancelOnMember
-    since: 2.0
+    since: "2.0"
     doc: |
       Cancels the task running on the member with the given address.
     request:
@@ -82,19 +82,19 @@ methods:
         - name: uuid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Unique id for the execution.
         - name: memberUUID
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The UUID of the member to execute the request on.
         - name: interrupt
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             If true, then the thread interrupt call can be used to cancel the thread, otherwise interrupt can not be used.
     response:
@@ -102,12 +102,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if cancelled successfully, false otherwise.
   - id: 5
     name: submitToPartition
-    since: 2.0
+    since: "2.0"
     doc: |
       Submits the task to the member that owns the partition with the given id.
     request:
@@ -117,19 +117,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the executor.
         - name: uuid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Unique id for the execution.
         - name: callable
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The callable object to be executed.
     response:
@@ -137,12 +137,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The result of the callable execution.
   - id: 6
     name: submitToMember
-    since: 2.0
+    since: "2.0"
     doc: |
       Submits the task to member specified by the address.
     request:
@@ -152,25 +152,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the executor.
         - name: uuid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Unique id for the execution.
         - name: callable
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The callable object to be executed.
         - name: memberUUID
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The UUID of the member host on which the callable shall be executed on.
     response:
@@ -178,6 +178,6 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The result of the callable execution.

--- a/protocol-definitions/Experimental.yaml
+++ b/protocol-definitions/Experimental.yaml
@@ -3,7 +3,7 @@ name: Experimental
 methods:
   - id: 1
     name: pipelineSubmit
-    since: 2.7
+    since: "2.7"
     doc: 'The message is used to transfer the declarative pipeline definition and the related resource files 
     from client to the server.'
     request:
@@ -13,29 +13,29 @@ methods:
         - name: jobName
           type: String
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: 'The name of the submitted Job using this pipeline.'
         - name: pipelineDefinition
           type: String
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: 'The definition of the pipeline steps. It currently uses the YAML format.'
         - name: resourceBundle
           type: byteArray
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: 'This is the zipped file which contains the user project folders and files. For Python project, 
           it is the Python project files. It is optional in the sense that if the user likes to use a user docker 
           image with all the resources and project files included, this parameter can be null.'
         - name: resourceBundleChecksum
           type: int
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: 'This is the CRC32 checksum over the resource bundle bytes.'
     response:
       params:
         - name: jobId
           type: long
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: 'This is the unique identifier for the job which is created for this pipeline'

--- a/protocol-definitions/FencedLock.yaml
+++ b/protocol-definitions/FencedLock.yaml
@@ -3,7 +3,7 @@ name: FencedLock
 methods:
   - id: 1
     name: lock
-    since: 2.0
+    since: "2.0"
     doc: |
       Acquires the given FencedLock on the given CP group. If the lock is
       acquired, a valid fencing token (positive number) is returned. If not
@@ -19,31 +19,31 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this FencedLock instance
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of this FencedLock instance
         - name: sessionId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Session ID of the caller
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the caller thread
         - name: invocationUid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             UID of this invocation
     response:
@@ -51,13 +51,13 @@ methods:
         - name: response
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             a valid fencing token (positive number) if the lock
             is acquired, otherwise -1.
   - id: 2
     name: tryLock
-    since: 2.0
+    since: "2.0"
     doc: |
       Attempts to acquire the given FencedLock on the given CP group.
       If the lock is acquired, a valid fencing token (positive number) is
@@ -74,37 +74,37 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this FencedLock instance
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of this FencedLock instance
         - name: sessionId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Session ID of the caller
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the caller thread
         - name: invocationUid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             UID of this invocation
         - name: timeoutMs
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Duration to wait for lock acquire
     response:
@@ -112,13 +112,13 @@ methods:
         - name: response
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             a valid fencing token (positive number) if the lock
             is acquired, otherwise -1.
   - id: 3
     name: unlock
-    since: 2.0
+    since: "2.0"
     doc: |
       Unlocks the given FencedLock on the given CP group. If the lock is
       not acquired, the call fails with {@link IllegalMonitorStateException}.
@@ -132,31 +132,31 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this FencedLock instance
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of this FencedLock instance
         - name: sessionId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Session ID of the caller
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the caller thread
         - name: invocationUid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             UID of this invocation
     response:
@@ -164,13 +164,13 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if the lock is still held by the caller after
             a successful unlock() call, false otherwise.
   - id: 4
     name: getLockOwnership
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns current lock ownership status of the given FencedLock instance.
     request:
@@ -180,13 +180,13 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this FencedLock instance
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of this FencedLock instance
     response:
@@ -194,24 +194,24 @@ methods:
         - name: fence
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Fence token of the lock
         - name: lockCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Reentrant lock count
         - name: sessionId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Id of the session that holds the lock
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Id of the thread that holds the lock

--- a/protocol-definitions/FlakeIdGenerator.yaml
+++ b/protocol-definitions/FlakeIdGenerator.yaml
@@ -3,7 +3,7 @@ name: FlakeIdGenerator
 methods:
   - id: 1
     name: newIdBatch
-    since: 2.0
+    since: "2.0"
     doc: |
       Fetches a new batch of ids for the given flake id generator.
     request:
@@ -13,13 +13,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the flake id generator.
         - name: batchSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Number of ids that will be fetched on one call.
     response:
@@ -27,18 +27,18 @@ methods:
         - name: base
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             First id in the batch.
         - name: increment
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Increment for the next id in the batch.
         - name: batchSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Number of ids in the batch.

--- a/protocol-definitions/Jet.yaml
+++ b/protocol-definitions/Jet.yaml
@@ -3,7 +3,7 @@ name: Jet
 methods:
   - id: 1
     name: submitJob
-    since: 2.0
+    since: "2.0"
     doc: ''
     request:
       retryable: false
@@ -12,27 +12,27 @@ methods:
         - name: jobId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: ''
         - name: dag
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: ''
         - name: jobConfig
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: ''
         - name: lightJobCoordinator
           type: UUID
           nullable: true
-          since: 2.3
+          since: "2.3"
           doc: ''
     response: {}
   - id: 2
     name: terminateJob
-    since: 2.0
+    since: "2.0"
     doc: ''
     request:
       retryable: false
@@ -41,22 +41,22 @@ methods:
         - name: jobId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: ''
         - name: terminateMode
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: ''
         - name: lightJobCoordinator
           type: UUID
           nullable: true
-          since: 2.3
+          since: "2.3"
           doc: ''
     response: {}
   - id: 3
     name: getJobStatus
-    since: 2.0
+    since: "2.0"
     doc: ''
     request:
       retryable: true
@@ -65,18 +65,18 @@ methods:
         - name: jobId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: ''
     response:
       params:
         - name: response
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: ''
   - id: 4
     name: getJobIds
-    since: 2.0
+    since: "2.0"
     doc: ''
     request:
       retryable: true
@@ -85,23 +85,23 @@ methods:
         - name: onlyName
           type: String
           nullable: true
-          since: 2.3
+          since: "2.3"
           doc: ''
         - name: onlyJobId
           type: long
           nullable: false
-          since: 2.3
+          since: "2.3"
           doc: ''
     response:
       params:
         - name: response
           type: Data
           nullable: false
-          since: 2.3
+          since: "2.3"
           doc: ''
   - id: 5
     name: joinSubmittedJob
-    since: 2.0
+    since: "2.0"
     doc: ''
     request:
       retryable: true
@@ -110,17 +110,17 @@ methods:
         - name: jobId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: ''
         - name: lightJobCoordinator
           type: UUID
           nullable: true
-          since: 2.3
+          since: "2.3"
           doc: ''
     response: {}
   - id: 7
     name: getJobSubmissionTime
-    since: 2.0
+    since: "2.0"
     doc: ''
     request:
       retryable: true
@@ -129,23 +129,23 @@ methods:
         - name: jobId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: ''
         - name: lightJobCoordinator
           type: UUID
           nullable: true
-          since: 2.3
+          since: "2.3"
           doc: ''
     response:
       params:
         - name: response
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: ''
   - id: 8
     name: getJobConfig
-    since: 2.0
+    since: "2.0"
     doc: ''
     request:
       retryable: true
@@ -154,23 +154,23 @@ methods:
         - name: jobId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: ''
         - name: lightJobCoordinator
           type: UUID
           nullable: true
-          since: 2.4
+          since: "2.4"
           doc: ''
     response:
       params:
         - name: response
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: ''
   - id: 9
     name: resumeJob
-    since: 2.0
+    since: "2.0"
     doc: ''
     request:
       retryable: false
@@ -179,12 +179,12 @@ methods:
         - name: jobId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: ''
     response: {}
   - id: 10
     name: exportSnapshot
-    since: 2.0
+    since: "2.0"
     doc: ''
     request:
       retryable: false
@@ -193,22 +193,22 @@ methods:
         - name: jobId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: ''
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: ''
         - name: cancelJob
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: ''
     response: {}
   - id: 11
     name: getJobSummaryList
-    since: 2.0
+    since: "2.0"
     doc: ''
     request:
       retryable: true
@@ -219,11 +219,11 @@ methods:
         - name: response
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: ''
   - id: 12
     name: existsDistributedObject
-    since: 2.0
+    since: "2.0"
     doc: ''
     request:
       retryable: true
@@ -232,23 +232,23 @@ methods:
         - name: serviceName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: ''
         - name: objectName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: ''
     response:
       params:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: ''
   - id: 13
     name: getJobMetrics
-    since: 2.0
+    since: "2.0"
     doc: ''
     request:
       retryable: true
@@ -257,18 +257,18 @@ methods:
         - name: jobId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: ''
     response:
       params:
         - name: response
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: ''
   - id: 14
     name: getJobSuspensionCause
-    since: 2.0
+    since: "2.0"
     doc: ''
     request:
       retryable: true
@@ -277,18 +277,18 @@ methods:
         - name: jobId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: ''
     response:
       params:
         - name: response
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: ''
   - id: 15
     name: getJobAndSqlSummaryList
-    since: 2.5
+    since: "2.5"
     doc: ''
     request:
       retryable: true
@@ -299,11 +299,11 @@ methods:
         - name: response
           type: List_JobAndSqlSummary
           nullable: false
-          since: 2.5
+          since: "2.5"
           doc: ''
   - id: 16
     name: isJobUserCancelled
-    since: 2.6
+    since: "2.6"
     doc: ''
     request:
       retryable: true
@@ -312,18 +312,18 @@ methods:
         - name: jobId
           type: long
           nullable: false
-          since: 2.6
+          since: "2.6"
           doc: ''
     response:
       params:
         - name: response
           type: boolean
           nullable: false
-          since: 2.6
+          since: "2.6"
           doc: ''
   - id: 17
     name: uploadJobMetaData
-    since: 2.6
+    since: "2.6"
     doc: ''
     request:
       retryable: true
@@ -332,47 +332,47 @@ methods:
         - name: sessionId
           type: UUID
           nullable: false
-          since: 2.6
+          since: "2.6"
           doc: 'Unique session ID of the job upload request'
         - name: jarOnMember
           type: boolean
           nullable: false
-          since: 2.6
+          since: "2.6"
           doc: 'Flag that indicates that the jar to be executed is already present on the member, and no jar will be uploaded from the client'
         - name: fileName
           type: String
           nullable: false
-          since: 2.6
+          since: "2.6"
           doc: 'Name of the jar file without extension'
         - name: sha256Hex
           type: String
           nullable: false
-          since: 2.6
+          since: "2.6"
           doc: 'Hexadecimal SHA256 of the jar file'
         - name: snapshotName
           type: String
           nullable: true
-          since: 2.6
+          since: "2.6"
           doc: 'Name of the initial snapshot to start the job from'
         - name: jobName
           type: String
           nullable: true
-          since: 2.6
+          since: "2.6"
           doc: 'Name of the job'
         - name: mainClass
           type: String
           nullable: true
-          since: 2.6
+          since: "2.6"
           doc: 'Fully qualified name of the main class inside the JAR file'
         - name: jobParameters
           type: List_String
           nullable: false
-          since: 2.6
+          since: "2.6"
           doc: 'Arguments to pass to the supplied jar file'
     response: {}
   - id: 18
     name: uploadJobMultipart
-    since: 2.6
+    since: "2.6"
     doc: ''
     request:
       retryable: true
@@ -381,37 +381,37 @@ methods:
         - name: sessionId
           type: UUID
           nullable: false
-          since: 2.6
+          since: "2.6"
           doc: 'Unique session ID of the job upload request'
         - name: currentPartNumber
           type: int
           nullable: false
-          since: 2.6
+          since: "2.6"
           doc: 'The current part number being sent. Starts from 1'
         - name: totalPartNumber
           type: int
           nullable: false
-          since: 2.6
+          since: "2.6"
           doc: 'The total number of parts to be sent. Minimum value is 1'
         - name: partData
           type: byteArray
           nullable: false
-          since: 2.6
+          since: "2.6"
           doc: 'The binary data of the message part'
         - name: partSize
           type: int
           nullable: false
-          since: 2.6
+          since: "2.6"
           doc: 'The size of binary data'
         - name: sha256Hex
           type: String
           nullable: false
-          since: 2.6
+          since: "2.6"
           doc: 'Hexadecimal SHA256 of the message part'
     response: {}
   - id: 19
     name: addJobStatusListener
-    since: 2.6
+    since: "2.6"
     doc: |
       Adds a JobStatusListener to the specified job.
     request:
@@ -421,19 +421,19 @@ methods:
         - name: jobId
           type: long
           nullable: false
-          since: 2.6
+          since: "2.6"
           doc: |
             ID of job.
         - name: lightJobCoordinator
           type: UUID
           nullable: true
-          since: 2.6
+          since: "2.6"
           doc: |
             Address of the job coordinator for light jobs, null otherwise.
         - name: localOnly
           type: boolean
           nullable: false
-          since: 2.6
+          since: "2.6"
           doc: |
             If true fires events that originated from this node only, otherwise fires all events.
     response:
@@ -441,23 +441,23 @@ methods:
         - name: response
           type: UUID
           nullable: true
-          since: 2.6
+          since: "2.6"
           doc: |
             A unique registration ID which is used as a key to remove the listener.
     events:
       - name: JobStatus
-        since: 2.6
+        since: "2.6"
         params:
           - name: jobId
             type: long
             nullable: false
-            since: 2.6
+            since: "2.6"
             doc: |
               ID of job.
           - name: previousStatus
             type: int
             nullable: false
-            since: 2.6
+            since: "2.6"
             doc: |
               NOT_RUNNING(0)
               STARTING(1)
@@ -467,7 +467,7 @@ methods:
           - name: newStatus
             type: int
             nullable: false
-            since: 2.6
+            since: "2.6"
             doc: |
               NOT_RUNNING(0)
               STARTING(1)
@@ -479,14 +479,14 @@ methods:
           - name: description
             type: String
             nullable: true
-            since: 2.6
+            since: "2.6"
             doc: |
               If the event is generated by the user, indicates the action;
               if there is a failure, indicates the cause; otherwise, null.
           - name: userRequested
             type: boolean
             nullable: false
-            since: 2.6
+            since: "2.6"
             doc: |
               Indicates whether the event is generated by the user via
               {@code Job.suspend()}, {@code Job.resume()}, {@code Job.restart()},
@@ -494,7 +494,7 @@ methods:
               {@code Job.cancelAndExportSnapshot(String)}.
   - id: 20
     name: removeJobStatusListener
-    since: 2.6
+    since: "2.6"
     doc: |
       Removes the specified job status listener. If there is no such listener
       added before, this call does no change in the cluster and returns false.
@@ -505,13 +505,13 @@ methods:
         - name: jobId
           type: long
           nullable: false
-          since: 2.6
+          since: "2.6"
           doc: |
             ID of job.
         - name: registrationId
           type: UUID
           nullable: false
-          since: 2.6
+          since: "2.6"
           doc: |
             ID of registered listener.
     response:
@@ -519,12 +519,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.6
+          since: "2.6"
           doc: |
             True if registration is removed, false otherwise.
   - id: 21
     name: updateJobConfig
-    since: 2.6
+    since: "2.6"
     doc: ''
     request:
       retryable: true
@@ -533,17 +533,17 @@ methods:
         - name: jobId
           type: long
           nullable: false
-          since: 2.6
+          since: "2.6"
           doc: ''
         - name: deltaConfig
           type: Data
           nullable: false
-          since: 2.6
+          since: "2.6"
           doc: ''
     response:
       params:
         - name: updatedConfig
           type: Data
           nullable: false
-          since: 2.6
+          since: "2.6"
           doc: ''

--- a/protocol-definitions/List.yaml
+++ b/protocol-definitions/List.yaml
@@ -3,7 +3,7 @@ name: List
 methods:
   - id: 1
     name: size
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the number of elements in this list.  If this list contains more than Integer.MAX_VALUE elements, returns
       Integer.MAX_VALUE.
@@ -14,7 +14,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of List
     response:
@@ -22,12 +22,12 @@ methods:
         - name: response
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The number of elements in this list
   - id: 2
     name: contains
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns true if this list contains the specified element.
     request:
@@ -37,13 +37,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the List
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Element whose presence in this list is to be tested
     response:
@@ -51,12 +51,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if this list contains the specified element, false otherwise
   - id: 3
     name: containsAll
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns true if this list contains all of the elements of the specified collection.
     request:
@@ -66,13 +66,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the List
         - name: values
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Collection to be checked for containment in this list
     response:
@@ -80,13 +80,13 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if this list contains all of the elements of the
             specified collection
   - id: 4
     name: add
-    since: 2.0
+    since: "2.0"
     doc: |
       Appends the specified element to the end of this list (optional operation). Lists that support this operation may
       place limitations on what elements may be added to this list.  In particular, some lists will refuse to add null
@@ -99,13 +99,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the List
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Element to be appended to this list
     response:
@@ -113,12 +113,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if this list changed as a result of the call, false otherwise
   - id: 5
     name: remove
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes the first occurrence of the specified element from this list, if it is present (optional operation).
       If this list does not contain the element, it is unchanged.
@@ -130,13 +130,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the List
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Element to be removed from this list, if present
     response:
@@ -144,12 +144,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if this list contained the specified element, false otherwise
   - id: 6
     name: addAll
-    since: 2.0
+    since: "2.0"
     doc: |
       Appends all of the elements in the specified collection to the end of this list, in the order that they are
       returned by the specified collection's iterator (optional operation).
@@ -162,13 +162,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the List
         - name: valueList
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Collection containing elements to be added to this list
     response:
@@ -176,12 +176,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if this list changed as a result of the call, false otherwise
   - id: 7
     name: compareAndRemoveAll
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes from this list all of its elements that are contained in the specified collection (optional operation).
     request:
@@ -191,13 +191,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the List
         - name: values
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The list of values to compare for removal.
     response:
@@ -205,12 +205,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if removed at least one of the items, false otherwise.
   - id: 8
     name: compareAndRetainAll
-    since: 2.0
+    since: "2.0"
     doc: |
       Retains only the elements in this list that are contained in the specified collection (optional operation).
       In other words, removes from this list all of its elements that are not contained in the specified collection.
@@ -221,13 +221,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the List
         - name: values
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The list of values to compare for retaining.
     response:
@@ -235,12 +235,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if this list changed as a result of the call, false otherwise.
   - id: 9
     name: clear
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes all of the elements from this list (optional operation). The list will be empty after this call returns.
     request:
@@ -250,13 +250,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the List
     response: {}
   - id: 10
     name: getAll
-    since: 2.0
+    since: "2.0"
     doc: |
       Return the all elements of this collection
     request:
@@ -266,7 +266,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the List
     response:
@@ -274,12 +274,12 @@ methods:
         - name: response
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             An array of all item values in the list.
   - id: 11
     name: addListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds an item listener for this collection. Listener will be notified for all collection add/remove events.
     request:
@@ -289,19 +289,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the List
         - name: includeValue
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Set to true if you want the event to contain the value.
         - name: localOnly
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
@@ -309,34 +309,34 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Registration id for the listener.
     events:
       - name: Item
-        since: 2.0
+        since: "2.0"
         params:
           - name: item
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Item that the event is fired for.
           - name: uuid
             type: UUID
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               UUID of the member that dispatches this event.
           - name: eventType
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Type of the event. It is either ADDED(1) or REMOVED(2).
   - id: 12
     name: removeListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes the specified item listener. If there is no such listener added before, this call does no change in the
       cluster and returns false.
@@ -347,13 +347,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the List
         - name: registrationId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the listener which was provided during registration.
     response:
@@ -361,12 +361,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if unregistered, false otherwise.
   - id: 13
     name: isEmpty
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns true if this list contains no elements
     request:
@@ -376,7 +376,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the List
     response:
@@ -384,12 +384,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if this list contains no elements
   - id: 14
     name: addAllWithIndex
-    since: 2.0
+    since: "2.0"
     doc: |
       Inserts all of the elements in the specified collection into this list at the specified position (optional operation).
       Shifts the element currently at that position (if any) and any subsequent elements to the right (increases their indices).
@@ -403,19 +403,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the List
         - name: index
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             index at which to insert the first element from the specified collection.
         - name: valueList
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The list of value to insert into the list.
     response:
@@ -423,12 +423,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if this list changed as a result of the call, false otherwise.
   - id: 15
     name: get
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the element at the specified position in this list
     request:
@@ -438,13 +438,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the List
         - name: index
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Index of the element to return
     response:
@@ -452,12 +452,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The element at the specified position in this list
   - id: 16
     name: set
-    since: 2.0
+    since: "2.0"
     doc: |
       The element previously at the specified position
     request:
@@ -467,19 +467,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the List
         - name: index
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Index of the element to replace
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Element to be stored at the specified position
     response:
@@ -487,12 +487,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The element previously at the specified position
   - id: 17
     name: addWithIndex
-    since: 2.0
+    since: "2.0"
     doc: |
       Inserts the specified element at the specified position in this list (optional operation). Shifts the element
       currently at that position (if any) and any subsequent elements to the right (adds one to their indices).
@@ -503,25 +503,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the List
         - name: index
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             index at which the specified element is to be inserted
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Value to be inserted.
     response: {}
   - id: 18
     name: removeWithIndex
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes the element at the specified position in this list (optional operation). Shifts any subsequent elements
       to the left (subtracts one from their indices). Returns the element that was removed from the list.
@@ -532,13 +532,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the List
         - name: index
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The index of the element to be removed
     response:
@@ -546,12 +546,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The element previously at the specified position
   - id: 19
     name: lastIndexOf
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the index of the last occurrence of the specified element in this list, or -1 if this list does not
       contain the element.
@@ -562,13 +562,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the List
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Element to search for
     response:
@@ -576,13 +576,13 @@ methods:
         - name: response
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the index of the last occurrence of the specified element in
             this list, or -1 if this list does not contain the element
   - id: 20
     name: indexOf
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the index of the first occurrence of the specified element in this list, or -1 if this list does not
       contain the element.
@@ -593,13 +593,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the List
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Element to search for
     response:
@@ -607,13 +607,13 @@ methods:
         - name: response
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The index of the first occurrence of the specified element in
             this list, or -1 if this list does not contain the element
   - id: 21
     name: sub
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns a view of the portion of this list between the specified from, inclusive, and to, exclusive.(If from and
       to are equal, the returned list is empty.) The returned list is backed by this list, so non-structural changes in
@@ -633,19 +633,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the List
         - name: from
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Low endpoint (inclusive) of the subList
         - name: to
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             High endpoint (exclusive) of the subList
     response:
@@ -653,12 +653,12 @@ methods:
         - name: response
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             A view of the specified range within this list
   - id: 22
     name: iterator
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns an iterator over the elements in this list in proper sequence.
     request:
@@ -668,7 +668,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the List
     response:
@@ -676,12 +676,12 @@ methods:
         - name: response
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             An iterator over the elements in this list in proper sequence
   - id: 23
     name: listIterator
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns a list iterator over the elements in this list (in proper sequence), starting at the specified position
       in the list. The specified index indicates the first element that would be returned by an initial call to
@@ -694,13 +694,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the List
         - name: index
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             index of the first element to be returned from the list iterator next
     response:
@@ -708,7 +708,7 @@ methods:
         - name: response
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             a list iterator over the elements in this list (in proper
             sequence), starting at the specified position in the list

--- a/protocol-definitions/MC.yaml
+++ b/protocol-definitions/MC.yaml
@@ -4,7 +4,7 @@ name: MC
 methods:
   - id: 1
     name: readMetrics
-    since: 2.0
+    since: "2.0"
     doc: |
       Reads the recorded metrics starting with the smallest sequence number
       greater or equals to the sequence number set in fromSequence.
@@ -15,13 +15,13 @@ methods:
         - name: uuid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The UUID of the member that is supposed to read the metrics from.
         - name: fromSequence
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The sequence the recorded metrics should be read starting with.
     response:
@@ -29,18 +29,18 @@ methods:
         - name: elements
           type: EntryList_Long_byteArray
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The map of timestamp and compressed metrics data
         - name: nextSequence
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The sequence number that the next task should start with
   - id: 2
     name: changeClusterState
-    since: 2.0
+    since: "2.0"
     doc: |
       Changes the state of a cluster.
     request:
@@ -50,7 +50,7 @@ methods:
         - name: newState
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             New state of the cluster:
             0 - ACTIVE
@@ -61,7 +61,7 @@ methods:
     response: {}
   - id: 3
     name: getMapConfig
-    since: 2.0
+    since: "2.0"
     doc: |
       Gets the config of a map on the member it's called on.
     request:
@@ -71,7 +71,7 @@ methods:
         - name: mapName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
     response:
@@ -79,7 +79,7 @@ methods:
         - name: inMemoryFormat
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The in memory storage format of the map:
             0 - Binary
@@ -88,37 +88,37 @@ methods:
         - name: backupCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Backup count of the map.
         - name: asyncBackupCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Async backup count of the map.
         - name: timeToLiveSeconds
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Time to live seconds for the map entries.
         - name: maxIdleSeconds
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Maximum idle seconds for the map entries.
         - name: maxSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Maximum size of the map.
         - name: maxSizePolicy
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The maximum size policy of the map:
             0 - PER_NODE
@@ -134,13 +134,13 @@ methods:
         - name: readBackupData
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Whether reading from backup data is allowed.
         - name: evictionPolicy
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The eviction policy of the map:
             0 - LRU
@@ -150,24 +150,24 @@ methods:
         - name: mergePolicy
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Classname of the SplitBrainMergePolicy for the map.
         - name: globalIndexes
           type: List_IndexConfig
           nullable: false
-          since: 2.4
+          since: "2.4"
           doc: |
             Global indexes of the map.
         - name: wanReplicationRef
           type: WanReplicationRef
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             WanReplicationRef of the map. WanReplicationRef is WAN replication target of the map.
   - id: 4
     name: updateMapConfig
-    since: 2.0
+    since: "2.0"
     doc: |
       Updates the config of a map on the member it's called on.
     request:
@@ -177,25 +177,25 @@ methods:
         - name: mapName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: timeToLiveSeconds
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Time to live seconds for the map entries.
         - name: maxIdleSeconds
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Maximum idle seconds for the map entries.
         - name: evictionPolicy
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The eviction policy of the map:
             0 - LRU
@@ -205,19 +205,19 @@ methods:
         - name: readBackupData
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Whether reading from backup data is allowed.
         - name: maxSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Maximum size of the map.
         - name: maxSizePolicy
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The maximum size policy of the map:
             0 - PER_NODE
@@ -233,13 +233,13 @@ methods:
         - name: wanReplicationRef
           type: WanReplicationRef
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             The new WanReplicationRef to apply.
     response: {}
   - id: 5
     name: getMemberConfig
-    since: 2.0
+    since: "2.0"
     doc: |
       Gets the effective config of a member rendered as XML.
     request:
@@ -250,12 +250,12 @@ methods:
         - name: configXml
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Effective config of a member rendered as XML.
   - id: 6
     name: runGc
-    since: 2.0
+    since: "2.0"
     doc: |
       Requests garbage collection to be performed on the member it's called on.
     request:
@@ -264,7 +264,7 @@ methods:
     response: {}
   - id: 7
     name: getThreadDump
-    since: 2.0
+    since: "2.0"
     doc: |
       Takes a thread dump of the member it's called on.
     request:
@@ -274,7 +274,7 @@ methods:
         - name: dumpDeadLocks
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Whether only dead-locked threads or all threads should be dumped.
     response:
@@ -282,12 +282,12 @@ methods:
         - name: threadDump
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Thread dump of the member's JVM.
   - id: 8
     name: shutdownMember
-    since: 2.0
+    since: "2.0"
     doc: |
       Shuts down the member it's called on.
     request:
@@ -296,7 +296,7 @@ methods:
     response: {}
   - id: 9
     name: promoteLiteMember
-    since: 2.0
+    since: "2.0"
     doc: |
       Promotes the lite member it's called on to a data member.
     request:
@@ -305,7 +305,7 @@ methods:
     response: {}
   - id: 10
     name: getSystemProperties
-    since: 2.0
+    since: "2.0"
     doc: |
       Gets the system properties of the member it's called on.
     request:
@@ -316,12 +316,12 @@ methods:
         - name: systemProperties
           type: EntryList_String_String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             System properties of the member.
   - id: 11
     name: getTimedMemberState
-    since: 2.0
+    since: "2.0"
     doc: |
       Gets the latest TimedMemberState of the member it's called on.
     request:
@@ -332,12 +332,12 @@ methods:
         - name: timedMemberStateJson
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Latest TimedMemberState of the member, serialized as JSON.
   - id: 12
     name: matchMCConfig
-    since: 2.0
+    since: "2.0"
     doc: |
       Checks if local MC config (client filter list) has the same ETag as provided.
     request:
@@ -347,7 +347,7 @@ methods:
         - name: eTag
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ETag value of current MC config.
     response:
@@ -355,12 +355,12 @@ methods:
         - name: result
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if ETag values are equal; or false otherwise.
   - id: 13
     name: applyMCConfig
-    since: 2.0
+    since: "2.0"
     doc: |
       Applies given MC config (client filter list).
     request:
@@ -370,13 +370,13 @@ methods:
         - name: eTag
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ETag value of the config.
         - name: clientBwListMode
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The mode for client filtering:
             0 - DISABLED
@@ -385,13 +385,13 @@ methods:
         - name: clientBwListEntries
           type: List_ClientBwListEntry
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Client filter list entries.
     response: {}
   - id: 14
     name: getClusterMetadata
-    since: 2.0
+    since: "2.0"
     doc: |
       Gets the current metadata of a cluster.
     request:
@@ -402,7 +402,7 @@ methods:
         - name: currentState
           type: byte
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Current state of the cluster:
             0 - ACTIVE
@@ -413,30 +413,30 @@ methods:
         - name: memberVersion
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Current version of the member.
         - name: jetVersion
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Current Jet version of the member.
         - name: clusterTime
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Cluster-wide time in milliseconds.
         - name: clusterId
           type: UUID
           nullable: false
-          since: 2.5
+          since: "2.5"
           doc: |
             Cluster ID.
   - id: 15
     name: shutdownCluster
-    since: 2.0
+    since: "2.0"
     doc: |
       Shuts down the cluster.
     request:
@@ -445,7 +445,7 @@ methods:
     response: {}
   - id: 16
     name: changeClusterVersion
-    since: 2.0
+    since: "2.0"
     doc: |
       Changes the cluster version.
     request:
@@ -455,19 +455,19 @@ methods:
         - name: majorVersion
           type: byte
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Major component of the new cluster version.
         - name: minorVersion
           type: byte
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Minor component of the new cluster version.
     response: {}
   - id: 17
     name: runScript
-    since: 2.0
+    since: "2.0"
     doc: |
       Runs given script on the member it's called on.
     request:
@@ -477,13 +477,13 @@ methods:
         - name: engine
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of script engine which will be used for the execution.
         - name: script
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The script to be executed.
     response:
@@ -491,12 +491,12 @@ methods:
         - name: result
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Execution result: script output.
   - id: 18
     name: runConsoleCommand
-    since: 2.0
+    since: "2.0"
     doc: |
       Runs given console command on the member it's called on.
     request:
@@ -506,13 +506,13 @@ methods:
         - name: namespace
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Optional namespace to be set before the command is executed.
         - name: command
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The console command to be executed.
     response:
@@ -520,12 +520,12 @@ methods:
         - name: result
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Execution result: console command output.
   - id: 19
     name: changeWanReplicationState
-    since: 2.0
+    since: "2.0"
     doc: |
       Stop, pause or resume WAN replication for the given WAN replication and publisher
     request:
@@ -535,19 +535,19 @@ methods:
         - name: wanReplicationName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the WAN replication to change state of.
         - name: wanPublisherId
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the WAN publisher to change state of.
         - name: newState
           type: byte
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             New state for the WAN publisher:
             0 - REPLICATING
@@ -556,7 +556,7 @@ methods:
     response: {}
   - id: 20
     name: clearWanQueues
-    since: 2.0
+    since: "2.0"
     doc: |
       Clear WAN replication queues for the given wan replication and publisher
     request:
@@ -566,19 +566,19 @@ methods:
         - name: wanReplicationName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the WAN replication to clear WAN replication queues of.
         - name: wanPublisherId
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the WAN publisher to clear WAN replication queues of.
     response: {}
   - id: 21
     name: addWanBatchPublisherConfig
-    since: 2.0
+    since: "2.0"
     doc: |
       Add a new WAN batch publisher configuration
     request:
@@ -588,43 +588,43 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the WAN replication to add
         - name: targetCluster
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the target cluster
         - name: publisherId
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             - ID used for identifying the publisher in a WanReplicationConfig
         - name: endpoints
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Comma separated list of target cluster members
         - name: queueCapacity
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Capacity of the primary and backup queue for WAN replication events
         - name: batchSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The maximum batch size that can be sent to target cluster
         - name: batchMaxDelayMillis
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The maximum amount of time in milliseconds to wait before sending a batch
              of events to target cluster, if `batch size` of events have not arrived
@@ -632,7 +632,7 @@ methods:
         - name: responseTimeoutMillis
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The duration in milliseconds for the wait time before retrying to
             send the events to target cluster again in case the acknowledgement
@@ -640,7 +640,7 @@ methods:
         - name: ackType
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The strategy for when the target cluster should acknowledge that
             a WAN event batch has been processed:
@@ -649,7 +649,7 @@ methods:
         - name: queueFullBehavior
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Behaviour of this WAN publisher when the WAN queue is full:
             0 - DISCARD_AFTER_MUTATION
@@ -658,7 +658,7 @@ methods:
         - name: consistencyCheckStrategy
           type: byte
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Strategy for checking the consistency of data between wanReplicationResourceName:
             0 - NONE
@@ -668,19 +668,19 @@ methods:
         - name: addedPublisherIds
           type: List_String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Returns the IDs for the WAN publishers which were added to the configuration
         - name: ignoredPublisherIds
           type: List_String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Returns the IDs for the WAN publishers which were ignored and not added to
             the configuration.
   - id: 22
     name: wanSyncMap
-    since: 2.0
+    since: "2.0"
     doc: |
       Initiate WAN sync for a specific map or all maps
     request:
@@ -690,19 +690,19 @@ methods:
         - name: wanReplicationName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the WAN replication to initiate WAN sync for
         - name: wanPublisherId
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the WAN publisher to initiate WAN sync for
         - name: wanSyncType
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Whether all maps are going to be synced or only a single one:
             0 - ALL_MAPS
@@ -710,7 +710,7 @@ methods:
         - name: mapName
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map to trigger WAN sync on, null if all maps are to be synced
     response:
@@ -718,12 +718,12 @@ methods:
         - name: uuid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             UUID of the synchronization
   - id: 23
     name: checkWanConsistency
-    since: 2.0
+    since: "2.0"
     doc: |
       Initiate WAN consistency check for a specific map
     request:
@@ -733,19 +733,19 @@ methods:
         - name: wanReplicationName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the WAN replication to initiate WAN consistency check for
         - name: wanPublisherId
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the WAN publisher to initiate WAN consistency check for
         - name: mapName
           type: String
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map to initiate WAN consistency check for
     response:
@@ -753,13 +753,13 @@ methods:
         - name: uuid
           type: UUID
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             UUID of the consistency check request or null if consistency
             check is ignored because of the configuration
   - id: 24
     name: pollMCEvents
-    since: 2.0
+    since: "2.0"
     doc: |
       Polls events available on member. Once read, events are removed from
       member's internal queue.
@@ -771,12 +771,12 @@ methods:
         - name: events
           type: List_MCEvent
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             List of events.
   - id: 25
     name: getCPMembers
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the current list of CP members.
     request:
@@ -787,13 +787,13 @@ methods:
         - name: cpMembers
           type: EntryList_UUID_UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             List of CP member UUIDs. The mapping is from the UUID of the CP member to UUID of that member on the
             member list of the cluster service.
   - id: 26
     name: promoteToCPMember
-    since: 2.0
+    since: "2.0"
     doc: |
       Promotes the local member to the CP role.
     request:
@@ -802,7 +802,7 @@ methods:
     response: {}
   - id: 27
     name: removeCPMember
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes the given unreachable CP member from the active CP members
       list and all CP groups it belongs to.
@@ -813,13 +813,13 @@ methods:
         - name: cpMemberUuid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             UUID of the unreachable CP member
     response: {}
   - id: 28
     name: resetCPSubsystem
-    since: 2.0
+    since: "2.0"
     doc: |
       Wipes and resets the whole CP Subsystem state and initializes it
       as if the Hazelcast cluster is starting up initially.
@@ -829,7 +829,7 @@ methods:
     response: {}
   - id: 29
     name: triggerPartialStart
-    since: 2.0
+    since: "2.0"
     doc: |
       Triggers partial start
     request:
@@ -839,13 +839,13 @@ methods:
       params:
         - name: result
           type: boolean
-          since: 2.0
+          since: "2.0"
           nullable: false
           doc: |
             True if the partial restart was successfully initiated, false otherwise
   - id: 30
     name: triggerForceStart
-    since: 2.0
+    since: "2.0"
     doc: |
       Triggers force start
     request:
@@ -855,13 +855,13 @@ methods:
       params:
         - name: result
           type: boolean
-          since: 2.0
+          since: "2.0"
           nullable: false
           doc: |
             True if the forced start was successfully initiated, false otherwise
   - id: 31
     name: triggerHotRestartBackup
-    since: 2.0
+    since: "2.0"
     doc: |
       Triggers hot restart backup
     request:
@@ -870,7 +870,7 @@ methods:
     response: {}
   - id: 32
     name: interruptHotRestartBackup
-    since: 2.0
+    since: "2.0"
     doc: |
       Interrupts hot restart backup
     request:
@@ -879,7 +879,7 @@ methods:
     response: {}
   - id: 33
     name: resetQueueAgeStatistics
-    since: 2.4
+    since: "2.4"
     doc: Resets the max-age, min-age and average-age metrics of the queue
     request:
       retryable: false
@@ -888,12 +888,12 @@ methods:
        - name: name
          type: String
          nullable: false
-         since: 2.4
+         since: "2.4"
          doc: Name of the Queue for which the age-related statistics should be reset to 0
     response: {}
   - id: 34
     name: reloadConfig
-    since: 2.4
+    since: "2.4"
     doc: Reloads the configuration on the member from its config file, applies (merges) the new config to the current config
     request:
       retryable: false
@@ -904,10 +904,10 @@ methods:
           type: UUID
           nullable: false
           doc: The unique identifier of the configuration reload process which will be included in all MCEvent instances emitted for MC during the update
-          since: 2.4
+          since: "2.4"
   - id: 35
     name: updateConfig
-    since: 2.4
+    since: "2.4"
     doc: Updates the configuration on the member with the passed configuration, applies (merges) the passed config to the current config
     request:
       retryable: false
@@ -916,7 +916,7 @@ methods:
        - name: configuration
          type: String
          nullable: false
-         since: 2.4
+         since: "2.4"
          doc: the config patch (XML or YAML string) to be applied to the current configuration
     response:
       params:
@@ -924,10 +924,10 @@ methods:
           type: UUID
           nullable: false
           doc: The unique identifier of the configuration update process which will be included in all MCEvent instances emitted for MC during the update
-          since: 2.4
+          since: "2.4"
   - id: 36
     name: forceCloseCPSession
-    since: 2.7
+    since: "2.7"
     doc: |
       Closes the given session forcefully on the given CP group.
     request:
@@ -937,13 +937,13 @@ methods:
         - name: groupName
           type: String
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Name of the CP group
         - name: sessionId
           type: long
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             ID of the session
     response:
@@ -951,13 +951,13 @@ methods:
         - name: result
           type: boolean
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             true if the session is found & closed,
             false otherwise.
   - id: 37
     name: demoteDataMember
-    since: 2.8
+    since: "2.8"
     doc: |
       Demotes the data member it's called on to a lite member.
       May throw an exception if the operation is not successful.
@@ -967,7 +967,7 @@ methods:
     response: {}
   - id: 38
     name: getConfigFileContent
-    since: 2.8
+    since: "2.8"
     doc: |
       Gets the member configuration file content (XML or YAML string) of the member.
     request:
@@ -978,12 +978,12 @@ methods:
         - name: configFileContent
           type: String
           nullable: true
-          since: 2.8
+          since: "2.8"
           doc: |
             Member configuration file content (XML or YAML string) of the member or null if the server was not started using a configuration file.
   - id: 39
     name: setDiagnosticsConfig
-    since: 2.9
+    since: "2.9"
     doc: |
       Sets the diagnostics configuration on a running cluster dynamically. It's a basically a dynamic configuration which can be done only by MC or Operator. Sending this
       request to a member is sufficient to set the diagnostics configuration on the whole cluster. If one of the members fails to set the configuration, 
@@ -995,61 +995,61 @@ methods:
         - name: enabled
           type: boolean
           nullable: false
-          since: 2.9
+          since: "2.9"
           doc: |
             Indicates whether diagnostics service is enabled or not
         - name: outputType
           type: String
           nullable: false
-          since: 2.9
+          since: "2.9"
           doc: |
             The output type for the diagnostics
         - name: includeEpochTime
           type: boolean
           nullable: false
-          since: 2.9
+          since: "2.9"
           doc: |
             Indicates if the epoch time should be included in the 'top' section
         - name: maxRolledFileSizeInMB
           type: float
           nullable: false
-          since: 2.9
+          since: "2.9"
           doc: |
             The maximum size in MB for a single file
         - name: maxRolledFileCount
           type: int
           nullable: false
-          since: 2.9
+          since: "2.9"
           doc: |
             The maximum number of rolling files to keep on disk
         - name: logDirectory
           type: String
           nullable: false
-          since: 2.9
+          since: "2.9"
           doc: |
             The path of output directory for the diagnostics log files. It can be a relative path to the working directory or an absolute path
         - name: fileNamePrefix
           type: String
           nullable: true
-          since: 2.9
+          since: "2.9"
           doc: |
             The prefix for the diagnostics file
         - name: properties
           type: Map_String_String
           nullable: true
-          since: 2.9
+          since: "2.9"
           doc: |
             Properties specific to DiagnosticsPlugin implementations
         - name: autoOffDurationInMinutes
           type: int
           nullable: false
-          since: 2.9
+          since: "2.9"
           doc: |
             The auto time off duration for the service in minutes. The value must be positive. Set -1 only if you want to disable the auto time off feature.
     response: { }
   - id: 40
     name: getDiagnosticsConfig
-    since: 2.9
+    since: "2.9"
     doc: |
       Gets the diagnostics configuration from the member.
     request:
@@ -1060,60 +1060,60 @@ methods:
         - name: enabled
           type: boolean
           nullable: false
-          since: 2.9
+          since: "2.9"
           doc: |
             Indicates whether diagnostics service is enabled or not
         - name: outputType
           type: String
           nullable: false
-          since: 2.9
+          since: "2.9"
           doc: |
             The output type for the diagnostics
         - name: includeEpochTime
           type: boolean
           nullable: false
-          since: 2.9
+          since: "2.9"
           doc: |
             Indicates if the epoch time should be included in the 'top' section
         - name: maxRolledFileSizeInMB
           type: float
           nullable: false
-          since: 2.9
+          since: "2.9"
           doc: |
             The maximum size in MB for a single file
         - name: maxRolledFileCount
           type: int
           nullable: false
-          since: 2.9
+          since: "2.9"
           doc: |
             The maximum number of rolling files to keep on disk
         - name: logDirectory
           type: String
           nullable: false
-          since: 2.9
+          since: "2.9"
           doc: |
             The path of output directory for the diagnostics log files. It can be a relative path to the working directory or an absolute path
         - name: fileNamePrefix
           type: String
           nullable: true
-          since: 2.9
+          since: "2.9"
           doc: |
             The prefix for the diagnostics file
         - name: properties
           type: Map_String_String
           nullable: true
-          since: 2.9
+          since: "2.9"
           doc: |
             Properties specific to DiagnosticsPlugin implementations
         - name: autoOffDurationInMinutes
           type: int
           nullable: false
-          since: 2.9
+          since: "2.9"
           doc: |
             The auto time off duration for the service in minutes. The value must be positive. Set -1 only if you want to disable the auto time off feature.
         - name: canBeConfiguredDynamically
           type: boolean
           nullable: false
-          since: 2.9
+          since: "2.9"
           doc: |
             Indicates whether the diagnostics service can be configured dynamically or not

--- a/protocol-definitions/Map.yaml
+++ b/protocol-definitions/Map.yaml
@@ -3,7 +3,7 @@ name: Map
 methods:
   - id: 1
     name: put
-    since: 2.0
+    since: "2.0"
     doc: |
       Puts an entry into this map with a given ttl (time to live) value.Entry will expire and get evicted after the ttl
       If ttl is 0, then the entry lives forever.This method returns a clone of the previous value, not the original
@@ -16,31 +16,31 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key for the map entry.
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Value for the map entry.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: ttl
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The duration in milliseconds after which this entry shall be deleted. O means infinite.
     response:
@@ -48,12 +48,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             old value of the entry
   - id: 2
     name: get
-    since: 2.0
+    since: "2.0"
     doc: |
       This method returns a clone of the original value, so modifying the returned value does not change the actual
       value in the map. You should put the modified value back to make changes visible to all nodes.
@@ -64,19 +64,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key for the map entry.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
@@ -84,12 +84,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The value for the key if exists
   - id: 3
     name: remove
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes the mapping for a key from this map if it is present (optional operation).
       Returns the value to which this map previously associated the key, or null if the map contained no mapping for the key.
@@ -103,19 +103,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key for the map entry.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
@@ -123,12 +123,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Clone of the removed value, not the original (identically equal) value previously put into the map.
   - id: 4
     name: replace
-    since: 2.0
+    since: "2.0"
     doc: |
       Replaces the entry for a key only if currently mapped to a given value.
     request:
@@ -138,25 +138,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key for the map entry.
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             New value for the map entry.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
@@ -164,12 +164,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Clone of the previous value, not the original (identically equal) value previously put into the map.
   - id: 5
     name: replaceIfSame
-    since: 2.0
+    since: "2.0"
     doc: |
       Replaces the the entry for a key only if existing values equal to the testValue
     request:
@@ -179,31 +179,31 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key for the map entry.
         - name: testValue
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Test the existing value against this value to find if equal to this value.
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             New value for the map entry. Only replace with this value if existing value is equal to the testValue.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
@@ -211,12 +211,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if value is replaced with new one, false otherwise
   - id: 6
     name: containsKey
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns true if this map contains a mapping for the specified key.
     request:
@@ -226,19 +226,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key for the map entry.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
@@ -246,12 +246,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Returns true if the key exists, otherwise returns false.
   - id: 7
     name: containsValue
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns true if this map maps one or more keys to the specified value.This operation will probably require time
       linear in the map size for most implementations of the Map interface.
@@ -262,13 +262,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Value to check if exists in the map.
     response:
@@ -276,12 +276,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Returns true if the value exists, otherwise returns false.
   - id: 8
     name: removeIfSame
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes the mapping for a key from this map if existing value equal to the this value
     request:
@@ -291,25 +291,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key for the map entry.
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Test the existing value against this value to find if equal to this value. Only remove the entry from the map if the value is equal to this value.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
@@ -317,12 +317,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Returns true if the key exists and removed, otherwise returns false.
   - id: 9
     name: delete
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes the mapping for a key from this map if it is present.Unlike remove(Object), this operation does not return
       the removed value, which avoids the serialization cost of the returned value.If the removed value will not be used,
@@ -337,19 +337,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key for the map entry.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
@@ -357,12 +357,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Returns true if the key exists and removed, otherwise returns false.
   - id: 10
     name: flush
-    since: 2.0
+    since: "2.0"
     doc: |
       If this map has a MapStore, this method flushes all the local dirty entries by calling MapStore.storeAll()
       and/or MapStore.deleteAll().
@@ -373,13 +373,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
     response: {}
   - id: 11
     name: tryRemove
-    since: 2.0
+    since: "2.0"
     doc: |
       Tries to remove the entry with the given key from this map within the specified timeout value.
       If the key is already locked by another thread and/or member, then this operation will wait the timeout
@@ -391,25 +391,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key for the map entry.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: timeout
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             maximum time in milliseconds to wait for acquiring the lock for the key.
     response:
@@ -417,12 +417,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Returns true if successful, otherwise returns false
   - id: 12
     name: tryPut
-    since: 2.0
+    since: "2.0"
     doc: |
       Tries to put the given key and value into this map within a specified timeout value. If this method returns false,
       it means that the caller thread could not acquire the lock for the key within the timeout duration,
@@ -434,31 +434,31 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key for the map entry.
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             New value for the map entry.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: timeout
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             maximum time in milliseconds to wait for acquiring the lock for the key.
     response:
@@ -466,12 +466,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Returns true if successful, otherwise returns false
   - id: 13
     name: putTransient
-    since: 2.0
+    since: "2.0"
     doc: |
       Same as put except that MapStore, if defined, will not be called to store/persist the entry.
       If ttl is 0, then the entry lives forever.
@@ -482,37 +482,37 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key for the map entry.
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             New value for the map entry.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: ttl
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The duration in milliseconds after which this entry shall be deleted. O means infinite.
     response: {}
   - id: 14
     name: putIfAbsent
-    since: 2.0
+    since: "2.0"
     doc: |
       Puts an entry into this map with a given ttl (time to live) value if the specified key is not already associated
       with a value. Entry will expire and get evicted after the ttl.
@@ -523,31 +523,31 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key for the map entry.
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             New value for the map entry.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: ttl
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The duration in milliseconds after which this entry shall be deleted. O means infinite.
     response:
@@ -555,12 +555,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             returns a clone of the previous value, not the original (identically equal) value previously put into the map.
   - id: 15
     name: set
-    since: 2.0
+    since: "2.0"
     doc: |
       Puts an entry into this map with a given ttl (time to live) value.Entry will expire and get evicted after the ttl
       If ttl is 0, then the entry lives forever. Similar to the put operation except that set doesn't
@@ -572,37 +572,37 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key for the map entry.
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             New value for the map entry.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: ttl
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The duration in milliseconds after which this entry shall be deleted. O means infinite.
     response: {}
   - id: 16
     name: lock
-    since: 2.0
+    since: "2.0"
     doc: |
       Acquires the lock for the specified lease time.After lease time, lock will be released.If the lock is not
       available then the current thread becomes disabled for thread scheduling purposes and lies dormant until the lock
@@ -616,37 +616,37 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key for the map entry.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: ttl
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The duration in milliseconds after which this entry shall be deleted. O means infinite.
         - name: referenceId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
     response: {}
   - id: 17
     name: tryLock
-    since: 2.0
+    since: "2.0"
     doc: |
       Tries to acquire the lock for the specified key for the specified lease time.After lease time, the lock will be
       released.If the lock is not available, then the current thread becomes disabled for thread scheduling
@@ -659,37 +659,37 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key for the map entry.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: lease
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             time in milliseconds to wait before releasing the lock.
         - name: timeout
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             maximum time to wait for getting the lock.
         - name: referenceId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
     response:
@@ -697,12 +697,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Returns true if successful, otherwise returns false
   - id: 18
     name: isLocked
-    since: 2.0
+    since: "2.0"
     doc: |
       Checks the lock for the specified key.If the lock is acquired then returns true, else returns false.
     request:
@@ -712,13 +712,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key for the map entry to check if it is locked.
     response:
@@ -726,12 +726,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Returns true if the entry is locked, otherwise returns false
   - id: 19
     name: unlock
-    since: 2.0
+    since: "2.0"
     doc: |
       Releases the lock for the specified key. It never blocks and returns immediately.
       If the current thread is the holder of this lock, then the hold count is decremented.If the hold count is zero,
@@ -744,31 +744,31 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key for the map entry to unlock
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: referenceId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
     response: {}
   - id: 20
     name: addInterceptor
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds an interceptor for this map. Added interceptor will intercept operations
       and execute user defined methods and will cancel operations if user defined method throw exception.
@@ -779,13 +779,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: interceptor
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             interceptor to add
     response:
@@ -793,12 +793,12 @@ methods:
         - name: response
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             id of registered interceptor.
   - id: 21
     name: removeInterceptor
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes the given interceptor for this map so it will not intercept operations anymore.
     request:
@@ -808,13 +808,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: id
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             of interceptor
     response:
@@ -822,12 +822,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Returns true if successful, otherwise returns false
   - id: 22
     name: addEntryListenerToKeyWithPredicate
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a MapListener for this map. To receive an event, you should implement a corresponding MapListener
       sub-interface for that event.
@@ -838,38 +838,38 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key for the map entry.
         - name: predicate
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             predicate for filtering entries.
         - name: includeValue
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if EntryEvent should
             contain the value.
         - name: listenerFlags
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             flags of enabled listeners.
         - name: localOnly
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
@@ -877,41 +877,41 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             A unique string which is used as a key to remove the listener.
     events:
       - name: Entry
-        since: 2.0
+        since: "2.0"
         params:
           - name: key
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Key of the entry event.
           - name: value
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Value of the entry event.
           - name: oldValue
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Old value of the entry event.
           - name: mergingValue
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Incoming merging value of the entry event.
           - name: eventType
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Type of the entry event. Possible values are
               ADDED(1)
@@ -927,18 +927,18 @@ methods:
           - name: uuid
             type: UUID
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               UUID of the member that dispatches the event.
           - name: numberOfAffectedEntries
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Number of entries affected by this event.
   - id: 23
     name: addEntryListenerWithPredicate
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds an continuous entry listener for this map. Listener will get notified for map add/remove/update/evict events
       filtered by the given predicate.
@@ -949,32 +949,32 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: predicate
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             predicate for filtering entries.
         - name: includeValue
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if EntryEvent should
             contain the value.
         - name: listenerFlags
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             flags of enabled listeners.
         - name: localOnly
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
@@ -982,41 +982,41 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             A unique string which is used as a key to remove the listener.
     events:
       - name: Entry
-        since: 2.0
+        since: "2.0"
         params:
           - name: key
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Key of the entry event.
           - name: value
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Value of the entry event.
           - name: oldValue
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Old value of the entry event.
           - name: mergingValue
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Incoming merging value of the entry event.
           - name: eventType
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Type of the entry event. Possible values are
               ADDED(1)
@@ -1032,18 +1032,18 @@ methods:
           - name: uuid
             type: UUID
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               UUID of the member that dispatches the event.
           - name: numberOfAffectedEntries
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Number of entries affected by this event.
   - id: 24
     name: addEntryListenerToKey
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a MapListener for this map. To receive an event, you should implement a corresponding MapListener
       sub-interface for that event.
@@ -1054,31 +1054,31 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key for the map entry.
         - name: includeValue
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if EntryEvent should contain the value.
         - name: listenerFlags
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             flags of enabled listeners.
         - name: localOnly
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
@@ -1086,41 +1086,41 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             A unique string which is used as a key to remove the listener.
     events:
       - name: Entry
-        since: 2.0
+        since: "2.0"
         params:
           - name: key
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Key of the entry event.
           - name: value
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Value of the entry event.
           - name: oldValue
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Old value of the entry event.
           - name: mergingValue
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Incoming merging value of the entry event.
           - name: eventType
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Type of the entry event. Possible values are
               ADDED(1)
@@ -1136,18 +1136,18 @@ methods:
           - name: uuid
             type: UUID
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               UUID of the member that dispatches the event.
           - name: numberOfAffectedEntries
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Number of entries affected by this event.
   - id: 25
     name: addEntryListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a MapListener for this map. To receive an event, you should implement a corresponding MapListener
       sub-interface for that event.
@@ -1158,25 +1158,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: includeValue
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if EntryEvent should contain the value.
         - name: listenerFlags
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             flags of enabled listeners.
         - name: localOnly
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
@@ -1184,41 +1184,41 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             A unique string which is used as a key to remove the listener.
     events:
       - name: Entry
-        since: 2.0
+        since: "2.0"
         params:
           - name: key
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Key of the entry event.
           - name: value
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Value of the entry event.
           - name: oldValue
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Old value of the entry event.
           - name: mergingValue
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Incoming merging value of the entry event.
           - name: eventType
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Type of the entry event. Possible values are
               ADDED(1)
@@ -1234,18 +1234,18 @@ methods:
           - name: uuid
             type: UUID
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               UUID of the member that dispatches the event.
           - name: numberOfAffectedEntries
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Number of entries affected by this event.
   - id: 26
     name: removeEntryListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes the specified entry listener. If there is no such listener added before, this call does no change in the
       cluster and returns false.
@@ -1256,13 +1256,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: registrationId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             id of registered listener.
     response:
@@ -1270,12 +1270,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if registration is removed, false otherwise.
   - id: 27
     name: addPartitionLostListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a MapPartitionLostListener. The addPartitionLostListener returns a register-id. This id is needed to remove
       the MapPartitionLostListener using the removePartitionLostListener(String) method.
@@ -1290,13 +1290,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: localOnly
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
@@ -1304,28 +1304,28 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             returns the registration id for the MapPartitionLostListener.
     events:
       - name: MapPartitionLost
-        since: 2.0
+        since: "2.0"
         params:
           - name: partitionId
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Id of the lost partition.
           - name: uuid
             type: UUID
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               UUID of the member that owns the lost partition.
   - id: 28
     name: removePartitionLostListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes the specified map partition lost listener. If there is no such listener added before, this call does no
       change in the cluster and returns false.
@@ -1336,13 +1336,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: registrationId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             id of register
     response:
@@ -1350,12 +1350,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if registration is removed, false otherwise.
   - id: 29
     name: getEntryView
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the EntryView for the specified key.
       This method returns a clone of original mapping, modifying the returned value does not change the actual value
@@ -1367,19 +1367,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the key of the entry.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
@@ -1387,18 +1387,18 @@ methods:
         - name: response
           type: SimpleEntryView
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Entry view of the specified key.
         - name: maxIdle
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Last set max idle in millis.
   - id: 30
     name: evict
-    since: 2.0
+    since: "2.0"
     doc: |
       Evicts the specified key from this map. If a MapStore is defined for this map, then the entry is not deleted
       from the underlying MapStore, evict only removes the entry from the memory.
@@ -1409,19 +1409,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the specified key to evict from this map.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
@@ -1429,12 +1429,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if the key is evicted, false otherwise.
   - id: 31
     name: evictAll
-    since: 2.0
+    since: "2.0"
     doc: |
       Evicts all keys from this map except the locked ones. If a MapStore is defined for this map, deleteAll is not
       called by this method. If you do want to deleteAll to be called use the clear method. The EVICT_ALL event is
@@ -1446,13 +1446,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
     response: {}
   - id: 32
     name: loadAll
-    since: 2.0
+    since: "2.0"
     doc: |
       Loads all keys into the store. This is a batch load operation so that an implementation can optimize the multiple loads.
     request:
@@ -1462,20 +1462,20 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: replaceExistingValues
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             when <code>true</code>, existing values in the Map will
             be replaced by those loaded from the MapLoader
     response: {}
   - id: 33
     name: loadGivenKeys
-    since: 2.0
+    since: "2.0"
     doc: |
       Loads the given keys. This is a batch load operation so that an implementation can optimize the multiple loads.
     request:
@@ -1485,25 +1485,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: keys
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             keys to load
         - name: replaceExistingValues
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             when <code>true</code>, existing values in the Map will be replaced by those loaded from the MapLoader
     response: {}
   - id: 34
     name: keySet
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns a set clone of the keys contained in this map. The set is NOT backed by the map, so changes to the map
       are NOT reflected in the set, and vice-versa. This method is always executed by a distributed query, so it may
@@ -1515,7 +1515,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of the map
     response:
@@ -1523,12 +1523,12 @@ methods:
         - name: response
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             a set clone of the keys contained in this map.
   - id: 35
     name: getAll
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the entries for the given keys. If any keys are not present in the Map, it will call loadAll The returned
       map is NOT backed by the original map, so changes to the original map are NOT reflected in the returned map, and vice-versa.
@@ -1542,13 +1542,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: keys
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             keys to get
     response:
@@ -1556,12 +1556,12 @@ methods:
         - name: response
           type: EntryList_Data_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             values for the provided keys.
   - id: 36
     name: values
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns a collection clone of the values contained in this map.
       The collection is NOT backed by the map, so changes to the map are NOT reflected in the collection, and vice-versa.
@@ -1574,7 +1574,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
     response:
@@ -1582,12 +1582,12 @@ methods:
         - name: response
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             All values in the map
   - id: 37
     name: entrySet
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns a Set clone of the mappings contained in this map.
       The collection is NOT backed by the map, so changes to the map are NOT reflected in the collection, and vice-versa.
@@ -1600,7 +1600,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
     response:
@@ -1608,12 +1608,12 @@ methods:
         - name: response
           type: EntryList_Data_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             a set clone of the keys mappings in this map
   - id: 38
     name: keySetWithPredicate
-    since: 2.0
+    since: "2.0"
     doc: |
       Queries the map based on the specified predicate and returns the keys of matching entries. Specified predicate
       runs on all members in parallel.The set is NOT backed by the map, so changes to the map are NOT reflected in the
@@ -1626,13 +1626,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map.
         - name: predicate
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             specified query criteria.
     response:
@@ -1640,12 +1640,12 @@ methods:
         - name: response
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             result key set for the query.
   - id: 39
     name: valuesWithPredicate
-    since: 2.0
+    since: "2.0"
     doc: |
       Queries the map based on the specified predicate and returns the values of matching entries.Specified predicate
       runs on all members in parallel. The collection is NOT backed by the map, so changes to the map are NOT reflected
@@ -1658,13 +1658,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: predicate
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             specified query criteria.
     response:
@@ -1672,12 +1672,12 @@ methods:
         - name: response
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             result value collection of the query.
   - id: 40
     name: entriesWithPredicate
-    since: 2.0
+    since: "2.0"
     doc: |
       Queries the map based on the specified predicate and returns the matching entries.Specified predicate
       runs on all members in parallel. The collection is NOT backed by the map, so changes to the map are NOT reflected
@@ -1690,13 +1690,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: predicate
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             specified query criteria.
     response:
@@ -1704,12 +1704,12 @@ methods:
         - name: response
           type: EntryList_Data_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             result key-value entry collection of the query.
   - id: 41
     name: addIndex
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds an index to this map with specified configuration.
     request:
@@ -1719,19 +1719,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of map.
         - name: indexConfig
           type: IndexConfig
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Index configuration.
     response: {}
   - id: 42
     name: size
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the number of key-value mappings in this map.  If the map contains more than Integer.MAX_VALUE elements,
       returns Integer.MAX_VALUE
@@ -1742,7 +1742,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             of map
     response:
@@ -1750,12 +1750,12 @@ methods:
         - name: response
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the number of key-value mappings in this map
   - id: 43
     name: isEmpty
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns true if this map contains no key-value mappings.
     request:
@@ -1765,7 +1765,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
     response:
@@ -1773,12 +1773,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if this map contains no key-value mappings
   - id: 44
     name: putAll
-    since: 2.0
+    since: "2.0"
     doc: |
       Copies all of the mappings from the specified map to this map (optional operation).The effect of this call is
       equivalent to that of calling put(Object,Object) put(k, v) on this map once for each mapping from key k to value
@@ -1794,25 +1794,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: entries
           type: EntryList_Data_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             mappings to be stored in this map
         - name: triggerMapLoader
           type: boolean
           nullable: false
-          since: 2.1
+          since: "2.1"
           doc: |
             should trigger MapLoader for elements not in this map
     response: {}
   - id: 45
     name: clear
-    since: 2.0
+    since: "2.0"
     doc: |
       This method clears the map and invokes MapStore#deleteAll deleteAll on MapStore which, if connected to a database,
       will delete the records from that database. The MAP_CLEARED event is fired for any registered listeners.
@@ -1824,13 +1824,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             of map
     response: {}
   - id: 46
     name: executeOnKey
-    since: 2.0
+    since: "2.0"
     doc: |
       Applies the user defined EntryProcessor to the entry mapped by the key. Returns the the object which is result of
       the process() method of EntryProcessor.
@@ -1841,25 +1841,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: entryProcessor
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             processor to execute on the map entry
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the key of the map entry.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Id of the thread that the task is submitted from.
     response:
@@ -1867,12 +1867,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             result of entry process.
   - id: 47
     name: submitToKey
-    since: 2.0
+    since: "2.0"
     doc: |
       Applies the user defined EntryProcessor to the entry mapped by the key. Returns immediately with a Future
       representing that task.EntryProcessor is not cancellable, so calling Future.cancel() method won't cancel the
@@ -1884,25 +1884,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: entryProcessor
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             entry processor to be executed on the entry.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the key of the map entry.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Id of the thread that the task is submitted from.
     response:
@@ -1910,12 +1910,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             result of entry process.
   - id: 48
     name: executeOnAllKeys
-    since: 2.0
+    since: "2.0"
     doc: |
       Applies the user defined EntryProcessor to the all entries in the map.Returns the results mapped by each key in the map.
     request:
@@ -1925,13 +1925,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: entryProcessor
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             entry processor to be executed.
     response:
@@ -1939,12 +1939,12 @@ methods:
         - name: response
           type: EntryList_Data_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             results of entry process on the entries
   - id: 49
     name: executeWithPredicate
-    since: 2.0
+    since: "2.0"
     doc: |
       Applies the user defined EntryProcessor to the entries in the map which satisfies provided predicate.
       Returns the results mapped by each key in the map.
@@ -1955,19 +1955,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: entryProcessor
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             entry processor to be executed.
         - name: predicate
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             specified query criteria.
     response:
@@ -1975,12 +1975,12 @@ methods:
         - name: response
           type: EntryList_Data_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             results of entry process on the entries matching the query criteria
   - id: 50
     name: executeOnKeys
-    since: 2.0
+    since: "2.0"
     doc: |
       Applies the user defined EntryProcessor to the entries mapped by the collection of keys.The results mapped by
       each key in the collection.
@@ -1991,19 +1991,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: entryProcessor
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             entry processor to be executed.
         - name: keys
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The keys for the entries for which the entry processor shall be executed on.
     response:
@@ -2011,12 +2011,12 @@ methods:
         - name: response
           type: EntryList_Data_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             results of entry process on the entries with the provided keys
   - id: 51
     name: forceUnlock
-    since: 2.0
+    since: "2.0"
     doc: |
       Releases the lock for the specified key regardless of the lock owner.It always successfully unlocks the key,
       never blocks,and returns immediately.
@@ -2027,25 +2027,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the key of the map entry.
         - name: referenceId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
     response: {}
   - id: 52
     name: keySetWithPagingPredicate
-    since: 2.0
+    since: "2.0"
     doc: |
       Queries the map based on the specified predicate and returns the keys of matching entries. Specified predicate
       runs on all members in parallel. The collection is NOT backed by the map, so changes to the map are NOT reflected
@@ -2058,13 +2058,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: predicate
           type: PagingPredicateHolder
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             specified query criteria.
     response:
@@ -2072,18 +2072,18 @@ methods:
         - name: response
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             result keys for the query.
         - name: anchorDataList
           type: AnchorDataListHolder
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The updated anchor list.
   - id: 53
     name: valuesWithPagingPredicate
-    since: 2.0
+    since: "2.0"
     doc: |
       Queries the map based on the specified predicate and returns the values of matching entries. Specified predicate
       runs on all members in parallel. The collection is NOT backed by the map, so changes to the map are NOT reflected
@@ -2096,13 +2096,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: predicate
           type: PagingPredicateHolder
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             specified query criteria.
     response:
@@ -2110,18 +2110,18 @@ methods:
         - name: response
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             values for the query.
         - name: anchorDataList
           type: AnchorDataListHolder
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The updated anchor list.
   - id: 54
     name: entriesWithPagingPredicate
-    since: 2.0
+    since: "2.0"
     doc: |
       Queries the map based on the specified predicate and returns the matching entries. Specified predicate
       runs on all members in parallel. The collection is NOT backed by the map, so changes to the map are NOT reflected
@@ -2134,13 +2134,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of map
         - name: predicate
           type: PagingPredicateHolder
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             specified query criteria.
     response:
@@ -2148,18 +2148,18 @@ methods:
         - name: response
           type: EntryList_Data_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             key-value pairs for the query.
         - name: anchorDataList
           type: AnchorDataListHolder
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The updated anchor list.
   - id: 55
     name: fetchKeys
-    since: 2.0
+    since: "2.0"
     doc: |
       Fetches specified number of keys from the specified partition starting from specified table index.
     request:
@@ -2169,19 +2169,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: iterationPointers
           type: EntryList_Integer_Integer
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The index-size pairs that define the state of iteration
         - name: batch
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The number of items to be batched
     response:
@@ -2189,18 +2189,18 @@ methods:
         - name: iterationPointers
           type: EntryList_Integer_Integer
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The index-size pairs that define the state of iteration
         - name: keys
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             List of keys.
   - id: 56
     name: fetchEntries
-    since: 2.0
+    since: "2.0"
     doc: |
       Fetches specified number of entries from the specified partition starting from specified table index.
     request:
@@ -2210,19 +2210,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: iterationPointers
           type: EntryList_Integer_Integer
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The index-size pairs that define the state of iteration
         - name: batch
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The number of items to be batched
     response:
@@ -2230,18 +2230,18 @@ methods:
         - name: iterationPointers
           type: EntryList_Integer_Integer
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The index-size pairs that define the state of iteration
         - name: entries
           type: EntryList_Data_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             List of entries.
   - id: 57
     name: aggregate
-    since: 2.0
+    since: "2.0"
     doc: |
       Applies the aggregation logic on all map entries and returns the result
     request:
@@ -2251,13 +2251,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: aggregator
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             aggregator to aggregate the entries with
     response:
@@ -2265,12 +2265,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             the aggregation result
   - id: 58
     name: aggregateWithPredicate
-    since: 2.0
+    since: "2.0"
     doc: |
       Applies the aggregation logic on map entries filtered with the Predicate and returns the result
     request:
@@ -2280,19 +2280,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: aggregator
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             aggregator to aggregate the entries with
         - name: predicate
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             predicate to filter the entries with
     response:
@@ -2300,12 +2300,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             the aggregation result
   - id: 59
     name: project
-    since: 2.0
+    since: "2.0"
     doc: |
       Applies the projection logic on all map entries and returns the result
     request:
@@ -2315,13 +2315,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: projection
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             projection to transform the entries with. May return null.
     response:
@@ -2329,12 +2329,12 @@ methods:
         - name: response
           type: ListCN_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the resulted collection upon transformation to the type of the projection
   - id: 60
     name: projectWithPredicate
-    since: 2.0
+    since: "2.0"
     doc: |
       Applies the projection logic on map entries filtered with the Predicate and returns the result
     request:
@@ -2344,19 +2344,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: projection
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             projection to transform the entries with. May return null.
         - name: predicate
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             predicate to filter the entries with
     response:
@@ -2364,12 +2364,12 @@ methods:
         - name: response
           type: ListCN_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the resulted collection upon transformation to the type of the projection
   - id: 61
     name: fetchNearCacheInvalidationMetadata
-    since: 2.0
+    since: "2.0"
     doc: |
       Fetches invalidation metadata from partitions of map.
     request:
@@ -2379,13 +2379,13 @@ methods:
         - name: names
           type: List_String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             names of the maps
         - name: uuid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The uuid of the member to fetch the near cache invalidation meta data
     response:
@@ -2393,18 +2393,18 @@ methods:
         - name: namePartitionSequenceList
           type: EntryList_String_EntryList_Integer_Long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Map of partition ids and sequence number of invalidations mapped by the map name.
         - name: partitionUuidList
           type: EntryList_Integer_UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Map of member UUIDs mapped by the partition ids of invalidations.
   - id: 62
     name: removeAll
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes all entries which match with the supplied predicate
     request:
@@ -2414,19 +2414,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             map name.
         - name: predicate
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             used to select entries to be removed from map.
     response: {}
   - id: 63
     name: addNearCacheInvalidationListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds listener to map. This listener will be used to listen near cache invalidation events.
     request:
@@ -2436,19 +2436,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of the map
         - name: listenerFlags
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             flags of enabled listeners.
         - name: localOnly
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
@@ -2456,67 +2456,67 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             A unique string which is used as a key to remove the listener.
     events:
       - name: IMapInvalidation
-        since: 2.0
+        since: "2.0"
         params:
           - name: key
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               The key of the invalidated entry.
           - name: sourceUuid
             type: UUID
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               UUID of the member who fired this event.
           - name: partitionUuid
             type: UUID
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               UUID of the source partition that invalidated entry belongs to.
           - name: sequence
             type: long
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Sequence number of the invalidation event.
       - name: IMapBatchInvalidation
-        since: 2.0
+        since: "2.0"
         params:
           - name: keys
             type: List_Data
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               List of the keys of the invalidated entries.
           - name: sourceUuids
             type: List_UUID
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               List of UUIDs of the members who fired these events.
           - name: partitionUuids
             type: List_UUID
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               List of UUIDs of the source partitions that invalidated entries belong to.
           - name: sequences
             type: List_Long
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               List of sequence numbers of the invalidation events.
   - id: 64
     name: fetchWithQuery
-    since: 2.0
+    since: "2.0"
     doc: |
       Fetches the specified number of entries from the specified partition starting from specified table index
       that match the predicate and applies the projection logic on them.
@@ -2527,31 +2527,31 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map
         - name: iterationPointers
           type: EntryList_Integer_Integer
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The index-size pairs that define the state of iteration
         - name: batch
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The number of items to be batched
         - name: projection
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             projection to transform the entries with
         - name: predicate
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             predicate to filter the entries with
     response:
@@ -2559,18 +2559,18 @@ methods:
         - name: results
           type: ListCN_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             List of fetched entries.
         - name: iterationPointers
           type: EntryList_Integer_Integer
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The index-size pairs that define the state of iteration
   - id: 65
     name: eventJournalSubscribe
-    since: 2.0
+    since: "2.0"
     doc: |
       Performs the initial subscription to the map event journal.
       This includes retrieving the event journal sequences of the
@@ -2582,7 +2582,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of the map
     response:
@@ -2590,18 +2590,18 @@ methods:
         - name: oldestSequence
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Sequence id of the oldest event in the event journal.
         - name: newestSequence
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Sequence id of the newest event in the event journal.
   - id: 66
     name: eventJournalRead
-    since: 2.0
+    since: "2.0"
     doc: |
       Reads from the map event journal in batches. You may specify the start sequence,
       the minimum required number of items in the response, the maximum number of items
@@ -2618,37 +2618,37 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             name of the map
         - name: startSequence
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the startSequence of the first item to read
         - name: minSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the minimum number of items to read.
         - name: maxSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the maximum number of items to read.
         - name: predicate
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             the predicate to apply before processing events
         - name: projection
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             the projection to apply to journal events
     response:
@@ -2656,30 +2656,30 @@ methods:
         - name: readCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Number of items that have been read.
         - name: items
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             List of items that have been read.
         - name: itemSeqs
           type: longArray
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Sequence numbers of items in the event journal.
         - name: nextSeq
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Sequence number of the item following the last read item.
   - id: 67
     name: setTtl
-    since: 2.0
+    since: "2.0"
     doc: |
       Updates TTL (time to live) value of the entry specified by {@code key} with a new TTL value.
       New TTL value is valid from this operation is invoked, not from the original creation of the entry.
@@ -2701,19 +2701,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key for the map entry
         - name: ttl
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The duration in milliseconds after which this entry shall be deleted. O means infinite.
     response:
@@ -2721,12 +2721,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             'true' if the entry is affected, 'false' otherwise
   - id: 68
     name: putWithMaxIdle
-    since: 2.0
+    since: "2.0"
     doc: |
       Puts an entry into this map with a given ttl (time to live) value.Entry will expire and get evicted after the ttl
       If ttl is 0, then the entry lives forever.This method returns a clone of the previous value, not the original
@@ -2739,37 +2739,37 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key for the map entry.
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Value for the map entry.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: ttl
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The duration in milliseconds after which this entry shall be deleted. O means infinite.
         - name: maxIdle
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The duration of maximum idle for this entry.
             Milliseconds of idle, after which this entry shall be deleted. O means infinite.
@@ -2778,12 +2778,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             old value of the entry
   - id: 69
     name: putTransientWithMaxIdle
-    since: 2.0
+    since: "2.0"
     doc: |
       Same as put except that MapStore, if defined, will not be called to store/persist the entry.
       If ttl and maxIdle are 0, then the entry lives forever.
@@ -2794,37 +2794,37 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key for the map entry.
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Value for the map entry.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: ttl
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The duration in milliseconds after which this entry shall be deleted. O means infinite.
         - name: maxIdle
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The duration of maximum idle for this entry.
             Milliseconds of idle, after which this entry shall be deleted. O means infinite.
@@ -2833,12 +2833,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             old value of the entry
   - id: 70
     name: putIfAbsentWithMaxIdle
-    since: 2.0
+    since: "2.0"
     doc: |
       Puts an entry into this map with a given ttl (time to live) value if the specified key is not already associated
       with a value. Entry will expire and get evicted after the ttl or maxIdle, whichever comes first.
@@ -2849,37 +2849,37 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key for the map entry.
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Value for the map entry.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: ttl
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The duration in milliseconds after which this entry shall be deleted. O means infinite.
         - name: maxIdle
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The duration of maximum idle for this entry.
             Milliseconds of idle, after which this entry shall be deleted. O means infinite.
@@ -2888,12 +2888,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             old value of the entry
   - id: 71
     name: setWithMaxIdle
-    since: 2.0
+    since: "2.0"
     doc: |
       Puts an entry into this map with a given ttl (time to live) value and maxIdle.
       Entry will expire and get evicted after the ttl or maxIdle, whichever comes first.
@@ -2907,37 +2907,37 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the map.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key for the map entry.
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Value for the map entry.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: ttl
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The duration in milliseconds after which this entry shall be deleted. O means infinite.
         - name: maxIdle
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The duration of maximum idle for this entry.
             Milliseconds of idle, after which this entry shall be deleted. O means infinite.
@@ -2946,12 +2946,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             old value of the entry
   - id: 72
     name: replaceAll
-    since: 2.4
+    since: "2.4"
     doc: |
       Replaces each entry's value with the result of invoking the given
       function on that entry until all entries have been processed in the targetted partition
@@ -2963,19 +2963,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.4
+          since: "2.4"
           doc: |
             name of map
         - name: function
           type: Data
           nullable: false
-          since: 2.4
+          since: "2.4"
           doc: |
             the function to apply to each entry.
     response: {}
   - id: 73
     name: putAllWithMetadata
-    since: 2.7
+    since: "2.7"
     doc: |
       Copies all of the mappings from the specified entry list to this map, including metadata.
       The implementation uses MergeOperation with PassThroughMergePolicy, so the effect of 
@@ -2990,13 +2990,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             name of map
         - name: entries
           type: List_SimpleEntryView
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             entries with metadata
     response: {}

--- a/protocol-definitions/MultiMap.yaml
+++ b/protocol-definitions/MultiMap.yaml
@@ -3,7 +3,7 @@ name: MultiMap
 methods:
   - id: 1
     name: put
-    since: 2.0
+    since: "2.0"
     doc: |
       Stores a key-value pair in the multimap.
     request:
@@ -13,25 +13,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the MultiMap
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The key to be stored
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The value to be stored
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
@@ -39,12 +39,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if size of the multimap is increased, false if the multimap already contains the key-value pair.
   - id: 2
     name: get
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the collection of values associated with the key. The collection is NOT backed by the map, so changes to
       the map are NOT reflected in the collection, and vice-versa.
@@ -55,19 +55,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the MultiMap
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The key whose associated values are to be returned
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
@@ -75,12 +75,12 @@ methods:
         - name: response
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The collection of the values associated with the key.
   - id: 3
     name: remove
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes the given key value pair from the multimap.
     request:
@@ -90,19 +90,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the MultiMap
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The key of the entry to remove
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
@@ -110,12 +110,12 @@ methods:
         - name: response
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if the size of the multimap changed after the remove operation, false otherwise.
   - id: 4
     name: keySet
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the set of keys in the multimap.The collection is NOT backed by the map, so changes to the map are NOT
       reflected in the collection, and vice-versa.
@@ -126,7 +126,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the MultiMap
     response:
@@ -134,12 +134,12 @@ methods:
         - name: response
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The set of keys in the multimap. The returned set might be modifiable but it has no effect on the multimap.
   - id: 5
     name: values
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the collection of values in the multimap.The collection is NOT backed by the map, so changes to the map
       are NOT reflected in the collection, and vice-versa.
@@ -150,7 +150,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the MultiMap
     response:
@@ -158,12 +158,12 @@ methods:
         - name: response
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The collection of values in the multimap. the returned collection might be modifiable but it has no effect on the multimap.
   - id: 6
     name: entrySet
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the set of key-value pairs in the multimap.The collection is NOT backed by the map, so changes to the map
       are NOT reflected in the collection, and vice-versa
@@ -174,7 +174,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the MultiMap
     response:
@@ -182,12 +182,12 @@ methods:
         - name: response
           type: EntryList_Data_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The set of key-value pairs in the multimap. The returned set might be modifiable but it has no effect on the multimap.
   - id: 7
     name: containsKey
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns whether the multimap contains an entry with the key.
     request:
@@ -197,19 +197,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the MultiMap
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The key whose existence is checked.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
@@ -217,12 +217,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if the multimap contains an entry with the key, false otherwise.
   - id: 8
     name: containsValue
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns whether the multimap contains an entry with the value.
     request:
@@ -232,13 +232,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the MultiMap
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The value whose existence is checked.
     response:
@@ -246,12 +246,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if the multimap contains an entry with the value, false otherwise.
   - id: 9
     name: containsEntry
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns whether the multimap contains the given key-value pair.
     request:
@@ -261,25 +261,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the MultiMap
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The key whose existence is checked.
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The value whose existence is checked.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation
     response:
@@ -287,12 +287,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if the multimap contains the key-value pair, false otherwise.
   - id: 10
     name: size
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the number of key-value pairs in the multimap.
     request:
@@ -302,7 +302,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the MultiMap
     response:
@@ -310,12 +310,12 @@ methods:
         - name: response
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The number of key-value pairs in the multimap.
   - id: 11
     name: clear
-    since: 2.0
+    since: "2.0"
     doc: |
       Clears the multimap. Removes all key-value pairs.
     request:
@@ -325,13 +325,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the MultiMap
     response: {}
   - id: 12
     name: valueCount
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the number of values that match the given key in the multimap.
     request:
@@ -341,19 +341,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the MultiMap
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The key whose values count is to be returned
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation
     response:
@@ -361,12 +361,12 @@ methods:
         - name: response
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The number of values that match the given key in the multimap
   - id: 13
     name: addEntryListenerToKey
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds the specified entry listener for the specified key.The listener will be notified for all
       add/remove/update/evict events for the specified key only.
@@ -377,25 +377,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the MultiMap
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The key to listen to
         - name: includeValue
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if EntryEvent should contain the value,false otherwise
         - name: localOnly
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
@@ -403,41 +403,41 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Returns registration id for the entry listener
     events:
       - name: Entry
-        since: 2.0
+        since: "2.0"
         params:
           - name: key
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Key of the entry event.
           - name: value
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Value of the entry event.
           - name: oldValue
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Old value of the entry event.
           - name: mergingValue
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Incoming merging value of the entry event.
           - name: eventType
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Type of the entry event. Possible values are
               ADDED(1)
@@ -453,18 +453,18 @@ methods:
           - name: uuid
             type: UUID
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               UUID of the member that dispatches the event.
           - name: numberOfAffectedEntries
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Number of entries affected by this event.
   - id: 14
     name: addEntryListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds an entry listener for this multimap. The listener will be notified for all multimap add/remove/update/evict events.
     request:
@@ -474,19 +474,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the MultiMap
         - name: includeValue
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if EntryEvent should contain the value,false otherwise
         - name: localOnly
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
@@ -494,41 +494,41 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Returns registration id for the entry listener
     events:
       - name: Entry
-        since: 2.0
+        since: "2.0"
         params:
           - name: key
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Key of the entry event.
           - name: value
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Value of the entry event.
           - name: oldValue
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Old value of the entry event.
           - name: mergingValue
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Incoming merging value of the entry event.
           - name: eventType
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Type of the entry event. Possible values are
               ADDED(1)
@@ -544,18 +544,18 @@ methods:
           - name: uuid
             type: UUID
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               UUID of the member that dispatches the event.
           - name: numberOfAffectedEntries
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Number of entries affected by this event.
   - id: 15
     name: removeEntryListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes the specified entry listener. If there is no such listener added before, this call does no change in the
       cluster and returns false.
@@ -566,13 +566,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the MultiMap
         - name: registrationId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Registration id of listener
     response:
@@ -580,12 +580,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if registration is removed, false otherwise
   - id: 16
     name: lock
-    since: 2.0
+    since: "2.0"
     doc: |
       Acquires the lock for the specified key for the specified lease time. After the lease time, the lock will be
       released. If the lock is not available, then the current thread becomes disabled for thread scheduling
@@ -599,37 +599,37 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the MultiMap
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The key the Lock
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation
         - name: ttl
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The duration in milliseconds after which this entry shall be deleted. O means infinite.
         - name: referenceId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
     response: {}
   - id: 17
     name: tryLock
-    since: 2.0
+    since: "2.0"
     doc: |
       Tries to acquire the lock for the specified key for the specified lease time. After lease time, the lock will be
       released. If the lock is not available, then the current thread becomes disabled for thread scheduling purposes
@@ -642,37 +642,37 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the MultiMap
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key to lock in this map.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation
         - name: lease
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Time in milliseconds to wait before releasing the lock.
         - name: timeout
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Maximum time to wait for the lock.
         - name: referenceId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
     response:
@@ -680,12 +680,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if the lock was acquired and false if the waiting time elapsed before the lock acquired
   - id: 18
     name: isLocked
-    since: 2.0
+    since: "2.0"
     doc: |
       Checks the lock for the specified key. If the lock is acquired, this method returns true, else it returns false.
     request:
@@ -695,13 +695,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the MultiMap
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key to lock to be checked.
     response:
@@ -709,12 +709,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if the lock acquired,false otherwise
   - id: 19
     name: unlock
-    since: 2.0
+    since: "2.0"
     doc: |
       Releases the lock for the specified key regardless of the lock owner. It always successfully unlocks the key,
       never blocks and returns immediately.
@@ -725,31 +725,31 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the MultiMap
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The key to Lock
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation
         - name: referenceId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
     response: {}
   - id: 20
     name: forceUnlock
-    since: 2.0
+    since: "2.0"
     doc: |
       Releases the lock for the specified key regardless of the lock owner. It always successfully unlocks the key,
       never blocks and returns immediately.
@@ -760,25 +760,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the MultiMap
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The key to Lock
         - name: referenceId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The client-wide unique id for this request. It is used to make the request idempotent by sending the same reference id during retries.
     response: {}
   - id: 21
     name: removeEntry
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes all the entries with the given key. The collection is NOT backed by the map, so changes to the map are
       NOT reflected in the collection, and vice-versa.
@@ -789,25 +789,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the MultiMap
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The key of the entry to remove
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The value of the entry to remove
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation
     response:
@@ -815,12 +815,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if the size of the multimap changed after the remove operation, false otherwise.
   - id: 22
     name: delete
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes all the entries with the given key.
     request:
@@ -830,25 +830,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the MultiMap
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The key of the entry to remove
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation
     response: {}
   - id: 23
     name: putAll
-    since: 2.1
+    since: "2.1"
     doc: |
       Copies all of the mappings from the specified map to this MultiMap. The effect of this call is
       equivalent to that of calling put(k, v) on this MultiMap iteratively for each value in the mapping from key k to value
@@ -861,13 +861,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.1
+          since: "2.1"
           doc: |
             name of map
         - name: entries
           type: EntryList_Data_List_Data
           nullable: false
-          since: 2.1
+          since: "2.1"
           doc: |
             mappings to be stored in this map
     response: {}

--- a/protocol-definitions/PNCounter.yaml
+++ b/protocol-definitions/PNCounter.yaml
@@ -3,7 +3,7 @@ name: PNCounter
 methods:
   - id: 1
     name: get
-    since: 2.0
+    since: "2.0"
     doc: |
       Query operation to retrieve the current value of the PNCounter.
       <p>
@@ -20,19 +20,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the name of the PNCounter
         - name: replicaTimestamps
           type: EntryList_UUID_Long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             last observed replica timestamps (vector clock)
         - name: targetReplicaUUID
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the target replica
     response:
@@ -40,24 +40,24 @@ methods:
         - name: value
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Value of the counter.
         - name: replicaTimestamps
           type: EntryList_UUID_Long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             last observed replica timestamps (vector clock)
         - name: replicaCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Number of replicas that keep the state of this counter.
   - id: 2
     name: add
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a delta to the PNCounter value. The delta may be negative for a
       subtraction.
@@ -75,19 +75,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the name of the PNCounter
         - name: delta
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the delta to add to the counter value, can be negative
         - name: getBeforeUpdate
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             {@code true} if the operation should return the
             counter value before the addition, {@code false}
@@ -95,13 +95,13 @@ methods:
         - name: replicaTimestamps
           type: EntryList_UUID_Long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             last observed replica timestamps (vector clock)
         - name: targetReplicaUUID
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the target replica
     response:
@@ -109,24 +109,24 @@ methods:
         - name: value
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Value of the counter.
         - name: replicaTimestamps
           type: EntryList_UUID_Long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             last observed replica timestamps (vector clock)
         - name: replicaCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Number of replicas that keep the state of this counter.
   - id: 3
     name: getConfiguredReplicaCount
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the configured number of CRDT replicas for the PN counter with
       the given {@code name}.
@@ -139,7 +139,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the name of the PNCounter
     response:
@@ -147,6 +147,6 @@ methods:
         - name: response
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the configured replica count

--- a/protocol-definitions/Queue.yaml
+++ b/protocol-definitions/Queue.yaml
@@ -3,7 +3,7 @@ name: Queue
 methods:
   - id: 1
     name: offer
-    since: 2.0
+    since: "2.0"
     doc: |
       Inserts the specified element into this queue, waiting up to the specified wait time if necessary for space to
       become available.
@@ -14,19 +14,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Queue
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The element to add
         - name: timeoutMillis
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Maximum time in milliseconds to wait for acquiring the lock for the key.
     response:
@@ -34,12 +34,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             <tt>True</tt> if the element was added to this queue, else <tt>false</tt>
   - id: 2
     name: put
-    since: 2.0
+    since: "2.0"
     doc: |
       Inserts the specified element into this queue, waiting if necessary for space to become available.
     request:
@@ -49,19 +49,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Queue
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The element to add
     response: {}
   - id: 3
     name: size
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the number of elements in this collection.  If this collection contains more than Integer.MAX_VALUE
       elements, returns Integer.MAX_VALUE
@@ -72,7 +72,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Queue
     response:
@@ -80,12 +80,12 @@ methods:
         - name: response
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The number of elements in this collection
   - id: 4
     name: remove
-    since: 2.0
+    since: "2.0"
     doc: |
       Retrieves and removes the head of this queue.  This method differs from poll only in that it throws an exception
       if this queue is empty.
@@ -96,13 +96,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Queue
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Element to be removed from this queue, if present
     response:
@@ -110,12 +110,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             <tt>true</tt> if this queue changed as a result of the call
   - id: 5
     name: poll
-    since: 2.0
+    since: "2.0"
     doc: |
       Retrieves and removes the head of this queue, waiting up to the specified wait time if necessary for an element
       to become available.
@@ -126,13 +126,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Queue
         - name: timeoutMillis
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Maximum time in milliseconds to wait for acquiring the lock for the key.
     response:
@@ -140,12 +140,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The head of this queue, or <tt>null</tt> if this queue is empty
   - id: 6
     name: take
-    since: 2.0
+    since: "2.0"
     doc: |
       Retrieves and removes the head of this queue, waiting if necessary until an element becomes available.
     request:
@@ -155,7 +155,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Queue
     response:
@@ -163,12 +163,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The head of this queue
   - id: 7
     name: peek
-    since: 2.0
+    since: "2.0"
     doc: |
       Retrieves, but does not remove, the head of this queue, or returns null if this queue is empty.
     request:
@@ -178,7 +178,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Queue
     response:
@@ -186,12 +186,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The head of this queue, or <tt>null</tt> if this queue is empty
   - id: 8
     name: iterator
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns an iterator over the elements in this collection.  There are no guarantees concerning the order in which
       the elements are returned (unless this collection is an instance of some class that provides a guarantee).
@@ -202,7 +202,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Queue
     response:
@@ -210,12 +210,12 @@ methods:
         - name: response
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             list of all data in queue
   - id: 9
     name: drainTo
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes all available elements from this queue and adds them to the given collection.  This operation may be more
       efficient than repeatedly polling this queue.  A failure encountered while attempting to add elements to
@@ -229,7 +229,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Queue
     response:
@@ -237,12 +237,12 @@ methods:
         - name: response
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             list of all removed data in queue
   - id: 10
     name: drainToMaxSize
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes at most the given number of available elements from this queue and adds them to the given collection.
       A failure encountered while attempting to add elements to collection may result in elements being in neither,
@@ -256,13 +256,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Queue
         - name: maxSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The maximum number of elements to transfer
     response:
@@ -270,12 +270,12 @@ methods:
         - name: response
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             list of all removed data in result of this method
   - id: 11
     name: contains
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns true if this queue contains the specified element. More formally, returns true if and only if this queue
       contains at least one element e such that value.equals(e)
@@ -286,13 +286,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Queue
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Element whose presence in this collection is to be tested
     response:
@@ -300,12 +300,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             <tt>true</tt> if this collection contains the specified element
   - id: 12
     name: containsAll
-    since: 2.0
+    since: "2.0"
     doc: |
       Return true if this collection contains all of the elements in the specified collection.
     request:
@@ -315,13 +315,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Queue
         - name: dataList
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Collection to be checked for containment in this collection
     response:
@@ -329,12 +329,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             <tt>true</tt> if this collection contains all of the elements in the specified collection
   - id: 13
     name: compareAndRemoveAll
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes all of this collection's elements that are also contained in the specified collection (optional operation).
       After this call returns, this collection will contain no elements in common with the specified collection.
@@ -345,13 +345,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Queue
         - name: dataList
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Collection containing elements to be removed from this collection
     response:
@@ -359,12 +359,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             <tt>true</tt> if this collection changed as a result of the call
   - id: 14
     name: compareAndRetainAll
-    since: 2.0
+    since: "2.0"
     doc: |
       Retains only the elements in this collection that are contained in the specified collection (optional operation).
       In other words, removes from this collection all of its elements that are not contained in the specified collection.
@@ -375,13 +375,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Queue
         - name: dataList
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             collection containing elements to be retained in this collection
     response:
@@ -389,12 +389,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             <tt>true</tt> if this collection changed as a result of the call
   - id: 15
     name: clear
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes all of the elements from this collection (optional operation). The collection will be empty after this
       method returns.
@@ -405,13 +405,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Queue
     response: {}
   - id: 16
     name: addAll
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds all of the elements in the specified collection to this collection (optional operation).The behavior of this
       operation is undefined if the specified collection is modified while the operation is in progress.
@@ -424,13 +424,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Queue
         - name: dataList
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Collection containing elements to be added to this collection
     response:
@@ -438,12 +438,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             <tt>true</tt> if this collection changed as a result of the call
   - id: 17
     name: addListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds an listener for this collection. Listener will be notified or all collection add/remove events.
     request:
@@ -453,19 +453,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Queue
         - name: includeValue
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             <tt>true</tt> if the updated item should be passed to the item listener, <tt>false</tt> otherwise.
         - name: localOnly
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
@@ -473,34 +473,34 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The registration id
     events:
       - name: Item
-        since: 2.0
+        since: "2.0"
         params:
           - name: item
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Item that the event is fired for.
           - name: uuid
             type: UUID
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               UUID of the member that dispatches this event.
           - name: eventType
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Type of the event. It is either ADDED(1) or REMOVED(2).
   - id: 18
     name: removeListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes the specified item listener. If there is no such listener added before, this call does no change in the
       cluster and returns false.
@@ -511,13 +511,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Queue
         - name: registrationId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Id of the listener registration.
     response:
@@ -525,12 +525,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if the item listener is removed, false otherwise
   - id: 19
     name: remainingCapacity
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the number of additional elements that this queue can ideally (in the absence of memory or resource
       constraints) accept without blocking, or Integer.MAX_VALUE if there is no intrinsic limit. Note that you cannot
@@ -543,7 +543,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Queue
     response:
@@ -551,12 +551,12 @@ methods:
         - name: response
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The remaining capacity
   - id: 20
     name: isEmpty
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns true if this collection contains no elements.
     request:
@@ -566,7 +566,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Queue
     response:
@@ -574,6 +574,6 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             <tt>True</tt> if this collection contains no elements

--- a/protocol-definitions/ReplicatedMap.yaml
+++ b/protocol-definitions/ReplicatedMap.yaml
@@ -3,7 +3,7 @@ name: ReplicatedMap
 methods:
   - id: 1
     name: put
-    since: 2.0
+    since: "2.0"
     doc: |
       Associates a given value to the specified key and replicates it to the cluster. If there is an old value, it will
       be replaced by the specified one and returned from the call. In addition, you have to specify a ttl and its TimeUnit
@@ -15,25 +15,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the ReplicatedMap
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key with which the specified value is to be associated.
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Value to be associated with the specified key
         - name: ttl
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ttl in milliseconds to be associated with the specified key-value pair
     response:
@@ -41,12 +41,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The old value if existed for the key.
   - id: 2
     name: size
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the number of key-value mappings in this map. If the map contains more than Integer.MAX_VALUE elements,
       returns Integer.MAX_VALUE.
@@ -57,7 +57,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the ReplicatedMap
     response:
@@ -65,12 +65,12 @@ methods:
         - name: response
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the number of key-value mappings in this map.
   - id: 3
     name: isEmpty
-    since: 2.0
+    since: "2.0"
     doc: |
       Return true if this map contains no key-value mappings
     request:
@@ -80,7 +80,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the ReplicatedMap
     response:
@@ -88,12 +88,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             <tt>True</tt> if this map contains no key-value mappings
   - id: 4
     name: containsKey
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns true if this map contains a mapping for the specified key.
     request:
@@ -103,13 +103,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the ReplicatedMap
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The key whose associated value is to be returned.
     response:
@@ -117,12 +117,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             <tt>True</tt> if this map contains a mapping for the specified key
   - id: 5
     name: containsValue
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns true if this map maps one or more keys to the specified value.
       This operation will probably require time linear in the map size for most implementations of the Map interface.
@@ -133,13 +133,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the ReplicatedMap
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             value whose presence in this map is to be tested
     response:
@@ -147,12 +147,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             <tt>true</tt> if this map maps one or more keys to the specified value
   - id: 6
     name: get
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the value to which the specified key is mapped, or null if this map contains no mapping for the key.
       If this map permits null values, then a return value of null does not
@@ -165,13 +165,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the ReplicatedMap
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The key whose associated value is to be returned
     response:
@@ -179,12 +179,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The value to which the specified key is mapped, or null if this map contains no mapping for the key
   - id: 7
     name: remove
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes the mapping for a key from this map if it is present (optional operation). Returns the value to which this map previously associated the key,
       or null if the map contained no mapping for the key. If this map permits null values, then a return value of
@@ -197,13 +197,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the ReplicatedMap
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key with which the specified value is to be associated.
     response:
@@ -211,12 +211,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             the previous value associated with <tt>key</tt>, or <tt>null</tt> if there was no mapping for <tt>key</tt>.
   - id: 8
     name: putAll
-    since: 2.0
+    since: "2.0"
     doc: |
       Copies all of the mappings from the specified map to this map (optional operation). The effect of this call is
       equivalent to that of calling put(Object,Object) put(k, v) on this map once for each mapping from key k to value
@@ -229,19 +229,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the ReplicatedMap
         - name: entries
           type: EntryList_Data_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             entries to be stored in this map
     response: {}
   - id: 9
     name: clear
-    since: 2.0
+    since: "2.0"
     doc: |
       The clear operation wipes data out of the replicated maps.It is the only synchronous remote operation in this
       implementation, so be aware that this might be a slow operation. If some node fails on executing the operation,
@@ -254,13 +254,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Replicated Map
     response: {}
   - id: 10
     name: addEntryListenerToKeyWithPredicate
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds an continuous entry listener for this map. The listener will be notified for map add/remove/update/evict
       events filtered by the given predicate.
@@ -271,25 +271,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Replicated Map
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key with which the specified value is to be associated.
         - name: predicate
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The predicate for filtering entries
         - name: localOnly
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
@@ -297,41 +297,41 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             A unique string  which is used as a key to remove the listener.
     events:
       - name: Entry
-        since: 2.0
+        since: "2.0"
         params:
           - name: key
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Key of the entry event.
           - name: value
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Value of the entry event.
           - name: oldValue
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Old value of the entry event.
           - name: mergingValue
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Incoming merging value of the entry event.
           - name: eventType
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Type of the entry event. Possible values are
               ADDED(1)
@@ -347,18 +347,18 @@ methods:
           - name: uuid
             type: UUID
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               UUID of the member that dispatches the event.
           - name: numberOfAffectedEntries
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Number of entries affected by this event.
   - id: 11
     name: addEntryListenerWithPredicate
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds an continuous entry listener for this map. The listener will be notified for map add/remove/update/evict
       events filtered by the given predicate.
@@ -369,19 +369,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Replicated Map
         - name: predicate
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The predicate for filtering entries
         - name: localOnly
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
@@ -389,41 +389,41 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             A unique string  which is used as a key to remove the listener.
     events:
       - name: Entry
-        since: 2.0
+        since: "2.0"
         params:
           - name: key
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Key of the entry event.
           - name: value
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Value of the entry event.
           - name: oldValue
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Old value of the entry event.
           - name: mergingValue
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Incoming merging value of the entry event.
           - name: eventType
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Type of the entry event. Possible values are
               ADDED(1)
@@ -439,18 +439,18 @@ methods:
           - name: uuid
             type: UUID
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               UUID of the member that dispatches the event.
           - name: numberOfAffectedEntries
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Number of entries affected by this event.
   - id: 12
     name: addEntryListenerToKey
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds the specified entry listener for the specified key. The listener will be notified for all
       add/remove/update/evict events of the specified key only.
@@ -461,19 +461,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Replicated Map
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Key with which the specified value is to be associated.
         - name: localOnly
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
@@ -481,41 +481,41 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             A unique string  which is used as a key to remove the listener.
     events:
       - name: Entry
-        since: 2.0
+        since: "2.0"
         params:
           - name: key
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Key of the entry event.
           - name: value
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Value of the entry event.
           - name: oldValue
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Old value of the entry event.
           - name: mergingValue
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Incoming merging value of the entry event.
           - name: eventType
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Type of the entry event. Possible values are
               ADDED(1)
@@ -531,18 +531,18 @@ methods:
           - name: uuid
             type: UUID
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               UUID of the member that dispatches the event.
           - name: numberOfAffectedEntries
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Number of entries affected by this event.
   - id: 13
     name: addEntryListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds an entry listener for this map. The listener will be notified for all map add/remove/update/evict events.
     request:
@@ -552,13 +552,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the ReplicatedMap
         - name: localOnly
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
@@ -566,41 +566,41 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             A unique string  which is used as a key to remove the listener.
     events:
       - name: Entry
-        since: 2.0
+        since: "2.0"
         params:
           - name: key
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Key of the entry event.
           - name: value
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Value of the entry event.
           - name: oldValue
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Old value of the entry event.
           - name: mergingValue
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Incoming merging value of the entry event.
           - name: eventType
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Type of the entry event. Possible values are
               ADDED(1)
@@ -616,18 +616,18 @@ methods:
           - name: uuid
             type: UUID
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               UUID of the member that dispatches the event.
           - name: numberOfAffectedEntries
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Number of entries affected by this event.
   - id: 14
     name: removeEntryListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes the specified entry listener. If there is no such listener added before, this call does no change in the
       cluster and returns false.
@@ -638,13 +638,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the ReplicatedMap
         - name: registrationId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the registered entry listener.
     response:
@@ -652,12 +652,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if registration is removed, false otherwise.
   - id: 15
     name: keySet
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns a lazy Set view of the key contained in this map. A LazySet is optimized for querying speed
       (preventing eager deserialization and hashing on HashSet insertion) and does NOT provide all operations.
@@ -672,7 +672,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the ReplicatedMap
     response:
@@ -680,12 +680,12 @@ methods:
         - name: response
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             A lazy set view of the keys contained in this map.
   - id: 16
     name: values
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns a lazy collection view of the values contained in this map.
     request:
@@ -695,7 +695,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the ReplicatedMap
     response:
@@ -703,12 +703,12 @@ methods:
         - name: response
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             A collection view of the values contained in this map.
   - id: 17
     name: entrySet
-    since: 2.0
+    since: "2.0"
     doc: |
       Gets a lazy set view of the mappings contained in this map.
     request:
@@ -718,7 +718,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the ReplicatedMap
     response:
@@ -726,12 +726,12 @@ methods:
         - name: response
           type: EntryList_Data_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             A lazy set view of the mappings contained in this map.
   - id: 18
     name: addNearCacheEntryListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a near cache entry listener for this map. This listener will be notified when an entry is added/removed/updated/evicted/expired etc. so that the near cache entries can be invalidated.
     request:
@@ -741,19 +741,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the ReplicatedMap
         - name: includeValue
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if EntryEvent should contain the value,false otherwise
         - name: localOnly
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
@@ -761,41 +761,41 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             A unique string  which is used as a key to remove the listener.
     events:
       - name: Entry
-        since: 2.0
+        since: "2.0"
         params:
           - name: key
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Key of the entry event.
           - name: value
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Value of the entry event.
           - name: oldValue
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Old value of the entry event.
           - name: mergingValue
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Incoming merging value of the entry event.
           - name: eventType
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Type of the entry event. Possible values are
               ADDED(1)
@@ -811,18 +811,18 @@ methods:
           - name: uuid
             type: UUID
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               UUID of the member that dispatches the event.
           - name: numberOfAffectedEntries
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Number of entries affected by this event.
   - id: 19
     name: putAllWithMetadata
-    since: 2.7
+    since: "2.7"
     doc: |
       Copies all of the mappings from the specified entry list to this map, including metadata.
       This method uses ReplicatedRecordStore.putRecord in the backend.
@@ -836,25 +836,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             name of replicated map
         - name: entries
           type: List_ReplicatedMapEntryViewHolder
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             entries with metadata
         - name: partitionId
           type: int
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             partition id of the entries
     response: {}
   - id: 20
     name: fetchEntryViews
-    since: 2.7
+    since: "2.7"
     doc: |
       Allows iteration over ReplicatedMapEntryViewHolder objects. The changes happened during the iteration may not be included in the iterated EntryViews. This method
       will throw an exception if there is no replicated record store with the given replicated map name and partition id. This method will consume some memory in the 
@@ -866,13 +866,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Name of the ReplicatedMap
         - name: cursorId
           type: UUID
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             The identifier of the last fetched page. Send a random UUID while sending the first fetchEntryViews
             request to start iteration. Also don't forget to set newIteration to true. Then, use the returned
@@ -880,20 +880,20 @@ methods:
         - name: newIteration
           type: boolean
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Set this true if you are creating a new iteration via fetchEntryViews. fetchEntryViews can also be 
             used to fetch new pages of an existing iteration. In that case, set this to false. 
         - name: partitionId
           type: int
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             The partition ID of the partition that the EntryViews belong to.
         - name: batchSize
           type: int
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             The maximum number of EntryViews to be returned.
     response:
@@ -901,18 +901,18 @@ methods:
         - name: cursorId
           type: UUID
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             A UUID which is used to fetch new pages.
         - name: entryViews
           type: List_ReplicatedMapEntryViewHolder
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             A list of EntryViews. If the page includes less items than the batchSize, it means the iteration has ended.
   - id: 21
     name: endEntryViewIteration
-    since: 2.7
+    since: "2.7"
     doc: |
       This method is used to release the resource generated by fetchEntryViews. Send this request after you retrieved the last page and no
       longer need the iterator.
@@ -923,13 +923,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.7
+          since: "2.7"
           doc: |
             Name of the ReplicatedMap
         - name: cursorId
           type: UUID
           nullable: true
-          since: 2.7
+          since: "2.7"
           doc: |
             The identifier of the iterator. This has to be the first cursor id that is returned by fetchEntryViews.
     response: {}

--- a/protocol-definitions/Ringbuffer.yaml
+++ b/protocol-definitions/Ringbuffer.yaml
@@ -3,7 +3,7 @@ name: Ringbuffer
 methods:
   - id: 1
     name: size
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns number of items in the ringbuffer. If no ttl is set, the size will always be equal to capacity after the
       head completed the first looparound the ring. This is because no items are getting retired.
@@ -14,7 +14,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Ringbuffer
     response:
@@ -22,12 +22,12 @@ methods:
         - name: response
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the size
   - id: 2
     name: tailSequence
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the sequence of the tail. The tail is the side of the ringbuffer where the items are added to.
       The initial value of the tail is -1.
@@ -38,7 +38,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Ringbuffer
     response:
@@ -46,12 +46,12 @@ methods:
         - name: response
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the sequence of the tail
   - id: 3
     name: headSequence
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the sequence of the head. The head is the side of the ringbuffer where the oldest items in the ringbuffer
       are found. If the RingBuffer is empty, the head will be one more than the tail.
@@ -63,7 +63,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Ringbuffer
     response:
@@ -71,12 +71,12 @@ methods:
         - name: response
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the sequence of the head
   - id: 4
     name: capacity
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the capacity of this Ringbuffer.
     request:
@@ -86,7 +86,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Ringbuffer
     response:
@@ -94,12 +94,12 @@ methods:
         - name: response
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the capacity
   - id: 5
     name: remainingCapacity
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the remaining capacity of the ringbuffer. The returned value could be stale as soon as it is returned.
       If ttl is not set, the remaining capacity will always be the capacity.
@@ -110,7 +110,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Ringbuffer
     response:
@@ -118,12 +118,12 @@ methods:
         - name: response
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the remaining capacity
   - id: 6
     name: add
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds an item to the tail of the Ringbuffer. If there is space in the ringbuffer, the call
       will return the sequence of the written item. If there is no space, it depends on the overflow policy what happens:
@@ -143,19 +143,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Ringbuffer
         - name: overflowPolicy
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the OverflowPolicy to use.
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             to item to add
     response:
@@ -163,12 +163,12 @@ methods:
         - name: response
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the sequence of the added item, or -1 if the add failed.
   - id: 7
     name: readOne
-    since: 2.0
+    since: "2.0"
     doc: |
       Reads one item from the Ringbuffer. If the sequence is one beyond the current tail, this call blocks until an
       item is added. This method is not destructive unlike e.g. a queue.take. So the same item can be read by multiple
@@ -181,13 +181,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Ringbuffer
         - name: sequence
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the sequence of the item to read.
     response:
@@ -195,12 +195,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             the read item
   - id: 8
     name: addAll
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds all the items of a collection to the tail of the Ringbuffer. A addAll is likely to outperform multiple calls
       to add(Object) due to better io utilization and a reduced number of executed operations. If the batch is empty,
@@ -217,19 +217,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Ringbuffer
         - name: valueList
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the batch of items to add
         - name: overflowPolicy
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the overflowPolicy to use
     response:
@@ -237,12 +237,12 @@ methods:
         - name: response
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the CompletionStage to synchronize on completion.
   - id: 9
     name: readMany
-    since: 2.0
+    since: "2.0"
     doc: |
       Reads a batch of items from the Ringbuffer. If the number of available items after the first read item is smaller
       than the maxCount, these items are returned. So it could be the number of items read is smaller than the maxCount.
@@ -258,31 +258,31 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Ringbuffer
         - name: startSequence
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the startSequence of the first item to read
         - name: minCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the minimum number of items to read.
         - name: maxCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             the maximum number of items to read.
         - name: filter
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Filter is allowed to be null, indicating there is no filter.
     response:
@@ -290,24 +290,24 @@ methods:
         - name: readCount
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Number of items that have been read before filtering.
         - name: items
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             List of items that have been read.
         - name: itemSeqs
           type: longArray
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             List of sequence numbers for the items that have been read.
         - name: nextSeq
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Sequence number of the item following the last read item.

--- a/protocol-definitions/ScheduledExecutor.yaml
+++ b/protocol-definitions/ScheduledExecutor.yaml
@@ -3,7 +3,7 @@ name: ScheduledExecutor
 methods:
   - id: 1
     name: shutdown
-    since: 2.0
+    since: "2.0"
     doc: |
       Initiates an orderly shutdown in which previously submitted tasks are executed, but no new tasks will be accepted.
       Invocation has no additional effect if already shut down.
@@ -14,19 +14,19 @@ methods:
         - name: schedulerName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the scheduler.
         - name: memberUuid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The UUID of the member where the shutdown for this scheduler will be sent.
     response: {}
   - id: 2
     name: submitToPartition
-    since: 2.0
+    since: "2.0"
     doc: |
       Submits the task to partition for execution, partition is chosen based on multiple criteria of the given task.
     request:
@@ -36,49 +36,49 @@ methods:
         - name: schedulerName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the scheduler.
         - name: type
           type: byte
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             type of schedule logic, values 0 for SINGLE_RUN, 1 for AT_FIXED_RATE
         - name: taskName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the task
         - name: task
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name The name of the task
         - name: initialDelayInMillis
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             initial delay in milliseconds
         - name: periodInMillis
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             period between each run in milliseconds
         - name: autoDisposable
           type: boolean
           nullable: false
-          since: 2.1
+          since: "2.1"
           doc: |
             A boolean flag to indicate whether the task should be destroyed automatically after execution.
     response: {}
   - id: 3
     name: submitToMember
-    since: 2.0
+    since: "2.0"
     doc: |
       Submits the task to a member for execution. Member is provided with its uuid.
     request:
@@ -88,55 +88,55 @@ methods:
         - name: schedulerName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the scheduler.
         - name: memberUuid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The UUID of the member where the task will get scheduled.
         - name: type
           type: byte
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             type of schedule logic, values 0 for SINGLE_RUN, 1 for AT_FIXED_RATE
         - name: taskName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the task
         - name: task
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name The name of the task
         - name: initialDelayInMillis
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             initial delay in milliseconds
         - name: periodInMillis
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             period between each run in milliseconds
         - name: autoDisposable
           type: boolean
           nullable: false
-          since: 2.1
+          since: "2.1"
           doc: |
             A boolean flag to indicate whether the task should be destroyed automatically after execution.
     response: {}
   - id: 4
     name: getAllScheduledFutures
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns all scheduled tasks in for a given scheduler in the given member.
     request:
@@ -146,7 +146,7 @@ methods:
         - name: schedulerName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the scheduler.
     response:
@@ -154,12 +154,12 @@ methods:
         - name: handlers
           type: List_ScheduledTaskHandler
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             A list of scheduled task handlers used to construct the future proxies.
   - id: 5
     name: getStatsFromPartition
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns statistics of the task
     request:
@@ -169,13 +169,13 @@ methods:
         - name: schedulerName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the scheduler.
         - name: taskName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the task
     response:
@@ -183,36 +183,36 @@ methods:
         - name: lastIdleTimeNanos
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Last period of time the task was idle, waiting to get scheduled.
         - name: totalIdleTimeNanos
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Total amount of time the task was idle, waiting to get scheduled in.
         - name: totalRuns
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             How many times the task was ran/called.
         - name: totalRunTimeNanos
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The total amount of time the task spent while scheduled in.
         - name: lastRunDurationNanos
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The duration of the task's last execution.
   - id: 6
     name: getStatsFromMember
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns statistics of the task
     request:
@@ -222,19 +222,19 @@ methods:
         - name: schedulerName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the scheduler.
         - name: taskName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the task
         - name: memberUuid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The UUID of the member where the task will get scheduled.
     response:
@@ -242,36 +242,36 @@ methods:
         - name: lastIdleTimeNanos
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Last period of time the task was idle, waiting to get scheduled.
         - name: totalIdleTimeNanos
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Total amount of time the task was idle, waiting to get scheduled in.
         - name: totalRuns
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             How many times the task was ran/called.
         - name: totalRunTimeNanos
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The total amount of time the task spent while scheduled in.
         - name: lastRunDurationNanos
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The duration of the task's last execution.
   - id: 7
     name: getDelayFromPartition
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the ScheduledFuture's delay in nanoseconds for the task in the scheduler.
     request:
@@ -281,13 +281,13 @@ methods:
         - name: schedulerName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the scheduler.
         - name: taskName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the task
     response:
@@ -295,12 +295,12 @@ methods:
         - name: response
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The remaining delay of the task formatted in nanoseconds.
   - id: 8
     name: getDelayFromMember
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the ScheduledFuture's delay in nanoseconds for the task in the scheduler.
     request:
@@ -310,19 +310,19 @@ methods:
         - name: schedulerName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the scheduler.
         - name: taskName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the task
         - name: memberUuid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The UUID of the member where the task will get scheduled.
     response:
@@ -330,12 +330,12 @@ methods:
         - name: response
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The remaining delay of the task formatted in nanoseconds.
   - id: 9
     name: cancelFromPartition
-    since: 2.0
+    since: "2.0"
     doc: |
       Cancels further execution and scheduling of the task
     request:
@@ -345,19 +345,19 @@ methods:
         - name: schedulerName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the scheduler.
         - name: taskName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the task
         - name: mayInterruptIfRunning
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             A boolean flag to indicate whether the task should be interrupted.
     response:
@@ -365,12 +365,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if the task was cancelled
   - id: 10
     name: cancelFromMember
-    since: 2.0
+    since: "2.0"
     doc: |
       Cancels further execution and scheduling of the task
     request:
@@ -380,25 +380,25 @@ methods:
         - name: schedulerName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the scheduler.
         - name: taskName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the task
         - name: memberUuid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The UUID of the member where the task will get scheduled.
         - name: mayInterruptIfRunning
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             A boolean flag to indicate whether the task should be interrupted.
     response:
@@ -406,12 +406,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if the task was cancelled
   - id: 11
     name: isCancelledFromPartition
-    since: 2.0
+    since: "2.0"
     doc: |
       Checks whether a task as identified from the given handler is already cancelled.
     request:
@@ -421,13 +421,13 @@ methods:
         - name: schedulerName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the scheduler.
         - name: taskName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the task
     response:
@@ -435,12 +435,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if the task is cancelled
   - id: 12
     name: isCancelledFromMember
-    since: 2.0
+    since: "2.0"
     doc: |
       Checks whether a task as identified from the given handler is already cancelled.
     request:
@@ -450,19 +450,19 @@ methods:
         - name: schedulerName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the scheduler.
         - name: taskName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the task
         - name: memberUuid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The UUID of the member where the task will get scheduled.
     response:
@@ -470,12 +470,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if the task is cancelled
   - id: 13
     name: isDoneFromPartition
-    since: 2.0
+    since: "2.0"
     doc: |
       Checks whether a task is done.
       @see java.util.concurrent.Future#cancel(boolean)
@@ -486,13 +486,13 @@ methods:
         - name: schedulerName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the scheduler.
         - name: taskName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the task
     response:
@@ -500,12 +500,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if the task is done
   - id: 14
     name: isDoneFromMember
-    since: 2.0
+    since: "2.0"
     doc: |
       Checks whether a task is done.
       @see java.util.concurrent.Future#cancel(boolean)
@@ -516,19 +516,19 @@ methods:
         - name: schedulerName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the scheduler.
         - name: taskName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the task
         - name: memberUuid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The UUID of the member where the task will get scheduled.
     response:
@@ -536,12 +536,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if the task is done
   - id: 15
     name: getResultFromPartition
-    since: 2.0
+    since: "2.0"
     doc: |
       Fetches the result of the task ({@link java.util.concurrent.Callable})
       The call will blocking until the result is ready.
@@ -552,13 +552,13 @@ methods:
         - name: schedulerName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the scheduler.
         - name: taskName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the task
     response:
@@ -566,12 +566,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The result of the completed task, in serialized form ({
   - id: 16
     name: getResultFromMember
-    since: 2.0
+    since: "2.0"
     doc: |
       Fetches the result of the task ({@link java.util.concurrent.Callable})
       The call will blocking until the result is ready.
@@ -582,19 +582,19 @@ methods:
         - name: schedulerName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the scheduler.
         - name: taskName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the task
         - name: memberUuid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The uuid of the member where the task will get scheduled.
     response:
@@ -602,12 +602,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The result of the completed task, in serialized form ({
   - id: 17
     name: disposeFromPartition
-    since: 2.0
+    since: "2.0"
     doc: |
       Dispose the task from the scheduler
     request:
@@ -617,19 +617,19 @@ methods:
         - name: schedulerName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the scheduler.
         - name: taskName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the task
     response: {}
   - id: 18
     name: disposeFromMember
-    since: 2.0
+    since: "2.0"
     doc: |
       Dispose the task from the scheduler
     request:
@@ -639,19 +639,19 @@ methods:
         - name: schedulerName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the scheduler.
         - name: taskName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The name of the task
         - name: memberUuid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The UUID of the member where the task will get scheduled.
     response: {}

--- a/protocol-definitions/Semaphore.yaml
+++ b/protocol-definitions/Semaphore.yaml
@@ -3,7 +3,7 @@ name: Semaphore
 methods:
   - id: 1
     name: init
-    since: 2.0
+    since: "2.0"
     doc: |
       Initializes the ISemaphore instance with the given permit number, if not
       initialized before.
@@ -14,19 +14,19 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this ISemaphore instance
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of this ISemaphore instance
         - name: permits
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Number of permits to initialize this ISemaphore
     response:
@@ -34,12 +34,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if the ISemaphore is initialized with this call
   - id: 2
     name: acquire
-    since: 2.0
+    since: "2.0"
     doc: |
       Acquires the requested amount of permits if available, reducing
       the number of available permits. If no enough permits are available,
@@ -52,43 +52,43 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this ISemaphore instance
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of this ISemaphore instance
         - name: sessionId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Session ID of the caller
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the caller thread
         - name: invocationUid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             UID of this invocation
         - name: permits
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             number of permits to acquire
         - name: timeoutMs
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Duration to wait for permit acquire
     response:
@@ -96,13 +96,13 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if requested permits are acquired,
             false otherwise
   - id: 3
     name: release
-    since: 2.0
+    since: "2.0"
     doc: |
       Releases the given number of permits and increases the number of
       available permits by that amount.
@@ -113,37 +113,37 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this ISemaphore instance
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of this ISemaphore instance
         - name: sessionId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Session ID of the caller
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the caller thread
         - name: invocationUid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             UID of this invocation
         - name: permits
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             number of permits to release
     response:
@@ -151,12 +151,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true
   - id: 4
     name: drain
-    since: 2.0
+    since: "2.0"
     doc: |
       Acquires all available permits at once and returns immediately.
     request:
@@ -166,31 +166,31 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this ISemaphore instance
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of this ISemaphore instance
         - name: sessionId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Session ID of the caller
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the caller thread
         - name: invocationUid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             UID of this invocation
     response:
@@ -198,12 +198,12 @@ methods:
         - name: response
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             number of acquired permits
   - id: 5
     name: change
-    since: 2.0
+    since: "2.0"
     doc: |
       Increases or decreases the number of permits by the given value.
     request:
@@ -213,37 +213,37 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this ISemaphore instance
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of this ISemaphore instance
         - name: sessionId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Session ID of the caller
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the caller thread
         - name: invocationUid
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             UID of this invocation
         - name: permits
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             number of permits to increase / decrease
     response:
@@ -251,12 +251,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true
   - id: 6
     name: availablePermits
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the number of available permits.
     request:
@@ -266,13 +266,13 @@ methods:
         - name: groupId
           type: RaftGroupId
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             CP group id of this ISemaphore instance
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of this ISemaphore instance
     response:
@@ -280,12 +280,12 @@ methods:
         - name: response
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             number of available permits
   - id: 7
     name: getSemaphoreType
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns true if the semaphore is JDK compatible
     request:
@@ -295,7 +295,7 @@ methods:
         - name: proxyName
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the ISemaphore proxy
     response:
@@ -303,6 +303,6 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if the semaphore is JDK compatible

--- a/protocol-definitions/Set.yaml
+++ b/protocol-definitions/Set.yaml
@@ -3,7 +3,7 @@ name: Set
 methods:
   - id: 1
     name: size
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the number of elements in this set (its cardinality). If this set contains more than Integer.MAX_VALUE
       elements, returns Integer.MAX_VALUE.
@@ -14,7 +14,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Set
     response:
@@ -22,12 +22,12 @@ methods:
         - name: response
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The number of elements in this set (its cardinality)
   - id: 2
     name: contains
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns true if this set contains the specified element.
     request:
@@ -37,13 +37,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Set
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Element whose presence in this set is to be tested
     response:
@@ -51,12 +51,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if this set contains the specified element, false otherwise
   - id: 3
     name: containsAll
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns true if this set contains all of the elements of the specified collection. If the specified collection is
       also a set, this method returns true if it is a subset of this set.
@@ -67,13 +67,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Set
         - name: items
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Collection to be checked for containment in this list
     response:
@@ -81,13 +81,13 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if this set contains all of the elements of the
             specified collection
   - id: 4
     name: add
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds the specified element to this set if it is not already present (optional operation).
       If this set already contains the element, the call leaves the set unchanged and returns false.In combination with
@@ -102,13 +102,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Set
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Element to be added to this set
     response:
@@ -116,13 +116,13 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if this set did not already contain the specified
             element and the element is added, returns false otherwise.
   - id: 5
     name: remove
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes the specified element from this set if it is present (optional operation).
       Returns true if this set contained the element (or equivalently, if this set changed as a result of the call).
@@ -134,13 +134,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Set
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Object to be removed from this set, if present
     response:
@@ -148,12 +148,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if this set contained the specified element and it is removed successfully
   - id: 6
     name: addAll
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds all of the elements in the specified collection to this set if they're not already present
       (optional operation). If the specified collection is also a set, the addAll operation effectively modifies this
@@ -166,13 +166,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Set
         - name: valueList
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Collection containing elements to be added to this set
     response:
@@ -180,12 +180,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if this set changed as a result of the call
   - id: 7
     name: compareAndRemoveAll
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes from this set all of its elements that are contained in the specified collection (optional operation).
       If the specified collection is also a set, this operation effectively modifies this set so that its value is the
@@ -197,13 +197,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Set
         - name: values
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The list of values to test for matching the item to remove.
     response:
@@ -211,12 +211,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if at least one item in values existed and removed, false otherwise.
   - id: 8
     name: compareAndRetainAll
-    since: 2.0
+    since: "2.0"
     doc: |
       Retains only the elements in this set that are contained in the specified collection (optional operation).
       In other words, removes from this set all of its elements that are not contained in the specified collection.
@@ -229,13 +229,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Set
         - name: values
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The list of values to test for matching the item to retain.
     response:
@@ -243,13 +243,13 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if at least one item in values existed and it is retained, false otherwise. All items not in valueSet but
             in the Set are removed.
   - id: 9
     name: clear
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes all of the elements from this set (optional operation). The set will be empty after this call returns.
     request:
@@ -259,13 +259,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Set
     response: {}
   - id: 10
     name: getAll
-    since: 2.0
+    since: "2.0"
     doc: |
       Return the all elements of this collection
     request:
@@ -275,7 +275,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Set
     response:
@@ -283,12 +283,12 @@ methods:
         - name: response
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Array of all values in the Set
   - id: 11
     name: addListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds an item listener for this collection. Listener will be notified for all collection add/remove events.
     request:
@@ -298,19 +298,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Set
         - name: includeValue
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             if set to true, the event shall also include the value.
         - name: localOnly
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             if true fires events that originated from this node only, otherwise fires all events
     response:
@@ -318,34 +318,34 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The registration id.
     events:
       - name: Item
-        since: 2.0
+        since: "2.0"
         params:
           - name: item
             type: Data
             nullable: true
-            since: 2.0
+            since: "2.0"
             doc: |
               Item that the event is fired for.
           - name: uuid
             type: UUID
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               UUID of the member that dispatches this event.
           - name: eventType
             type: int
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Type of the event. It is either ADDED(1) or REMOVED(2).
   - id: 12
     name: removeListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes the specified item listener. If there is no such listener added before, this call does no change in the
       cluster and returns false.
@@ -356,13 +356,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Set
         - name: registrationId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id retrieved during registration.
     response:
@@ -370,12 +370,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if the listener with the provided id existed and removed, false otherwise.
   - id: 13
     name: isEmpty
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns true if this set contains no elements.
     request:
@@ -385,7 +385,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Set
     response:
@@ -393,6 +393,6 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if this set contains no elements

--- a/protocol-definitions/Sql.yaml
+++ b/protocol-definitions/Sql.yaml
@@ -3,7 +3,7 @@ name: Sql
 methods:
   - id: 1
     name: execute_reserved
-    since: 2.1
+    since: "2.1"
     doc: |
       THIS MESSAGE IS NO LONGER USED BUT KEPT FOR BACKWARD COMPATIBILITY TESTS
       Starts execution of an SQL query.
@@ -14,25 +14,25 @@ methods:
         - name: sql
           type: String
           nullable: false
-          since: 2.1
+          since: "2.1"
           doc: |
             Query string.
         - name: parameters
           type: List_Data
           nullable: false
-          since: 2.1
+          since: "2.1"
           doc: |
             Query parameters.
         - name: timeoutMillis
           type: long
           nullable: false
-          since: 2.1
+          since: "2.1"
           doc: |
             Timeout in milliseconds.
         - name: cursorBufferSize
           type: int
           nullable: false
-          since: 2.1
+          since: "2.1"
           doc: |
             Cursor buffer size.
     response:
@@ -40,42 +40,42 @@ methods:
         - name: queryId
           type: SqlQueryId
           nullable: true
-          since: 2.1
+          since: "2.1"
           doc: |
             Query ID.
         - name: rowMetadata
           type: List_SqlColumnMetadata
           nullable: true
-          since: 2.1
+          since: "2.1"
           doc: |
             Row metadata.
         - name: rowPage
           type: List_ListCN_Data
           nullable: true
-          since: 2.1
+          since: "2.1"
           doc: |
             Row page.
         - name: rowPageLast
           type: boolean
           nullable: false
-          since: 2.1
+          since: "2.1"
           doc: |
             Whether the row page is the last.
         - name: updateCount
           type: long
           nullable: false
-          since: 2.1
+          since: "2.1"
           doc: |
             The number of updated rows.
         - name: error
           type: SqlError
           nullable: true
-          since: 2.1
+          since: "2.1"
           doc: |
             Error object.
   - id: 2
     name: fetch_reserved
-    since: 2.1
+    since: "2.1"
     doc: |
       Fetches the next row page.
     request:
@@ -85,13 +85,13 @@ methods:
         - name: queryId
           type: SqlQueryId
           nullable: false
-          since: 2.1
+          since: "2.1"
           doc: |
             Query ID.
         - name: cursorBufferSize
           type: int
           nullable: false
-          since: 2.1
+          since: "2.1"
           doc: |
             Cursor buffer size.
     response:
@@ -99,24 +99,24 @@ methods:
         - name: rowPage
           type: List_ListCN_Data
           nullable: true
-          since: 2.1
+          since: "2.1"
           doc: |
             Row page.
         - name: rowPageLast
           type: boolean
           nullable: false
-          since: 2.1
+          since: "2.1"
           doc: |
             Whether the row page is the last.
         - name: error
           type: SqlError
           nullable: true
-          since: 2.1
+          since: "2.1"
           doc: |
             Error object.
   - id: 3
     name: close
-    since: 2.1
+    since: "2.1"
     doc: |
       Closes server-side query cursor.
     request:
@@ -126,13 +126,13 @@ methods:
         - name: queryId
           type: SqlQueryId
           nullable: false
-          since: 2.1
+          since: "2.1"
           doc: |
             Query ID.
     response: {}
   - id: 4
     name: execute
-    since: 2.2
+    since: "2.2"
     doc: |
       Starts execution of an SQL query (as of 4.2).
     request:
@@ -142,37 +142,37 @@ methods:
         - name: sql
           type: String
           nullable: false
-          since: 2.2
+          since: "2.2"
           doc: |
             Query string.
         - name: parameters
           type: ListCN_Data
           nullable: false
-          since: 2.2
+          since: "2.2"
           doc: |
             Query parameters.
         - name: timeoutMillis
           type: long
           nullable: false
-          since: 2.2
+          since: "2.2"
           doc: |
             Timeout in milliseconds.
         - name: cursorBufferSize
           type: int
           nullable: false
-          since: 2.2
+          since: "2.2"
           doc: |
             Cursor buffer size.
         - name: schema
           type: String
           nullable: true
-          since: 2.2
+          since: "2.2"
           doc: |
             Schema name.
         - name: expectedResultType
           type: byte
           nullable: false
-          since: 2.2
+          since: "2.2"
           doc: |
             The expected result type. Possible values are:
               ANY(0)
@@ -181,13 +181,13 @@ methods:
         - name: queryId
           type: SqlQueryId
           nullable: false
-          since: 2.2
+          since: "2.2"
           doc: |
             Query ID.
         - name: skipUpdateStatistics
           type: boolean
           nullable: false
-          since: 2.3
+          since: "2.3"
           doc: |
             Flag to skip updating phone home statistics.
     response:
@@ -195,42 +195,42 @@ methods:
         - name: rowMetadata
           type: List_SqlColumnMetadata
           nullable: true
-          since: 2.2
+          since: "2.2"
           doc: |
             Row metadata.
         - name: rowPage
           type: SqlPage
           nullable: true
-          since: 2.2
+          since: "2.2"
           doc: |
             Row page.
         - name: updateCount
           type: long
           nullable: false
-          since: 2.2
+          since: "2.2"
           doc: |
             The number of updated rows.
         - name: error
           type: SqlError
           nullable: true
-          since: 2.2
+          since: "2.2"
           doc: |
             Error object.
         - name: isInfiniteRows
           type: boolean
           nullable: false
-          since: 2.5
+          since: "2.5"
           doc: |
             Is the result set unbounded.
         - name: partitionArgumentIndex
           type: int
           nullable: false
-          since: 2.6
+          since: "2.6"
           doc: |
             Index of the partition-determining argument, -1 if not applicable.
   - id: 5
     name: fetch
-    since: 2.2
+    since: "2.2"
     doc: |
       Fetches the next row page.
     request:
@@ -240,13 +240,13 @@ methods:
         - name: queryId
           type: SqlQueryId
           nullable: false
-          since: 2.2
+          since: "2.2"
           doc: |
             Query ID.
         - name: cursorBufferSize
           type: int
           nullable: false
-          since: 2.2
+          since: "2.2"
           doc: |
             Cursor buffer size.
     response:
@@ -254,18 +254,18 @@ methods:
         - name: rowPage
           type: SqlPage
           nullable: true
-          since: 2.2
+          since: "2.2"
           doc: |
             Row page.
         - name: error
           type: SqlError
           nullable: true
-          since: 2.2
+          since: "2.2"
           doc: |
             Error object.
   - id: 6
     name: mappingDdl
-    since: 2.3
+    since: "2.3"
     doc: |
       Derives CREATE MAPPING SQL.
     request:
@@ -275,7 +275,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.3
+          since: "2.3"
           doc: |
             Object name to derive CREATE MAPPING SQL for.
     response:
@@ -283,6 +283,6 @@ methods:
         - name: sql
           type: String
           nullable: true
-          since: 2.3
+          since: "2.3"
           doc: |
             CREATE MAPPING SQL.

--- a/protocol-definitions/Topic.yaml
+++ b/protocol-definitions/Topic.yaml
@@ -3,7 +3,7 @@ name: Topic
 methods:
   - id: 1
     name: publish
-    since: 2.0
+    since: "2.0"
     doc: |
       Publishes the message to all subscribers of this topic
     request:
@@ -13,19 +13,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Topic
         - name: message
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The message to publish to all subscribers of this topic
     response: {}
   - id: 2
     name: addMessageListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Subscribes to this topic. When someone publishes a message on this topic. onMessage() function of the given
       MessageListener is called. More than one message listener can be added on one instance.
@@ -36,13 +36,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Topic
         - name: localOnly
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             if true listens only local events on registered member
     response:
@@ -50,34 +50,34 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             returns the registration id
     events:
       - name: Topic
-        since: 2.0
+        since: "2.0"
         params:
           - name: item
             type: Data
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Item that the event is fired for.
           - name: publishTime
             type: long
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               Time that the item is published to the topic.
           - name: uuid
             type: UUID
             nullable: false
-            since: 2.0
+            since: "2.0"
             doc: |
               UUID of the member that dispatches this event.
   - id: 3
     name: removeMessageListener
-    since: 2.0
+    since: "2.0"
     doc: |
       Stops receiving messages for the given message listener.If the given listener already removed, this method does nothing.
     request:
@@ -87,13 +87,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Topic
         - name: registrationId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Id of listener registration.
     response:
@@ -101,12 +101,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if registration is removed, false otherwise
   - id: 4
     name: publishAll
-    since: 2.1
+    since: "2.1"
     doc: |
       Publishes all messages to all subscribers of this topic
     request:
@@ -116,13 +116,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.1
+          since: "2.1"
           doc: |
             Name of the Topic
         - name: messages
           type: List_Data
           nullable: false
-          since: 2.1
+          since: "2.1"
           doc: |
             The messages to publish to all subscribers of this topic
     response: {}

--- a/protocol-definitions/Transaction.yaml
+++ b/protocol-definitions/Transaction.yaml
@@ -3,7 +3,7 @@ name: Transaction
 methods:
   - id: 1
     name: commit
-    since: 2.0
+    since: "2.0"
     doc: |
       Commits the transaction with the given id.
     request:
@@ -13,19 +13,19 @@ methods:
         - name: transactionId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The internal Hazelcast transaction id.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The thread id for the transaction.
     response: {}
   - id: 2
     name: create
-    since: 2.0
+    since: "2.0"
     doc: |
       Creates a transaction with the given parameters.
     request:
@@ -35,19 +35,19 @@ methods:
         - name: timeout
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The maximum allowed duration for the transaction operations.
         - name: durability
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The durability of the transaction
         - name: transactionType
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Identifies the type of the transaction. Possible values are:
             1 (Two phase):  The two phase commit is more than the classic two phase commit (if you want a regular
@@ -59,7 +59,7 @@ methods:
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The thread id for the transaction.
     response:
@@ -67,12 +67,12 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The transaction id for the created transaction.
   - id: 3
     name: rollback
-    since: 2.0
+    since: "2.0"
     doc: |
       Rollbacks the transaction with the given id.
     request:
@@ -82,13 +82,13 @@ methods:
         - name: transactionId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The internal Hazelcast transaction id.
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The thread id for the transaction.
     response: {}

--- a/protocol-definitions/TransactionalList.yaml
+++ b/protocol-definitions/TransactionalList.yaml
@@ -3,7 +3,7 @@ name: TransactionalList
 methods:
   - id: 1
     name: add
-    since: 2.0
+    since: "2.0"
     doc: |
       Adds a new item to the transactional list.
     request:
@@ -13,25 +13,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional List
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the this transaction operation
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: item
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The new item added to the transactionalList
     response:
@@ -39,12 +39,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if the item is added successfully, false otherwise
   - id: 2
     name: remove
-    since: 2.0
+    since: "2.0"
     doc: |
       Remove item from the transactional list
     request:
@@ -54,25 +54,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional List
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the this transaction operation
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: item
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Item to remove to transactional List
     response:
@@ -80,12 +80,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if the removed successfully,false otherwise
   - id: 3
     name: size
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the size of the list
     request:
@@ -95,19 +95,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional List
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the this transaction operation
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
@@ -115,6 +115,6 @@ methods:
         - name: response
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The size of the list

--- a/protocol-definitions/TransactionalMap.yaml
+++ b/protocol-definitions/TransactionalMap.yaml
@@ -3,7 +3,7 @@ name: TransactionalMap
 methods:
   - id: 1
     name: containsKey
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns true if this map contains an entry for the specified key.
     request:
@@ -13,25 +13,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Map
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the this transaction operation
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The specified key.
     response:
@@ -39,12 +39,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if this map contains an entry for the specified key.
   - id: 2
     name: get
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the value for the specified key, or null if this map does not contain this key.
     request:
@@ -54,25 +54,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Map
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the this transaction operation
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The specified key
     response:
@@ -80,12 +80,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The value for the specified key
   - id: 3
     name: getForUpdate
-    since: 2.0
+    since: "2.0"
     doc: |
       Locks the key and then gets and returns the value to which the specified key is mapped. Lock will be released at
       the end of the transaction (either commit or rollback).
@@ -96,25 +96,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Map
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the this transaction operation
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The value to which the specified key is mapped
     response:
@@ -122,12 +122,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The value for the specified key
   - id: 4
     name: size
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the number of entries in this map.
     request:
@@ -137,19 +137,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Map
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the this transaction operation
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
@@ -157,12 +157,12 @@ methods:
         - name: response
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The number of entries in this map.
   - id: 5
     name: isEmpty
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns true if this map contains no entries.
     request:
@@ -172,19 +172,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Map
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the this transaction operation
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
@@ -192,12 +192,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             <tt>true</tt> if this map contains no entries.
   - id: 6
     name: put
-    since: 2.0
+    since: "2.0"
     doc: |
       Associates the specified value with the specified key in this map. If the map previously contained a mapping for
       the key, the old value is replaced by the specified value. The object to be put will be accessible only in the
@@ -209,37 +209,37 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Map
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the this transaction operation
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The specified key
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The value to associate with the key.
         - name: ttl
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The duration in milliseconds after which this entry shall be deleted. O means infinite.
     response:
@@ -247,12 +247,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             Previous value associated with key or  null if there was no mapping for key
   - id: 7
     name: set
-    since: 2.0
+    since: "2.0"
     doc: |
       Associates the specified value with the specified key in this map. If the map previously contained a mapping for
       the key, the old value is replaced by the specified value. This method is preferred to #put(Object, Object)
@@ -265,37 +265,37 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Map
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the this transaction operation
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The specified key
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The value to associate with key
     response: {}
   - id: 8
     name: putIfAbsent
-    since: 2.0
+    since: "2.0"
     doc: |
       If the specified key is not already associated with a value, associate it with the given value.
       The object to be put will be accessible only in the current transaction context until the transaction is committed.
@@ -306,31 +306,31 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Map
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the this transaction operation
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The specified key
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The value to associate with the key when there is no previous value.
     response:
@@ -338,12 +338,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The previous value associated with key, or null if there was no mapping for key.
   - id: 9
     name: replace
-    since: 2.0
+    since: "2.0"
     doc: |
       Replaces the entry for a key only if it is currently mapped to some value. The object to be replaced will be
       accessible only in the current transaction context until the transaction is committed.
@@ -354,31 +354,31 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Map
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the this transaction operation
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The specified key
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The value replaced the previous value
     response:
@@ -386,12 +386,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The previous value associated with key, or null if there was no mapping for key.
   - id: 10
     name: replaceIfSame
-    since: 2.0
+    since: "2.0"
     doc: |
       Replaces the entry for a key only if currently mapped to a given value. The object to be replaced will be
       accessible only in the current transaction context until the transaction is committed.
@@ -402,37 +402,37 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Map
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the this transaction operation
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The specified key.
         - name: oldValue
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Replace the key value if it is the old value.
         - name: newValue
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The new value to replace the old value.
     response:
@@ -440,12 +440,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             true if the value was replaced.
   - id: 11
     name: remove
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes the mapping for a key from this map if it is present. The map will not contain a mapping for the
       specified key once the call returns. The object to be removed will be accessible only in the current transaction
@@ -457,25 +457,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Map
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the this transaction operation
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Remove the mapping for this key.
     response:
@@ -483,12 +483,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The previous value associated with key, or null if there was no mapping for key
   - id: 12
     name: delete
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes the mapping for a key from this map if it is present. The map will not contain a mapping for the specified
       key once the call returns. This method is preferred to #remove(Object) if the old value is not needed. The object
@@ -500,31 +500,31 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Map
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the this transaction operation
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Remove the mapping for this key.
     response: {}
   - id: 13
     name: removeIfSame
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes the entry for a key only if currently mapped to a given value. The object to be removed will be removed
       from only the current transaction context until the transaction is committed.
@@ -535,31 +535,31 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Map
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the this transaction operation
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The specified key
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Remove the key if it has this value.
     response:
@@ -567,12 +567,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if the value was removed
   - id: 14
     name: keySet
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns a set clone of the keys contained in this map. The set is NOT backed by the map, so changes to the map
       are NOT reflected in the set, and vice-versa. This method is always executed by a distributed query, so it may throw
@@ -584,19 +584,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Map
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the this transaction operation
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
@@ -604,12 +604,12 @@ methods:
         - name: response
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             A set clone of the keys contained in this map.
   - id: 15
     name: keySetWithPredicate
-    since: 2.0
+    since: "2.0"
     doc: |
       Queries the map based on the specified predicate and returns the keys of matching entries. Specified predicate
       runs on all members in parallel.The set is NOT backed by the map, so changes to the map are NOT reflected in the
@@ -622,25 +622,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Map
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the this transaction operation
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: predicate
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Specified query criteria.
     response:
@@ -648,12 +648,12 @@ methods:
         - name: response
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Result key set for the query.
   - id: 16
     name: values
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns a collection clone of the values contained in this map. The collection is NOT backed by the map,
       so changes to the map are NOT reflected in the collection, and vice-versa. This method is always executed by a
@@ -665,19 +665,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Map
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the this transaction operation
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
@@ -685,12 +685,12 @@ methods:
         - name: response
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             All values in the map
   - id: 17
     name: valuesWithPredicate
-    since: 2.0
+    since: "2.0"
     doc: |
       Queries the map based on the specified predicate and returns the values of matching entries.Specified predicate
       runs on all members in parallel. The collection is NOT backed by the map, so changes to the map are NOT reflected
@@ -703,25 +703,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Map
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the this transaction operation
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: predicate
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Specified query criteria.
     response:
@@ -729,12 +729,12 @@ methods:
         - name: response
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Result value collection of the query.
   - id: 18
     name: containsValue
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns true if this map contains an entry for the specified value.
     request:
@@ -744,25 +744,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Map
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the this transaction operation
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The specified value.
     response:
@@ -770,6 +770,6 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if this map contains an entry for the specified key.

--- a/protocol-definitions/TransactionalMultiMap.yaml
+++ b/protocol-definitions/TransactionalMultiMap.yaml
@@ -3,7 +3,7 @@ name: TransactionalMultiMap
 methods:
   - id: 1
     name: put
-    since: 2.0
+    since: "2.0"
     doc: |
       Stores a key-value pair in the multimap.
     request:
@@ -13,31 +13,31 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Multi Map
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the transaction
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The key to be stored
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The value to be stored
     response:
@@ -45,12 +45,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if the size of the multimap is increased, false if the multimap already contains the key-value pair.
   - id: 2
     name: get
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the collection of values associated with the key.
     request:
@@ -60,25 +60,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Multi Map
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the transaction
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The key whose associated values are returned
     response:
@@ -86,12 +86,12 @@ methods:
         - name: response
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The collection of the values associated with the key
   - id: 3
     name: remove
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes the given key value pair from the multimap.
     request:
@@ -101,25 +101,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Multi Map
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the transaction
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The key whose associated values are returned
     response:
@@ -127,12 +127,12 @@ methods:
         - name: response
           type: List_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if the size of the multimap changed after the remove operation, false otherwise.
   - id: 4
     name: removeEntry
-    since: 2.0
+    since: "2.0"
     doc: |
       Removes all the entries associated with the given key.
     request:
@@ -142,31 +142,31 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Multi Map
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the this transaction operation
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The key whose associated values are returned
         - name: value
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The value to be stored
     response:
@@ -174,12 +174,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if the size of the multimap changed after the remove operation, false otherwise.
   - id: 5
     name: valueCount
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the number of values matching the given key in the multimap.
     request:
@@ -189,25 +189,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Multi Map
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the this transaction operation
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: key
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The key whose number of values are returned
     response:
@@ -215,12 +215,12 @@ methods:
         - name: response
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The number of values matching the given key in the multimap
   - id: 6
     name: size
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the number of key-value pairs in the multimap.
     request:
@@ -230,19 +230,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Multi Map
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the this transaction operation
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
@@ -250,6 +250,6 @@ methods:
         - name: response
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The number of key-value pairs in the multimap

--- a/protocol-definitions/TransactionalQueue.yaml
+++ b/protocol-definitions/TransactionalQueue.yaml
@@ -3,7 +3,7 @@ name: TransactionalQueue
 methods:
   - id: 1
     name: offer
-    since: 2.0
+    since: "2.0"
     doc: |
       Inserts the specified element into this queue, waiting up to the specified wait time if necessary for space to
       become available.
@@ -14,31 +14,31 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Queue
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the transaction
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: item
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The element to add
         - name: timeout
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             How long to wait before giving up, in milliseconds
     response:
@@ -46,12 +46,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             <tt>true</tt> if successful, or <tt>false</tt> if the specified waiting time elapses before space is available
   - id: 2
     name: take
-    since: 2.0
+    since: "2.0"
     doc: |
       Retrieves and removes the head of this queue, waiting if necessary until an element becomes available.
     request:
@@ -61,19 +61,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Queue
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the transaction
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
@@ -81,12 +81,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The head of this queue
   - id: 3
     name: poll
-    since: 2.0
+    since: "2.0"
     doc: |
       Retrieves and removes the head of this queue, waiting up to the specified wait time if necessary for an element
       to become available.
@@ -97,25 +97,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Queue
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the transaction
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: timeout
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             How long to wait before giving up, in milliseconds
     response:
@@ -123,12 +123,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The head of this queue, or <tt>null</tt> if the specified waiting time elapses before an element is available
   - id: 4
     name: peek
-    since: 2.0
+    since: "2.0"
     doc: |
       Retrieves, but does not remove, the head of this queue, or returns null if this queue is empty.
     request:
@@ -138,25 +138,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Queue
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the transaction
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: timeout
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             How long to wait before giving up, in milliseconds
     response:
@@ -164,12 +164,12 @@ methods:
         - name: response
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
           doc: |
             The value at the head of the queue.
   - id: 5
     name: size
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the number of elements in this collection.If this collection contains more than Integer.MAX_VALUE
       elements, returns Integer.MAX_VALUE.
@@ -180,19 +180,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Queue
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the transaction
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
@@ -200,6 +200,6 @@ methods:
         - name: response
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The number of elements in this collection

--- a/protocol-definitions/TransactionalSet.yaml
+++ b/protocol-definitions/TransactionalSet.yaml
@@ -3,7 +3,7 @@ name: TransactionalSet
 methods:
   - id: 1
     name: add
-    since: 2.0
+    since: "2.0"
     doc: |
       Add new item to transactional set.
     request:
@@ -13,25 +13,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Set
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the this transaction operation
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: item
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Item added to transactional set
     response:
@@ -39,12 +39,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if item is added successfully
   - id: 2
     name: remove
-    since: 2.0
+    since: "2.0"
     doc: |
       Remove item from transactional set.
     request:
@@ -54,25 +54,25 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Set
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the this transaction operation
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
         - name: item
           type: Data
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Item removed from Transactional Set
     response:
@@ -80,12 +80,12 @@ methods:
         - name: response
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             True if item is remove successfully
   - id: 3
     name: size
-    since: 2.0
+    since: "2.0"
     doc: |
       Returns the size of the set.
     request:
@@ -95,19 +95,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Name of the Transactional Set
         - name: txnId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             ID of the this transaction operation
         - name: threadId
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the user thread performing the operation. It is used to guarantee that only the lock holder thread (if a lock exists on the entry) can perform the requested operation.
     response:
@@ -115,6 +115,6 @@ methods:
         - name: response
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The size of the set

--- a/protocol-definitions/VectorCollection.yaml
+++ b/protocol-definitions/VectorCollection.yaml
@@ -3,7 +3,7 @@ name: VectorCollection
 methods:
   - id: 1
     name: put
-    since: 2.8
+    since: "2.8"
     doc: |
       Puts a document into the Vector Collection.
     request:
@@ -13,19 +13,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             Name of the Vector Collection.
         - name: key
           type: Data
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             Key for the document.
         - name: value
           type: VectorDocument
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             Value for the entry.
     response:
@@ -33,13 +33,13 @@ methods:
         - name: value
           type: VectorDocument
           nullable: true
-          since: 2.8
+          since: "2.8"
           doc: |
             Value previously associated with the key if any.
 
   - id: 2
     name: putIfAbsent
-    since: 2.8
+    since: "2.8"
     doc: |
       Puts an entry into this map if the specified key is not already associated with a value.
     request:
@@ -49,19 +49,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             Name of the Vector Collection.
         - name: key
           type: Data
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             Key for the document.
         - name: value
           type: VectorDocument
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             Value for the entry.
     response:
@@ -69,13 +69,13 @@ methods:
         - name: value
           type: VectorDocument
           nullable: true
-          since: 2.8
+          since: "2.8"
           doc: |
             Value previously associated with the key if any.
 
   - id: 3
     name: putAll
-    since: 2.8
+    since: "2.8"
     doc: |
       The effect of this call is equivalent to set(k, v) on this VectorCollection once for each mapping from key k to value v.
       The behavior of this operation is undefined if the specified collection is modified while the operation is in progress.
@@ -89,20 +89,20 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             Name of the Vector Collection.
         - name: entries
           type: EntryList_Data_VectorDocument
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             Key/VectorDocument entries to be stored in this VectorCollection.
     response: {}
 
   - id: 4
     name: get
-    since: 2.8
+    since: "2.8"
     doc: |
       Returns the VectorDocument for the given key.
     request:
@@ -112,13 +112,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             Name of the Vector Collection.
         - name: key
           type: Data
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             Key for the document.
     response:
@@ -126,13 +126,13 @@ methods:
         - name: value
           type: VectorDocument
           nullable: true
-          since: 2.8
+          since: "2.8"
           doc: |
             The value for the key if it exists.
 
   - id: 5
     name: remove
-    since: 2.8
+    since: "2.8"
     doc: |
       Removes the mapping for a key from this VectorCollection.
     request:
@@ -142,13 +142,13 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             Name of the VectorCollection.
         - name: key
           type: Data
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             Key for the entry.
     response:
@@ -156,13 +156,13 @@ methods:
         - name: value
           type: VectorDocument
           nullable: true
-          since: 2.8
+          since: "2.8"
           doc: |
             Value previously associated with the key if any.
 
   - id: 6
     name: set
-    since: 2.8
+    since: "2.8"
     doc: |
       Puts a document into the Vector Collection without returning previous value.
     request:
@@ -172,26 +172,26 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             Name of the Vector Collection.
         - name: key
           type: Data
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             Key for the document.
         - name: value
           type: VectorDocument
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             Value for the entry.
     response: {}
 
   - id: 7
     name: delete
-    since: 2.8
+    since: "2.8"
     doc: |
       Removes the mapping for a key from this VectorCollection without returning previous value.
     request:
@@ -201,20 +201,20 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             Name of the VectorCollection.
         - name: key
           type: Data
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             Key for the entry.
     response: {}
 
   - id: 8
     name: searchNearVector
-    since: 2.8
+    since: "2.8"
     doc: |
       Returns the VectorDocuments closest to the given vector.
     request:
@@ -224,19 +224,19 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             Name of the Vector Collection.
         - name: vectors
           type: List_VectorPair
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             Vector for which closest neighbours should be returned.
         - name: options
           type: VectorSearchOptions
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             Search options.
     response:
@@ -244,13 +244,13 @@ methods:
         - name: result
           nullable: false
           type: List_VectorSearchResult
-          since: 2.8
+          since: "2.8"
           doc: |
             Zero or more VectorSearchResult values.
 
   - id: 9
     name: optimize
-    since: 2.8
+    since: "2.8"
     doc: |
       Optimize index.
     request:
@@ -260,27 +260,27 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             Name of the Vector Collection.
         - name: indexName
           type: String
           nullable: true
-          since: 2.8
+          since: "2.8"
           doc: |
             Name of the Index to optimize.
             A null value triggers the optimization of the only index within the collection.
         - name: uuid
           type: UUID
           nullable: true
-          since: 2.9
+          since: "2.9"
           doc: |
             UUID of this optimization request.
     response: {}
 
   - id: 10
     name: clear
-    since: 2.8
+    since: "2.8"
     doc: |
       Clear vector collection.
     request:
@@ -290,14 +290,14 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             Name of the Vector Collection.
     response: { }
 
   - id: 11
     name: size
-    since: 2.8
+    since: "2.8"
     doc: |
       Size of vector collection.
     request:
@@ -307,7 +307,7 @@ methods:
         - name: name
           type: String
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             Name of the Vector Collection.
     response:
@@ -315,6 +315,6 @@ methods:
         - name: response
           type: long
           nullable: false
-          since: 2.8
+          since: "2.8"
           doc: |
             the number of entries in this collection

--- a/protocol-definitions/XATransaction.yaml
+++ b/protocol-definitions/XATransaction.yaml
@@ -3,7 +3,7 @@ name: XATransaction
 methods:
   - id: 1
     name: clearRemote
-    since: 2.0
+    since: "2.0"
     doc: |
       Clears the XA transaction with the given xid from remote member.
     request:
@@ -13,13 +13,13 @@ methods:
         - name: xid
           type: Xid
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Java XA transaction id as defined in interface javax.transaction.xa.Xid.
     response: {}
   - id: 2
     name: collectTransactions
-    since: 2.0
+    since: "2.0"
     doc: |
       Obtains a list of prepared transaction from the cluster.
     request:
@@ -30,12 +30,12 @@ methods:
         - name: response
           type: List_Xid
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Array of Xids.
   - id: 3
     name: finalize
-    since: 2.0
+    since: "2.0"
     doc: |
       Finalizes the commit of XA transaction with the given xid.
     request:
@@ -45,19 +45,19 @@ methods:
         - name: xid
           type: Xid
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Java XA transaction id as defined in interface javax.transaction.xa.Xid.
         - name: isCommit
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             If true, the transaction is committed else transaction is rolled back.
     response: {}
   - id: 4
     name: commit
-    since: 2.0
+    since: "2.0"
     doc: |
       Commits the global transaction specified by xid.
     request:
@@ -67,19 +67,19 @@ methods:
         - name: transactionId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The internal Hazelcast transaction id.
         - name: onePhase
           type: boolean
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             If true, the prepare is also done.
     response: {}
   - id: 5
     name: create
-    since: 2.0
+    since: "2.0"
     doc: |
       Creates an XA transaction with the given parameters.
     request:
@@ -89,13 +89,13 @@ methods:
         - name: xid
           type: Xid
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             Java XA transaction id as defined in interface javax.transaction.xa.Xid.
         - name: timeout
           type: long
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The timeout in seconds for XA operations such as prepare, commit, rollback.
     response:
@@ -103,12 +103,12 @@ methods:
         - name: response
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The transaction unique identifier.
   - id: 6
     name: prepare
-    since: 2.0
+    since: "2.0"
     doc: |
       Ask a member to prepare for a transaction commit of the transaction specified in xid.
     request:
@@ -118,13 +118,13 @@ methods:
         - name: transactionId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the transaction to prepare.
     response: {}
   - id: 7
     name: rollback
-    since: 2.0
+    since: "2.0"
     doc: |
       Informs the member to roll back work done on behalf of a transaction.
     request:
@@ -134,7 +134,7 @@ methods:
         - name: transactionId
           type: UUID
           nullable: false
-          since: 2.0
+          since: "2.0"
           doc: |
             The id of the transaction to rollback.
     response: {}

--- a/protocol-definitions/custom/Custom.yaml
+++ b/protocol-definitions/custom/Custom.yaml
@@ -1,1633 +1,1633 @@
 customTypes:
   - name: Address
-    since: 2.0
+    since: "2.0"
     returnWithFactory: true
     params:
       - name: host
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: port
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
   - name: CacheEventData
-    since: 2.0
+    since: "2.0"
     returnWithFactory: true
     params:
       - name: name
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: cacheEventType
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: dataKey
         type: Data
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: dataValue
         type: Data
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: dataOldValue
         type: Data
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: oldValueAvailable
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
   - name: CacheSimpleEntryListenerConfig
-    since: 2.0
+    since: "2.0"
     returnWithFactory: true
     params:
       - name: oldValueRequired
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: synchronous
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: cacheEntryListenerFactory
         type: String
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: cacheEntryEventFilterFactory
         type: String
         nullable: true
-        since: 2.0
+        since: "2.0"
   - name: DistributedObjectInfo
-    since: 2.0
+    since: "2.0"
     params:
       - name: serviceName
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: name
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
   - name: ErrorHolder
-    since: 2.0
+    since: "2.0"
     params:
       - name: errorCode
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: className
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: message
         type: String
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: stackTraceElements
         type: List_StackTraceElement
         nullable: false
-        since: 2.0
+        since: "2.0"
   - name: EventJournalConfig
-    since: 2.0
+    since: "2.0"
     returnWithFactory: true
     params:
       - name: enabled
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: capacity
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: timeToLiveSeconds
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
   - name: EvictionConfigHolder
-    since: 2.0
+    since: "2.0"
     params:
       - name: size
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: maxSizePolicy
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: evictionPolicy
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: comparatorClassName
         type: String
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: comparator
         type: Data
         nullable: true
-        since: 2.0
+        since: "2.0"
   - name: HotRestartConfig
-    since: 2.0
+    since: "2.0"
     returnWithFactory: true
     params:
       - name: enabled
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: fsync
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
   - name: ListenerConfigHolder
-    since: 2.0
+    since: "2.0"
     params:
       - name: listenerType
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: listenerImplementation
         type: Data
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: className
         type: String
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: includeValue
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: local
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
   - name: AttributeConfig
-    since: 2.0
+    since: "2.0"
     params:
       - name: name
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: extractorClassName
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
   - name: IndexConfig
-    since: 2.0
+    since: "2.0"
     returnWithFactory: true
     params:
       - name: name
         type: String
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: type
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: attributes
         type: List_String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: bitmapIndexOptions
         type: BitmapIndexOptions
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: bTreeIndexConfig
         type: BTreeIndexConfig
         nullable: true
-        since: 2.5
+        since: "2.5"
   - name: BitmapIndexOptions
-    since: 2.0
+    since: "2.0"
     returnWithFactory: true
     params:
       - name: uniqueKey
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: uniqueKeyTransformation
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
   - name: BTreeIndexConfig
-    since: 2.5
+    since: "2.5"
     returnWithFactory: true
     params:
       - name: pageSize
         type: Capacity
         nullable: false
-        since: 2.5
+        since: "2.5"
       - name: memoryTierConfig
         type: MemoryTierConfig
         nullable: false
-        since: 2.5
+        since: "2.5"
   - name: MapStoreConfigHolder
-    since: 2.0
+    since: "2.0"
     params:
       - name: enabled
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: writeCoalescing
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: writeDelaySeconds
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: writeBatchSize
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: className
         type: String
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: implementation
         type: Data
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: factoryClassName
         type: String
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: factoryImplementation
         type: Data
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: properties
         type: Map_String_String
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: initialLoadMode
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: offload
         type: boolean
         nullable: false
-        since: 2.5
+        since: "2.5"
   - name: MerkleTreeConfig
-    since: 2.0
+    since: "2.0"
     returnWithFactory: true
     params:
       - name: enabled
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: depth
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: enabledSet
         type: boolean
         nullable: false
-        since: 2.3
+        since: "2.3"
   - name: NearCacheConfigHolder
-    since: 2.0
+    since: "2.0"
     params:
       - name: name
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: inMemoryFormat
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: serializeKeys
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: invalidateOnChange
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: timeToLiveSeconds
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: maxIdleSeconds
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: evictionConfigHolder
         type: EvictionConfigHolder
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: cacheLocalEntries
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: localUpdatePolicy
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: preloaderConfig
         type: NearCachePreloaderConfig
         nullable: true
-        since: 2.0
+        since: "2.0"
   - name: NearCachePreloaderConfig
-    since: 2.0
+    since: "2.0"
     returnWithFactory: true
     params:
       - name: enabled
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: directory
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: storeInitialDelaySeconds
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: storeIntervalSeconds
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
   - name: PredicateConfigHolder
-    since: 2.0
+    since: "2.0"
     params:
       - name: className
         type: String
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: sql
         type: String
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: implementation
         type: Data
         nullable: true
-        since: 2.0
+        since: "2.0"
   - name: QueryCacheConfigHolder
-    since: 2.0
+    since: "2.0"
     params:
       - name: batchSize
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: bufferSize
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: delaySeconds
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: includeValue
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: populate
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: coalesce
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: inMemoryFormat
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: name
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: predicateConfigHolder
         type: PredicateConfigHolder
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: evictionConfigHolder
         type: EvictionConfigHolder
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: listenerConfigs
         type: List_ListenerConfigHolder
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: indexConfigs
         type: List_IndexConfig
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: serializeKeys
         type: boolean
         nullable: false
-        since: 2.4
+        since: "2.4"
   - name: QueryCacheEventData
-    since: 2.0
+    since: "2.0"
     returnWithFactory: true
     params:
       - name: dataKey
         type: Data
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: dataNewValue
         type: Data
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: sequence
         type: long
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: eventType
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: partitionId
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: mapName
         type: String
         nullable: false
-        since: 2.7
+        since: "2.7"
   - name: QueueStoreConfigHolder
-    since: 2.0
+    since: "2.0"
     params:
       - name: className
         type: String
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: factoryClassName
         type: String
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: implementation
         type: Data
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: factoryImplementation
         type: Data
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: properties
         type: Map_String_String
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: enabled
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
   - name: RaftGroupId
-    since: 2.0
+    since: "2.0"
     params:
       - name: name
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: seed
         type: long
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: id
         type: long
         nullable: false
-        since: 2.0
+        since: "2.0"
   - name: RingbufferStoreConfigHolder
-    since: 2.0
+    since: "2.0"
     params:
       - name: className
         type: String
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: factoryClassName
         type: String
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: implementation
         type: Data
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: factoryImplementation
         type: Data
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: properties
         type: Map_String_String
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: enabled
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
   - name: ScheduledTaskHandler
-    since: 2.0
+    since: "2.0"
     params:
       - name: uuid
         type: UUID
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: partitionId
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: schedulerName
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: taskName
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
   - name: SimpleEntryView
-    since: 2.0
+    since: "2.0"
     returnWithFactory: true
     params:
       - name: key
         type: Data
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: value
         type: Data
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: cost
         type: long
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: creationTime
         type: long
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: expirationTime
         type: long
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: hits
         type: long
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: lastAccessTime
         type: long
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: lastStoredTime
         type: long
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: lastUpdateTime
         type: long
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: version
         type: long
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: ttl
         type: long
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: maxIdle
         type: long
         nullable: false
-        since: 2.0
+        since: "2.0"
   - name: StackTraceElement
-    since: 2.0
+    since: "2.0"
     params:
       - name: className
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: methodName
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: fileName
         type: String
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: lineNumber
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
   - name: DurationConfig
-    since: 2.0
+    since: "2.0"
     returnWithFactory: true
     params:
       - name: durationAmount
         type: long
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: timeUnit
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
   - name: TimedExpiryPolicyFactoryConfig
-    since: 2.0
+    since: "2.0"
     returnWithFactory: true
     params:
       - name: expiryPolicyType
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: durationConfig
         type: DurationConfig
         nullable: False
-        since: 2.0
+        since: "2.0"
   - name: WanReplicationRef
-    since: 2.0
+    since: "2.0"
     params:
       - name: name
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: mergePolicyClassName
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: filters
         type: List_String
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: republishingEnabled
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
   - name: Xid
-    since: 2.0
+    since: "2.0"
     params:
       - name: formatId
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: globalTransactionId
         type: byteArray
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: branchQualifier
         type: byteArray
         nullable: false
-        since: 2.0
+        since: "2.0"
   - name: MergePolicyConfig
-    since: 2.0
+    since: "2.0"
     params:
       - name: policy
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: batchSize
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
   - name: CacheConfigHolder
-    since: 2.0
+    since: "2.0"
     params:
       - name: name
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: managerPrefix
         type: String
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: uriString
         type: String
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: backupCount
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: asyncBackupCount
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: inMemoryFormat
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: evictionConfigHolder
         type: EvictionConfigHolder
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: wanReplicationRef
         type: WanReplicationRef
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: keyClassName
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: valueClassName
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: cacheLoaderFactory
         type: Data
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: cacheWriterFactory
         type: Data
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: expiryPolicyFactory
         type: Data
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: readThrough
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: writeThrough
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: storeByValue
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: managementEnabled
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: statisticsEnabled
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: hotRestartConfig
         type: HotRestartConfig
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: eventJournalConfig
         type: EventJournalConfig
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: splitBrainProtectionName
         type: String
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: listenerConfigurations
         type: List_Data
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: mergePolicyConfig
         type: MergePolicyConfig
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: disablePerEntryInvalidationEvents
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: cachePartitionLostListenerConfigs
         type: List_ListenerConfigHolder
         nullable: true
-        since: 2.0
+        since: "2.0"
       - name: merkleTreeConfig
         type: MerkleTreeConfig
         nullable: true
-        since: 2.3
+        since: "2.3"
       - name: dataPersistenceConfig
         type: DataPersistenceConfig
         nullable: false
-        since: 2.5
+        since: "2.5"
       - name: userCodeNamespace
         type: String
         nullable: true
-        since: 2.7
+        since: "2.7"
   - name: ClientBwListEntry
-    since: 2.0
+    since: "2.0"
     returnWithFactory: true
     params:
       - name: type
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: value
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
   - name: MemberInfo
-    since: 2.0
+    since: "2.0"
     params:
       - name: address
         type: Address
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: uuid
         type: UUID
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: attributes
         type: Map_String_String
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: liteMember
         type: boolean
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: version
         type: MemberVersion
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: addressMap
         type: Map_EndpointQualifier_Address
         nullable: false
-        since: 2.0.1
+        since: "2.0.1"
   - name: EndpointQualifier
     returnWithFactory: true
-    since: 2.0.1
+    since: "2.0.1"
     params:
       - name: type
         type: int
         nullable: false
-        since: 2.0.1
+        since: "2.0.1"
       - name: identifier
         type: String
-        since: 2.0.1
+        since: "2.0.1"
         nullable: true
   - name: MemberVersion
-    since: 2.0
+    since: "2.0"
     params:
       - name: major
         type: byte
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: minor
         type: byte
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: patch
         type: byte
         nullable: false
-        since: 2.0
+        since: "2.0"
   - name: MCEvent
-    since: 2.0
+    since: "2.0"
     params:
       - name: timestamp
         type: long
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: type
         type: int
         nullable: false
-        since: 2.0
+        since: "2.0"
       - name: dataJson
         type: String
         nullable: false
-        since: 2.0
+        since: "2.0"
   - name: AnchorDataListHolder
-    since: 2.0
+    since: "2.0"
     params:
         - name: anchorPageList
           type: List_Integer
           nullable: false
-          since: 2.0
+          since: "2.0"
         - name: anchorDataList
           type: EntryList_Data_Data
           nullable: false
-          since: 2.0
+          since: "2.0"
   - name: PagingPredicateHolder
-    since: 2.0
+    since: "2.0"
     params:
         - name: anchorDataListHolder
           type: AnchorDataListHolder
           nullable: false
-          since: 2.0
+          since: "2.0"
         - name: predicateData
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
         - name: comparatorData
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
         - name: pageSize
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
         - name: page
           type: int
           nullable: false
-          since: 2.0
+          since: "2.0"
         - name: iterationTypeId
           type: byte
           nullable: false
-          since: 2.0
+          since: "2.0"
         - name: partitionKeyData
           type: Data
           nullable: true
-          since: 2.0
+          since: "2.0"
         - name: partitionKeysData
           type: List_Data
           nullable: true
-          since: 2.5
+          since: "2.5"
   - name: SqlQueryId
-    since: 2.1
+    since: "2.1"
     params:
       - name: memberIdHigh
         type: long
         nullable: false
-        since: 2.1
+        since: "2.1"
       - name: memberIdLow
         type: long
         nullable: false
-        since: 2.1
+        since: "2.1"
       - name: localIdHigh
         type: long
         nullable: false
-        since: 2.1
+        since: "2.1"
       - name: localIdLow
         type: long
         nullable: false
-        since: 2.1
+        since: "2.1"
   - name: SqlError
-    since: 2.1
+    since: "2.1"
     params:
       - name: code
         type: int
         nullable: false
-        since: 2.1
+        since: "2.1"
       - name: message
         type: String
         nullable: true
-        since: 2.1
+        since: "2.1"
       - name: originatingMemberId
         type: UUID
         nullable: false
-        since: 2.1
+        since: "2.1"
       - name: suggestion
         type: String
         nullable: true
-        since: 2.3
+        since: "2.3"
       - name: causeStackTrace
         type: String
         nullable: true
-        since: 2.7
+        since: "2.7"
   - name: SqlColumnMetadata
-    since: 2.1
+    since: "2.1"
     returnWithFactory: true
     params:
       - name: name
         type: String
         nullable: false
-        since: 2.1
+        since: "2.1"
       - name: type
         type: int
         nullable: false
-        since: 2.1
+        since: "2.1"
       - name: nullable
         type: boolean
         nullable: false
-        since: 2.2
+        since: "2.2"
   - name: CPMember
-    since: 2.1
+    since: "2.1"
     params:
       - name: uuid
         type: UUID
         nullable: false
-        since: 2.1
+        since: "2.1"
       - name: address
         type: Address
         nullable: false
-        since: 2.1
+        since: "2.1"
       - name: autoStepDownWhenLeader
         type: boolean
         nullable: false
-        since: 2.9
+        since: "2.10"
   - name: MigrationState
-    since: 2.2
+    since: "2.2"
     params:
       - name: startTime
         type: long
         nullable: false
-        since: 2.2
+        since: "2.2"
       - name: plannedMigrations
         type: int
         nullable: false
-        since: 2.2
+        since: "2.2"
       - name: completedMigrations
         type: int
         nullable: false
-        since: 2.2
+        since: "2.2"
       - name: totalElapsedTime
         type: long
         nullable: false
-        since: 2.2
+        since: "2.2"
   - name: FieldDescriptor
-    since: 2.3
+    since: "2.3"
     returnWithFactory: true
     params:
       - name: fieldName
         type: String
         nullable: false
-        since: 2.3
+        since: "2.3"
       - name: kind
         type: int
         nullable: false
-        since: 2.3
+        since: "2.3"
   - name: Schema
-    since: 2.3
+    since: "2.3"
     returnWithFactory: true
     params:
       - name: typeName
         type: String
         nullable: false
-        since: 2.3
+        since: "2.3"
       - name: fields
         type: List_FieldDescriptor
         nullable: false
-        since: 2.3
+        since: "2.3"
   - name: HazelcastJsonValue
-    since: 2.4
+    since: "2.4"
     returnWithFactory: true
     params:
       - name: value
         type: String
         nullable: false
-        since: 2.4
+        since: "2.4"
   - name: DataPersistenceConfig
-    since: 2.5
+    since: "2.5"
     returnWithFactory: true
     params:
       - name: enabled
         type: boolean
         nullable: false
-        since: 2.5
+        since: "2.5"
       - name: fsync
         type: boolean
         nullable: false
-        since: 2.5
+        since: "2.5"
   - name: Capacity
-    since: 2.5
+    since: "2.5"
     returnWithFactory: true
     params:
       - name: value
         type: long
         nullable: false
-        since: 2.5
+        since: "2.5"
       - name: unit
         type: int
         nullable: false
-        since: 2.5
+        since: "2.5"
   - name: MemoryTierConfig
-    since: 2.5
+    since: "2.5"
     returnWithFactory: true
     params:
       - name: capacity
         type: Capacity
         nullable: false
-        since: 2.5
+        since: "2.5"
   - name: DiskTierConfig
-    since: 2.5
+    since: "2.5"
     returnWithFactory: true
     params:
       - name: enabled
         type: boolean
         nullable: false
-        since: 2.5
+        since: "2.5"
       - name: deviceName
         type: String
         nullable: false
-        since: 2.5
+        since: "2.5"
   - name: TieredStoreConfig
-    since: 2.5
+    since: "2.5"
     returnWithFactory: true
     params:
       - name: enabled
         type: boolean
         nullable: false
-        since: 2.5
+        since: "2.5"
       - name: memoryTierConfig
         type: MemoryTierConfig
         nullable: false
-        since: 2.5
+        since: "2.5"
       - name: diskTierConfig
         type: DiskTierConfig
         nullable: false
-        since: 2.5
+        since: "2.5"
   - name: SqlSummary
-    since: 2.5
+    since: "2.5"
     returnWithFactory: true
     params:
       - name: query
         type: String
         nullable: false
-        since: 2.5
+        since: "2.5"
       - name: unbounded
         type: boolean
         nullable: false
-        since: 2.5
+        since: "2.5"
   - name: JobAndSqlSummary
-    since: 2.5
+    since: "2.5"
     returnWithFactory: true
     params:
       - name: lightJob
         type: boolean
         nullable: false
-        since: 2.5
+        since: "2.5"
       - name: jobId
         type: long
         nullable: false
-        since: 2.5
+        since: "2.5"
       - name: executionId
         type: long
         nullable: false
-        since: 2.5
+        since: "2.5"
       - name: nameOrId
         type: String
         nullable: false
-        since: 2.5
+        since: "2.5"
       - name: status
         type: int
         nullable: false
-        since: 2.5
+        since: "2.5"
       - name: submissionTime
         type: long
         nullable: false
-        since: 2.5
+        since: "2.5"
       - name: completionTime
         type: long
         nullable: false
-        since: 2.5
+        since: "2.5"
       - name: failureText
         type: String
         nullable: true
-        since: 2.5
+        since: "2.5"
       - name: sqlSummary
         type: SqlSummary
         nullable: true
-        since: 2.5
+        since: "2.5"
       - name: suspensionCause
         type: String
         nullable: true
-        since: 2.6
+        since: "2.6"
       - name: userCancelled
         type: boolean
         nullable: false
-        since: 2.6
+        since: "2.6"
   - name: PartitioningAttributeConfig
-    since: 2.6
+    since: "2.6"
     params:
       - name: attributeName
         type: String
         nullable: false
-        since: 2.6
+        since: "2.6"
   - name: WanConsumerConfigHolder
-    since: 2.7
+    since: "2.7"
     params:
       - name: persistWanReplicatedData
         type: boolean
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: className
         type: String
         nullable: true
-        since: 2.7
+        since: "2.7"
       - name: implementation
         type: Data
         nullable: true
-        since: 2.7
+        since: "2.7"
       - name: properties
         type: Map_String_Data
         nullable: false
-        since: 2.7
+        since: "2.7"
   - name: WanCustomPublisherConfigHolder
-    since: 2.7
+    since: "2.7"
     params:
       - name: publisherId
         type: String
         nullable: true
-        since: 2.7
+        since: "2.7"
       - name: className
         type: String
         nullable: true
-        since: 2.7
+        since: "2.7"
       - name: implementation
         type: Data
         nullable: true
-        since: 2.7
+        since: "2.7"
       - name: properties
         type: Map_String_Data
         nullable: false
-        since: 2.7
+        since: "2.7"
   - name: WanBatchPublisherConfigHolder
-    since: 2.7
+    since: "2.7"
     params:
       - name: publisherId
         type: String
         nullable: true
-        since: 2.7
+        since: "2.7"
       - name: className
         type: String
         nullable: true
-        since: 2.7
+        since: "2.7"
       - name: implementation
         type: Data
         nullable: true
-        since: 2.7
+        since: "2.7"
       - name: properties
         type: Map_String_Data
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: clusterName
         type: String
         nullable: true
-        since: 2.7
+        since: "2.7"
       - name: snapshotEnabled
         type: boolean
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: initialPublisherState
         type: byte
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: queueCapacity
         type: int
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: batchSize
         type: int
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: batchMaxDelayMillis
         type: int
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: responseTimeoutMillis
         type: int
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: queueFullBehavior
         type: int
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: acknowledgeType
         type: int
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: discoveryPeriodSeconds
         type: int
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: maxTargetEndpoints
         type: int
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: maxConcurrentInvocations
         type: int
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: useEndpointPrivateAddress
         type: boolean
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: idleMinParkNs
         type: long
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: idleMaxParkNs
         type: long
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: targetEndpoints
         type: String
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: awsConfig
         type: AwsConfig
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: gcpConfig
         type: GcpConfig
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: azureConfig
         type: AzureConfig
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: kubernetesConfig
         type: KubernetesConfig
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: eurekaConfig
         type: EurekaConfig
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: discoveryConfig
         type: DiscoveryConfig
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: syncConfig
         type: WanSyncConfig
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: endpoint
         type: String
         nullable: true
-        since: 2.7
+        since: "2.7"
   - name: AwsConfig
-    since: 2.7
+    since: "2.7"
     params:
       - name: tag
         type: String
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: enabled
         type: boolean
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: usePublicIp
         type: boolean
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: properties
         type: Map_String_String
         nullable: false
-        since: 2.7
+        since: "2.7"
   - name: GcpConfig
-    since: 2.7
+    since: "2.7"
     params:
       - name: tag
         type: String
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: enabled
         type: boolean
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: usePublicIp
         type: boolean
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: properties
         type: Map_String_String
         nullable: false
-        since: 2.7
+        since: "2.7"
   - name: AzureConfig
-    since: 2.7
+    since: "2.7"
     params:
       - name: tag
         type: String
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: enabled
         type: boolean
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: usePublicIp
         type: boolean
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: properties
         type: Map_String_String
         nullable: false
-        since: 2.7
+        since: "2.7"
   - name: KubernetesConfig
-    since: 2.7
+    since: "2.7"
     params:
       - name: tag
         type: String
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: enabled
         type: boolean
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: usePublicIp
         type: boolean
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: properties
         type: Map_String_String
         nullable: false
-        since: 2.7
+        since: "2.7"
   - name: EurekaConfig
-    since: 2.7
+    since: "2.7"
     params:
       - name: tag
         type: String
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: enabled
         type: boolean
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: usePublicIp
         type: boolean
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: properties
         type: Map_String_String
         nullable: false
-        since: 2.7
+        since: "2.7"
   - name: DiscoveryStrategyConfig
-    since: 2.7
+    since: "2.7"
     params:
       - name: className
         type: String
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: properties
         type: Map_String_Data
         nullable: false
-        since: 2.7
+        since: "2.7"
   - name: DiscoveryConfig
-    since: 2.7
+    since: "2.7"
     params:
       - name: discoveryStrategyConfigs
         type: List_DiscoveryStrategyConfig
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: discoveryServiceProvider
         type: Data
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: nodeFilter
         type: Data
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: nodeFilterClass
         type: String
         nullable: false
-        since: 2.7
+        since: "2.7"
   - name: WanSyncConfig
-    since: 2.7
+    since: "2.7"
     params:
       - name: consistencyCheckStrategy
         type: byte
         nullable: false
-        since: 2.7
+        since: "2.7"
   - name: ReplicatedMapEntryViewHolder
-    since: 2.7
+    since: "2.7"
     returnWithFactory: false
     params:
       - name: key
         type: Data
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: value
         type: Data
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: creationTime
         type: long
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: hits
         type: long
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: lastAccessTime
         type: long
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: lastUpdateTime
         type: long
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: ttlMillis
         type: long
         nullable: false
-        since: 2.7
+        since: "2.7"
   - name: ResourceDefinition
-    since: 2.7
+    since: "2.7"
     params:
       - name: id
         type: String
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: resourceType
         type: int
         nullable: false
-        since: 2.7
+        since: "2.7"
       - name: payload
         type: byteArray
-        since: 2.7
+        since: "2.7"
         nullable: true
       - name: resourceUrl
         type: String
-        since: 2.7
+        since: "2.7"
         nullable: true
   - name: VectorIndexConfig
-    since: 2.8
+    since: "2.8"
     returnWithFactory: true
     params:
       - name: name
         type: String
         nullable: true
-        since: 2.8
+        since: "2.8"
       - name: metric
         type: int
         nullable: false
-        since: 2.8
+        since: "2.8"
       - name: dimension
         type: int
-        since: 2.8
+        since: "2.8"
         nullable: false
       - name: maxDegree
         type: int
-        since: 2.8
+        since: "2.8"
         nullable: false
       - name: efConstruction
         type: int
-        since: 2.8
+        since: "2.8"
         nullable: false
       - name: useDeduplication
         type: boolean
-        since: 2.8
+        since: "2.8"
         nullable: false
 
   - name: VectorPair
-    since: 2.8
+    since: "2.8"
     params:
       - name: name
         type: String
         nullable: false
-        since: 2.8
+        since: "2.8"
       - name: type
         type: byte
         nullable: false
-        since: 2.8
+        since: "2.8"
       - name: vector
         type: floatArray
         nullable: true
-        since: 2.8
+        since: "2.8"
 
   - name: VectorDocument
     returnWithFactory: true
-    since: 2.8
+    since: "2.8"
     params:
       - name: value
         type: Data
         nullable: false
-        since: 2.8
+        since: "2.8"
       - name: vectors
         type: List_VectorPair
         nullable: false
-        since: 2.8
+        since: "2.8"
 
   - name: VectorSearchOptions
     returnWithFactory: true
-    since: 2.8
+    since: "2.8"
     params:
       - name: includeValue
         type: boolean
         nullable: false
-        since: 2.8
+        since: "2.8"
       - name: includeVectors
         type: boolean
         nullable: false
-        since: 2.8
+        since: "2.8"
       - name: limit
         type: int
         nullable: false
-        since: 2.8
+        since: "2.8"
       - name: hints
         type: Map_String_String
         nullable: true
-        since: 2.8
+        since: "2.8"
 
   - name: VectorSearchResult
     returnWithFactory: true
-    since: 2.8
+    since: "2.8"
     params:
       - name: key
         type: Data
         nullable: false
-        since: 2.8
+        since: "2.8"
       - name: value
         type: Data
         nullable: true
-        since: 2.8
+        since: "2.8"
       - name: score
         type: float
         nullable: false
-        since: 2.8
+        since: "2.8"
       - name: vectors
         type: List_VectorPair
         nullable: true
-        since: 2.8
+        since: "2.8"
 
   - name: Version
-    since: 2.8
+    since: "2.8"
     returnWithFactory: true
     params:
       - name: major
         type: byte
         nullable: false
-        since: 2.8
+        since: "2.8"
       - name: minor
         type: byte
         nullable: false
-        since: 2.8
+        since: "2.8"
 
   - name: RaftGroupInfo
-    since: 2.8
+    since: "2.8"
     params:
       - name: groupId
         type: RaftGroupId
         nullable: false
-        since: 2.8
+        since: "2.8"
       - name: leader
         type: CPMember
         nullable: false
-        since: 2.8
+        since: "2.8"
       - name: followers
         type: List_CPMember
         nullable: false
-        since: 2.8
+        since: "2.8"


### PR DESCRIPTION
Fix for since tag usage. We need to encode it as string in yaml file, otherwise the yaml parser by default parses it as float and for example 2.10 is treated as 2.1, hence it results in incorrect versions.

Surrounding the version with double quotes lets the yaml parser treat it as a string as expected by our generator.

I did find replace using regex. 
replaced 
`since\: (\d+\.\d+\.\d+)` 
with 
`since\: "$1"`

and replaced
`since\: (\d+\.\d*)` 
with 
`since\: "$1"`

doc update PR at [here](https://github.com/hazelcast/hazelcast-client-protocol/pull/566)